### PR TITLE
Added promises to make redisson truly async

### DIFF
--- a/src/main/java/com/lambdaworks/redis/RedisAsyncConnection.java
+++ b/src/main/java/com/lambdaworks/redis/RedisAsyncConnection.java
@@ -68,7 +68,7 @@ public class RedisAsyncConnection<K, V> extends ChannelInboundHandlerAdapter {
         this.unit = unit;
     }
 
-    public Future<Long> append(K key, V value) {
+    public FutureWithPromise<Long> append(K key, V value) {
         return dispatch(APPEND, new IntegerOutput<K, V>(codec), key, value);
     }
 
@@ -80,38 +80,38 @@ public class RedisAsyncConnection<K, V> extends ChannelInboundHandlerAdapter {
         return status;
     }
 
-    public Future<String> bgrewriteaof() {
+    public FutureWithPromise<String> bgrewriteaof() {
         return dispatch(BGREWRITEAOF, new StatusOutput<K, V>(codec));
     }
 
-    public Future<String> bgsave() {
+    public FutureWithPromise<String> bgsave() {
         return dispatch(BGSAVE, new StatusOutput<K, V>(codec));
     }
 
-    public Future<Long> bitcount(K key) {
+    public FutureWithPromise<Long> bitcount(K key) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key);
         return dispatch(BITCOUNT, new IntegerOutput<K, V>(codec), args);
     }
 
-    public Future<Long> bitcount(K key, long start, long end) {
+    public FutureWithPromise<Long> bitcount(K key, long start, long end) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec);
         args.addKey(key).add(start).add(end);
         return dispatch(BITCOUNT, new IntegerOutput<K, V>(codec), args);
     }
 
-    public Future<Long> bitopAnd(K destination, K... keys) {
+    public FutureWithPromise<Long> bitopAnd(K destination, K... keys) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec);
         args.add(AND).addKey(destination).addKeys(keys);
         return dispatch(BITOP, new IntegerOutput<K, V>(codec), args);
     }
 
-    public Future<Long> bitopNot(K destination, K source) {
+    public FutureWithPromise<Long> bitopNot(K destination, K source) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec);
         args.add(NOT).addKey(destination).addKey(source);
         return dispatch(BITOP, new IntegerOutput<K, V>(codec), args);
     }
 
-    public Future<Long> bitopOr(K destination, K... keys) {
+    public FutureWithPromise<Long> bitopOr(K destination, K... keys) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec);
         args.add(OR).addKey(destination).addKeys(keys);
         return dispatch(BITOP, new IntegerOutput<K, V>(codec), args);
@@ -123,81 +123,81 @@ public class RedisAsyncConnection<K, V> extends ChannelInboundHandlerAdapter {
         return dispatch(BITOP, new IntegerOutput<K, V>(codec), args);
     }
 
-    public Future<KeyValue<K, V>> blpop(long timeout, K... keys) {
+    public FutureWithPromise<KeyValue<K, V>> blpop(long timeout, K... keys) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKeys(keys).add(timeout);
         return dispatch(BLPOP, new KeyValueOutput<K, V>(codec), args);
     }
 
-    public Future<KeyValue<K, V>> brpop(long timeout, K... keys) {
+    public FutureWithPromise<KeyValue<K, V>> brpop(long timeout, K... keys) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKeys(keys).add(timeout);
         return dispatch(BRPOP, new KeyValueOutput<K, V>(codec), args);
     }
 
-    public Future<V> brpoplpush(long timeout, K source, K destination) {
+    public FutureWithPromise<V> brpoplpush(long timeout, K source, K destination) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec);
         args.addKey(source).addKey(destination).add(timeout);
         return dispatch(BRPOPLPUSH, new ValueOutput<K, V>(codec), args);
     }
 
-    public Future<K> clientGetname() {
+    public FutureWithPromise<K> clientGetname() {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).add(GETNAME);
         return dispatch(CLIENT, new KeyOutput<K, V>(codec), args);
     }
 
-    public Future<String> clientSetname(K name) {
+    public FutureWithPromise<String> clientSetname(K name) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).add(SETNAME).addKey(name);
         return dispatch(CLIENT, new StatusOutput<K, V>(codec), args);
     }
 
-    public Future<String> clientKill(String addr) {
+    public FutureWithPromise<String> clientKill(String addr) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).add(KILL).add(addr);
         return dispatch(CLIENT, new StatusOutput<K, V>(codec), args);
     }
 
-    public Future<String> clientList() {
+    public FutureWithPromise<String> clientList() {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).add(LIST);
         return dispatch(CLIENT, new StatusOutput<K, V>(codec), args);
     }
 
-    public Future<List<String>> configGet(String parameter) {
+    public FutureWithPromise<List<String>> configGet(String parameter) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).add(GET).add(parameter);
         return dispatch(CONFIG, new StringListOutput<K, V>(codec), args);
     }
 
-    public Future<String> configResetstat() {
+    public FutureWithPromise<String> configResetstat() {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).add(RESETSTAT);
         return dispatch(CONFIG, new StatusOutput<K, V>(codec), args);
     }
 
-    public Future<String> configSet(String parameter, String value) {
+    public FutureWithPromise<String> configSet(String parameter, String value) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).add(SET).add(parameter).add(value);
         return dispatch(CONFIG, new StatusOutput<K, V>(codec), args);
     }
 
-    public Future<Long> dbsize() {
+    public FutureWithPromise<Long> dbsize() {
         return dispatch(DBSIZE, new IntegerOutput<K, V>(codec));
     }
 
-    public Future<String> debugObject(K key) {
+    public FutureWithPromise<String> debugObject(K key) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).add(OBJECT).addKey(key);
         return dispatch(DEBUG, new StatusOutput<K, V>(codec), args);
     }
 
-    public Future<Long> decr(K key) {
+    public FutureWithPromise<Long> decr(K key) {
         return dispatch(DECR, new IntegerOutput<K, V>(codec), key);
     }
 
-    public Future<Long> decrby(K key, long amount) {
+    public FutureWithPromise<Long> decrby(K key, long amount) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).add(amount);
         return dispatch(DECRBY, new IntegerOutput<K, V>(codec), args);
     }
 
-    public Future<Long> del(K... keys) {
+    public FutureWithPromise<Long> del(K... keys) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKeys(keys);
         return dispatch(DEL, new IntegerOutput<K, V>(codec), args);
     }
 
-    public Future<String> discard() {
+    public FutureWithPromise<String> discard() {
         if (multi != null) {
             multi.cancel();
             multi = null;
@@ -205,378 +205,378 @@ public class RedisAsyncConnection<K, V> extends ChannelInboundHandlerAdapter {
         return dispatch(DISCARD, new StatusOutput<K, V>(codec));
     }
 
-    public Future<byte[]> dump(K key) {
+    public FutureWithPromise<byte[]> dump(K key) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key);
         return dispatch(DUMP, new ByteArrayOutput<K, V>(codec), args);
     }
 
-    public Future<V> echo(V msg) {
+    public FutureWithPromise<V> echo(V msg) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addValue(msg);
         return dispatch(ECHO, new ValueOutput<K, V>(codec), args);
     }
 
-    public <T> Future<T> eval(V script, ScriptOutputType type, K[] keys, V... values) {
+    public <T> FutureWithPromise<T> eval(V script, ScriptOutputType type, K[] keys, V... values) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec);
         args.addValue(script).add(keys.length).addKeys(keys).addValues(values);
         CommandOutput<K, V, T> output = newScriptOutput(codec, type);
         return dispatch(EVAL, output, args);
     }
 
-    public <T> Future<T> evalsha(String digest, ScriptOutputType type, K[] keys, V... values) {
+    public <T> FutureWithPromise<T> evalsha(String digest, ScriptOutputType type, K[] keys, V... values) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec);
         args.add(digest).add(keys.length).addKeys(keys).addValues(values);
         CommandOutput<K, V, T> output = newScriptOutput(codec, type);
         return dispatch(EVALSHA, output, args);
     }
 
-    public Future<Boolean> exists(K key) {
+    public FutureWithPromise<Boolean> exists(K key) {
         return dispatch(EXISTS, new BooleanOutput<K, V>(codec), key);
     }
 
-    public Future<Boolean> expire(K key, long seconds) {
+    public FutureWithPromise<Boolean> expire(K key, long seconds) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).add(seconds);
         return dispatch(EXPIRE, new BooleanOutput<K, V>(codec), args);
     }
 
-    public Future<Boolean> expireat(K key, Date timestamp) {
+    public FutureWithPromise<Boolean> expireat(K key, Date timestamp) {
         return expireat(key, timestamp.getTime() / 1000);
     }
 
-    public Future<Boolean> expireat(K key, long timestamp) {
+    public FutureWithPromise<Boolean> expireat(K key, long timestamp) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).add(timestamp);
         return dispatch(EXPIREAT, new BooleanOutput<K, V>(codec), args);
     }
 
-    public Future<List<Object>> exec() {
+    public FutureWithPromise<List<Object>> exec() {
         MultiOutput<K, V> multi = this.multi;
         this.multi = null;
         if (multi == null) multi = new MultiOutput<K, V>(codec);
         return dispatch(EXEC, multi);
     }
 
-    public Future<String> flushall() {
+    public FutureWithPromise<String> flushall() {
         return dispatch(FLUSHALL, new StatusOutput<K, V>(codec));
     }
 
-    public Future<String> flushdb() {
+    public FutureWithPromise<String> flushdb() {
         return dispatch(FLUSHDB, new StatusOutput<K, V>(codec));
     }
 
-    public Future<V> get(K key) {
+    public FutureWithPromise<V> get(K key) {
         return dispatch(GET, new ValueOutput<K, V>(codec), key);
     }
 
-    public Future<Long> getbit(K key, long offset) {
+    public FutureWithPromise<Long> getbit(K key, long offset) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).add(offset);
         return dispatch(GETBIT, new IntegerOutput<K, V>(codec), args);
     }
 
-    public Future<V> getrange(K key, long start, long end) {
+    public FutureWithPromise<V> getrange(K key, long start, long end) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).add(start).add(end);
         return dispatch(GETRANGE, new ValueOutput<K, V>(codec), args);
     }
 
-    public Future<V> getset(K key, V value) {
+    public FutureWithPromise<V> getset(K key, V value) {
         return dispatch(GETSET, new ValueOutput<K, V>(codec), key, value);
     }
 
-    public Future<Long> hdel(K key, K... fields) {
+    public FutureWithPromise<Long> hdel(K key, K... fields) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).addKeys(fields);
         return dispatch(HDEL, new IntegerOutput<K, V>(codec), args);
     }
 
-    public Future<Boolean> hexists(K key, K field) {
+    public FutureWithPromise<Boolean> hexists(K key, K field) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).addKey(field);
         return dispatch(HEXISTS, new BooleanOutput<K, V>(codec), args);
     }
 
-    public Future<V> hget(K key, K field) {
+    public FutureWithPromise<V> hget(K key, K field) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).addKey(field);
         return dispatch(HGET, new ValueOutput<K, V>(codec), args);
     }
 
-    public Future<Long> hincrby(K key, K field, long amount) {
+    public FutureWithPromise<Long> hincrby(K key, K field, long amount) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).addKey(field).add(amount);
         return dispatch(HINCRBY, new IntegerOutput<K, V>(codec), args);
     }
 
-    public Future<Double> hincrbyfloat(K key, K field, double amount) {
+    public FutureWithPromise<Double> hincrbyfloat(K key, K field, double amount) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).addKey(field).add(amount);
         return dispatch(HINCRBYFLOAT, new DoubleOutput<K, V>(codec), args);
     }
 
-    public Future<Map<K, V>> hgetall(K key) {
+    public FutureWithPromise<Map<K, V>> hgetall(K key) {
         return dispatch(HGETALL, new MapOutput<K, V>(codec), key);
     }
 
-    public Future<List<K>> hkeys(K key) {
+    public FutureWithPromise<List<K>> hkeys(K key) {
         return dispatch(HKEYS, new KeyListOutput<K, V>(codec), key);
     }
 
-    public Future<Long> hlen(K key) {
+    public FutureWithPromise<Long> hlen(K key) {
         return dispatch(HLEN, new IntegerOutput<K, V>(codec), key);
     }
 
-    public Future<List<V>> hmget(K key, K... fields) {
+    public FutureWithPromise<List<V>> hmget(K key, K... fields) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).addKeys(fields);
         return dispatch(HMGET, new ValueListOutput<K, V>(codec), args);
     }
 
-    public Future<String> hmset(K key, Map<K, V> map) {
+    public FutureWithPromise<String> hmset(K key, Map<K, V> map) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).add(map);
         return dispatch(HMSET, new StatusOutput<K, V>(codec), args);
     }
 
-    public Future<Boolean> hset(K key, K field, V value) {
+    public FutureWithPromise<Boolean> hset(K key, K field, V value) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).addKey(field).addValue(value);
         return dispatch(HSET, new BooleanOutput<K, V>(codec), args);
     }
 
-    public Future<Boolean> hsetnx(K key, K field, V value) {
+    public FutureWithPromise<Boolean> hsetnx(K key, K field, V value) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).addKey(field).addValue(value);
         return dispatch(HSETNX, new BooleanOutput<K, V>(codec), args);
     }
 
-    public Future<List<V>> hvals(K key) {
+    public FutureWithPromise<List<V>> hvals(K key) {
         return dispatch(HVALS, new ValueListOutput<K, V>(codec), key);
     }
 
-    public Future<Long> incr(K key) {
+    public FutureWithPromise<Long> incr(K key) {
         return dispatch(INCR, new IntegerOutput<K, V>(codec), key);
     }
 
-    public Future<Long> incrby(K key, long amount) {
+    public FutureWithPromise<Long> incrby(K key, long amount) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).add(amount);
         return dispatch(INCRBY, new IntegerOutput<K, V>(codec), args);
     }
 
-    public Future<Double> incrbyfloat(K key, double amount) {
+    public FutureWithPromise<Double> incrbyfloat(K key, double amount) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).add(amount);
         return dispatch(INCRBYFLOAT, new DoubleOutput<K, V>(codec), args);
     }
 
-    public Future<String> info() {
+    public FutureWithPromise<String> info() {
         return dispatch(INFO, new StatusOutput<K, V>(codec));
     }
 
-    public Future<String> info(String section) {
+    public FutureWithPromise<String> info(String section) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).add(section);
         return dispatch(INFO, new StatusOutput<K, V>(codec), args);
     }
 
-    public Future<List<K>> keys(K pattern) {
+    public FutureWithPromise<List<K>> keys(K pattern) {
        return dispatch(KEYS, new KeyListOutput<K, V>(codec), pattern);
     }
 
-    public Future<Date> lastsave() {
+    public FutureWithPromise<Date> lastsave() {
         return dispatch(LASTSAVE, new DateOutput<K, V>(codec));
     }
 
-    public Future<V> lindex(K key, long index) {
+    public FutureWithPromise<V> lindex(K key, long index) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).add(index);
         return dispatch(LINDEX, new ValueOutput<K, V>(codec), args);
     }
 
-    public Future<Long> linsert(K key, boolean before, V pivot, V value) {
+    public FutureWithPromise<Long> linsert(K key, boolean before, V pivot, V value) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec);
         args.addKey(key).add(before ? BEFORE : AFTER).addValue(pivot).addValue(value);
         return dispatch(LINSERT, new IntegerOutput<K, V>(codec), args);
     }
 
-    public Future<Long> llen(K key) {
+    public FutureWithPromise<Long> llen(K key) {
         return dispatch(LLEN, new IntegerOutput<K, V>(codec), key);
     }
 
-    public Future<V> lpop(K key) {
+    public FutureWithPromise<V> lpop(K key) {
         return dispatch(LPOP, new ValueOutput<K, V>(codec), key);
     }
 
-    public Future<Long> lpush(K key, V... values) {
+    public FutureWithPromise<Long> lpush(K key, V... values) {
         return dispatch(LPUSH, new IntegerOutput<K, V>(codec), key, values);
     }
 
-    public Future<Long> lpushx(K key, V value) {
+    public FutureWithPromise<Long> lpushx(K key, V value) {
         return dispatch(LPUSHX, new IntegerOutput<K, V>(codec), key, value);
     }
 
-    public Future<List<V>> lrange(K key, long start, long stop) {
+    public FutureWithPromise<List<V>> lrange(K key, long start, long stop) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).add(start).add(stop);
         return dispatch(LRANGE, new ValueListOutput<K, V>(codec), args);
     }
 
-    public Future<Long> lrem(K key, long count, V value) {
+    public FutureWithPromise<Long> lrem(K key, long count, V value) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).add(count).addValue(value);
         return dispatch(LREM, new IntegerOutput<K, V>(codec), args);
     }
 
-    public Future<String> lset(K key, long index, V value) {
+    public FutureWithPromise<String> lset(K key, long index, V value) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).add(index).addValue(value);
         return dispatch(LSET, new StatusOutput<K, V>(codec), args);
     }
 
-    public Future<String> ltrim(K key, long start, long stop) {
+    public FutureWithPromise<String> ltrim(K key, long start, long stop) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).add(start).add(stop);
         return dispatch(LTRIM, new StatusOutput<K, V>(codec), args);
     }
 
-    public Future<String> migrate(String host, int port, K key, int db, long timeout) {
+    public FutureWithPromise<String> migrate(String host, int port, K key, int db, long timeout) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec);
         args.add(host).add(port).addKey(key).add(db).add(timeout);
         return dispatch(MIGRATE, new StatusOutput<K, V>(codec), args);
     }
 
-    public Future<List<V>> mget(K... keys) {
+    public FutureWithPromise<List<V>> mget(K... keys) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKeys(keys);
         return dispatch(MGET, new ValueListOutput<K, V>(codec), args);
     }
 
-    public Future<Boolean> move(K key, int db) {
+    public FutureWithPromise<Boolean> move(K key, int db) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).add(db);
         return dispatch(MOVE, new BooleanOutput<K, V>(codec), args);
     }
 
-    public Future<String> multi() {
+    public FutureWithPromise<String> multi() {
         Command<K, V, String> cmd = dispatch(MULTI, new StatusOutput<K, V>(codec));
         multi = (multi == null ? new MultiOutput<K, V>(codec) : multi);
         return cmd;
     }
 
-    public Future<String> mset(Map<K, V> map) {
+    public FutureWithPromise<String> mset(Map<K, V> map) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).add(map);
         return dispatch(MSET, new StatusOutput<K, V>(codec), args);
     }
 
-    public Future<Boolean> msetnx(Map<K, V> map) {
+    public FutureWithPromise<Boolean> msetnx(Map<K, V> map) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).add(map);
         return dispatch(MSETNX, new BooleanOutput<K, V>(codec), args);
     }
 
-    public Future<String> objectEncoding(K key) {
+    public FutureWithPromise<String> objectEncoding(K key) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).add(ENCODING).addKey(key);
         return dispatch(OBJECT, new StatusOutput<K, V>(codec), args);
     }
 
-    public Future<Long> objectIdletime(K key) {
+    public FutureWithPromise<Long> objectIdletime(K key) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).add(IDLETIME).addKey(key);
         return dispatch(OBJECT, new IntegerOutput<K, V>(codec), args);
     }
 
-    public Future<Long> objectRefcount(K key) {
+    public FutureWithPromise<Long> objectRefcount(K key) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).add(REFCOUNT).addKey(key);
         return dispatch(OBJECT, new IntegerOutput<K, V>(codec), args);
     }
 
-    public Future<Boolean> persist(K key) {
+    public FutureWithPromise<Boolean> persist(K key) {
         return dispatch(PERSIST, new BooleanOutput<K, V>(codec), key);
     }
 
-    public Future<Boolean> pexpire(K key, long milliseconds) {
+    public FutureWithPromise<Boolean> pexpire(K key, long milliseconds) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).add(milliseconds);
         return dispatch(PEXPIRE, new BooleanOutput<K, V>(codec), args);
     }
 
-    public Future<Boolean> pexpireat(K key, Date timestamp) {
+    public FutureWithPromise<Boolean> pexpireat(K key, Date timestamp) {
         return pexpireat(key, timestamp.getTime());
     }
 
-    public Future<Boolean> pexpireat(K key, long timestamp) {
+    public FutureWithPromise<Boolean> pexpireat(K key, long timestamp) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).add(timestamp);
         return dispatch(PEXPIREAT, new BooleanOutput<K, V>(codec), args);
     }
 
-    public Future<String> ping() {
+    public FutureWithPromise<String> ping() {
         return dispatch(PING, new StatusOutput<K, V>(codec));
     }
 
-    public Future<Long> pttl(K key) {
+    public FutureWithPromise<Long> pttl(K key) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key);
         return dispatch(PTTL, new IntegerOutput<K, V>(codec), args);
     }
 
-    public Future<Long> publish(K channel, V message) {
+    public FutureWithPromise<Long> publish(K channel, V message) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(channel).addValue(message);
         return dispatch(PUBLISH, new IntegerOutput<K, V>(codec), args);
     }
 
-    public Future<String> quit() {
+    public FutureWithPromise<String> quit() {
         return dispatch(QUIT, new StatusOutput<K, V>(codec));
     }
 
-    public Future<V> randomkey() {
+    public FutureWithPromise<V> randomkey() {
         return dispatch(RANDOMKEY, new ValueOutput<K, V>(codec));
     }
 
-    public Future<String> rename(K key, K newKey) {
+    public FutureWithPromise<String> rename(K key, K newKey) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).addKey(newKey);
         return dispatch(RENAME, new StatusOutput<K, V>(codec), args);
     }
 
-    public Future<Boolean> renamenx(K key, K newKey) {
+    public FutureWithPromise<Boolean> renamenx(K key, K newKey) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).addKey(newKey);
         return dispatch(RENAMENX, new BooleanOutput<K, V>(codec), args);
     }
 
-    public Future<String> restore(K key, long ttl, byte[] value) {
+    public FutureWithPromise<String> restore(K key, long ttl, byte[] value) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).add(ttl).add(value);
         return dispatch(RESTORE, new StatusOutput<K, V>(codec), args);
     }
 
-    public Future<V> rpop(K key) {
+    public FutureWithPromise<V> rpop(K key) {
         return dispatch(RPOP, new ValueOutput<K, V>(codec), key);
     }
 
-    public Future<V> rpoplpush(K source, K destination) {
+    public FutureWithPromise<V> rpoplpush(K source, K destination) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(source).addKey(destination);
         return dispatch(RPOPLPUSH, new ValueOutput<K, V>(codec), args);
     }
 
-    public Future<Long> rpush(K key, V... values) {
+    public FutureWithPromise<Long> rpush(K key, V... values) {
         return dispatch(RPUSH, new IntegerOutput<K, V>(codec), key, values);
     }
 
-    public Future<Long> rpushx(K key, V value) {
+    public FutureWithPromise<Long> rpushx(K key, V value) {
         return dispatch(RPUSHX, new IntegerOutput<K, V>(codec), key, value);
     }
 
-    public Future<Long> sadd(K key, V... members) {
+    public FutureWithPromise<Long> sadd(K key, V... members) {
         return dispatch(SADD, new IntegerOutput<K, V>(codec), key, members);
     }
 
-    public Future<String> save() {
+    public FutureWithPromise<String> save() {
         return dispatch(SAVE, new StatusOutput<K, V>(codec));
     }
 
-    public Future<Long> scard(K key) {
+    public FutureWithPromise<Long> scard(K key) {
         return dispatch(SCARD, new IntegerOutput<K, V>(codec), key);
     }
 
-    public Future<List<Boolean>> scriptExists(String... digests) {
+    public FutureWithPromise<List<Boolean>> scriptExists(String... digests) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).add(EXISTS);
         for (String sha : digests) args.add(sha);
         return dispatch(SCRIPT, new BooleanListOutput<K, V>(codec), args);
     }
 
-    public Future<String> scriptFlush() {
+    public FutureWithPromise<String> scriptFlush() {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).add(FLUSH);
         return dispatch(SCRIPT, new StatusOutput<K, V>(codec), args);
     }
 
-    public Future<String> scriptKill() {
+    public FutureWithPromise<String> scriptKill() {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).add(KILL);
         return dispatch(SCRIPT, new StatusOutput<K, V>(codec), args);
     }
 
-    public Future<String> scriptLoad(V script) {
+    public FutureWithPromise<String> scriptLoad(V script) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).add(LOAD).addValue(script);
         return dispatch(SCRIPT, new StatusOutput<K, V>(codec), args);
     }
 
-    public Future<Set<V>> sdiff(K... keys) {
+    public FutureWithPromise<Set<V>> sdiff(K... keys) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKeys(keys);
         return dispatch(SDIFF, new ValueSetOutput<K, V>(codec), args);
     }
 
-    public Future<Long> sdiffstore(K destination, K... keys) {
+    public FutureWithPromise<Long> sdiffstore(K destination, K... keys) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(destination).addKeys(keys);
         return dispatch(SDIFFSTORE, new IntegerOutput<K, V>(codec), args);
     }
@@ -589,25 +589,25 @@ public class RedisAsyncConnection<K, V> extends ChannelInboundHandlerAdapter {
         return status;
     }
 
-    public Future<String> set(K key, V value) {
+    public FutureWithPromise<String> set(K key, V value) {
         return dispatch(SET, new StatusOutput<K, V>(codec), key, value);
     }
 
-    public Future<Long> setbit(K key, long offset, int value) {
+    public FutureWithPromise<Long> setbit(K key, long offset, int value) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).add(offset).add(value);
         return dispatch(SETBIT, new IntegerOutput<K, V>(codec), args);
     }
 
-    public Future<String> setex(K key, long seconds, V value) {
+    public FutureWithPromise<String> setex(K key, long seconds, V value) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).add(seconds).addValue(value);
         return dispatch(SETEX, new StatusOutput<K, V>(codec), args);
     }
 
-    public Future<Boolean> setnx(K key, V value) {
+    public FutureWithPromise<Boolean> setnx(K key, V value) {
         return dispatch(SETNX, new BooleanOutput<K, V>(codec), key, value);
     }
 
-    public Future<Long> setrange(K key, long offset, V value) {
+    public FutureWithPromise<Long> setrange(K key, long offset, V value) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).add(offset).addValue(value);
         return dispatch(SETRANGE, new IntegerOutput<K, V>(codec), args);
     }
@@ -622,31 +622,31 @@ public class RedisAsyncConnection<K, V> extends ChannelInboundHandlerAdapter {
         dispatch(SHUTDOWN, new StatusOutput<K, V>(codec), save ? args.add(SAVE) : args.add(NOSAVE));
     }
 
-    public Future<Set<V>> sinter(K... keys) {
+    public FutureWithPromise<Set<V>> sinter(K... keys) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKeys(keys);
         return dispatch(SINTER, new ValueSetOutput<K, V>(codec), args);
     }
 
-    public Future<Long> sinterstore(K destination, K... keys) {
+    public FutureWithPromise<Long> sinterstore(K destination, K... keys) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(destination).addKeys(keys);
         return dispatch(SINTERSTORE, new IntegerOutput<K, V>(codec), args);
     }
 
-    public Future<Boolean> sismember(K key, V member) {
+    public FutureWithPromise<Boolean> sismember(K key, V member) {
         return dispatch(SISMEMBER, new BooleanOutput<K, V>(codec), key, member);
     }
 
-    public Future<Boolean> smove(K source, K destination, V member) {
+    public FutureWithPromise<Boolean> smove(K source, K destination, V member) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(source).addKey(destination).addValue(member);
         return dispatch(SMOVE, new BooleanOutput<K, V>(codec), args);
     }
 
-    public Future<String> slaveof(String host, int port) {
+    public FutureWithPromise<String> slaveof(String host, int port) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).add(host).add(port);
         return dispatch(SLAVEOF, new StatusOutput<K, V>(codec), args);
     }
 
-    public Future<String> slaveofNoOne() {
+    public FutureWithPromise<String> slaveofNoOne() {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).add(NO).add(ONE);
         return dispatch(SLAVEOF, new StatusOutput<K, V>(codec), args);
     }
@@ -656,100 +656,100 @@ public class RedisAsyncConnection<K, V> extends ChannelInboundHandlerAdapter {
         return dispatch(SLOWLOG, new NestedMultiOutput<K, V>(codec), args);
     }
 
-    public Future<List<Object>> slowlogGet(int count) {
+    public FutureWithPromise<List<Object>> slowlogGet(int count) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).add(GET).add(count);
         return dispatch(SLOWLOG, new NestedMultiOutput<K, V>(codec), args);
     }
 
-    public Future<Long> slowlogLen() {
+    public FutureWithPromise<Long> slowlogLen() {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).add(LEN);
         return dispatch(SLOWLOG, new IntegerOutput<K, V>(codec), args);
     }
 
-    public Future<String> slowlogReset() {
+    public FutureWithPromise<String> slowlogReset() {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).add(RESET);
         return dispatch(SLOWLOG, new StatusOutput<K, V>(codec), args);
     }
 
-    public Future<Set<V>> smembers(K key) {
+    public FutureWithPromise<Set<V>> smembers(K key) {
         return dispatch(SMEMBERS, new ValueSetOutput<K, V>(codec), key);
     }
 
-    public Future<List<V>> sort(K key) {
+    public FutureWithPromise<List<V>> sort(K key) {
         return dispatch(SORT, new ValueListOutput<K, V>(codec), key);
     }
 
-    public Future<List<V>> sort(K key, SortArgs sortArgs) {
+    public FutureWithPromise<List<V>> sort(K key, SortArgs sortArgs) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key);
         sortArgs.build(args, null);
         return dispatch(SORT, new ValueListOutput<K, V>(codec), args);
     }
 
-    public Future<Long> sortStore(K key, SortArgs sortArgs, K destination) {
+    public FutureWithPromise<Long> sortStore(K key, SortArgs sortArgs, K destination) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key);
         sortArgs.build(args, destination);
         return dispatch(SORT, new IntegerOutput<K, V>(codec), args);
     }
 
-    public Future<V> spop(K key) {
+    public FutureWithPromise<V> spop(K key) {
         return dispatch(SPOP, new ValueOutput<K, V>(codec), key);
     }
 
-    public Future<V> srandmember(K key) {
+    public FutureWithPromise<V> srandmember(K key) {
         return dispatch(SRANDMEMBER, new ValueOutput<K, V>(codec), key);
     }
 
-    public Future<Set<V>> srandmember(K key, long count) {
+    public FutureWithPromise<Set<V>> srandmember(K key, long count) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).add(count);
         return dispatch(SRANDMEMBER, new ValueSetOutput<K, V>(codec), args);
     }
 
-    public Future<Long> srem(K key, V... members) {
+    public FutureWithPromise<Long> srem(K key, V... members) {
         return dispatch(SREM, new IntegerOutput<K, V>(codec), key, members);
     }
 
-    public Future<Set<V>> sunion(K... keys) {
+    public FutureWithPromise<Set<V>> sunion(K... keys) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKeys(keys);
         return dispatch(SUNION, new ValueSetOutput<K, V>(codec), args);
     }
 
-    public Future<Long> sunionstore(K destination, K... keys) {
+    public FutureWithPromise<Long> sunionstore(K destination, K... keys) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(destination).addKeys(keys);
         return dispatch(SUNIONSTORE, new IntegerOutput<K, V>(codec), args);
     }
 
-    public Future<String> sync() {
+    public FutureWithPromise<String> sync() {
         return dispatch(SYNC, new StatusOutput<K, V>(codec));
     }
 
-    public Future<Long> strlen(K key) {
+    public FutureWithPromise<Long> strlen(K key) {
         return dispatch(STRLEN, new IntegerOutput<K, V>(codec), key);
     }
 
-    public Future<Long> ttl(K key) {
+    public FutureWithPromise<Long> ttl(K key) {
         return dispatch(TTL, new IntegerOutput<K, V>(codec), key);
     }
 
-    public Future<String> type(K key) {
+    public FutureWithPromise<String> type(K key) {
         return dispatch(TYPE, new StatusOutput<K, V>(codec), key);
     }
 
-    public Future<String> watch(K... keys) {
+    public FutureWithPromise<String> watch(K... keys) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKeys(keys);
         return dispatch(WATCH, new StatusOutput<K, V>(codec), args);
     }
 
-    public Future<String> unwatch() {
+    public FutureWithPromise<String> unwatch() {
         return dispatch(UNWATCH, new StatusOutput<K, V>(codec));
     }
 
-    public Future<Long> zadd(K key, double score, V member) {
+    public FutureWithPromise<Long> zadd(K key, double score, V member) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).add(score).addValue(member);
         return dispatch(ZADD, new IntegerOutput<K, V>(codec), args);
     }
 
     @SuppressWarnings("unchecked")
-    public Future<Long> zadd(K key, Object... scoresAndValues) {
+    public FutureWithPromise<Long> zadd(K key, Object... scoresAndValues) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key);
         for (int i = 0; i < scoresAndValues.length; i += 2) {
             args.add((Double) scoresAndValues[i]);
@@ -758,169 +758,169 @@ public class RedisAsyncConnection<K, V> extends ChannelInboundHandlerAdapter {
         return dispatch(ZADD, new IntegerOutput<K, V>(codec), args);
     }
 
-    public Future<Long> zcard(K key) {
+    public FutureWithPromise<Long> zcard(K key) {
         return dispatch(ZCARD, new IntegerOutput<K, V>(codec), key);
     }
 
-    public Future<Long> zcount(K key, double min, double max) {
+    public FutureWithPromise<Long> zcount(K key, double min, double max) {
         return zcount(key, string(min), string(max));
     }
 
-    public Future<Long> zcount(K key, String min, String max) {
+    public FutureWithPromise<Long> zcount(K key, String min, String max) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).add(min).add(max);
         return dispatch(ZCOUNT, new IntegerOutput<K, V>(codec), args);
     }
 
-    public Future<Double> zincrby(K key, double amount, K member) {
+    public FutureWithPromise<Double> zincrby(K key, double amount, K member) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).add(amount).addKey(member);
         return dispatch(ZINCRBY, new DoubleOutput<K, V>(codec), args);
     }
 
-    public Future<Long> zinterstore(K destination, K... keys) {
+    public FutureWithPromise<Long> zinterstore(K destination, K... keys) {
         return zinterstore(destination, new ZStoreArgs(), keys);
     }
 
-    public Future<Long> zinterstore(K destination, ZStoreArgs storeArgs, K... keys) {
+    public FutureWithPromise<Long> zinterstore(K destination, ZStoreArgs storeArgs, K... keys) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(destination).add(keys.length).addKeys(keys);
         storeArgs.build(args);
         return dispatch(ZINTERSTORE, new IntegerOutput<K, V>(codec), args);
     }
 
-    public Future<List<V>> zrange(K key, long start, long stop) {
+    public FutureWithPromise<List<V>> zrange(K key, long start, long stop) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).add(start).add(stop);
         return dispatch(ZRANGE, new ValueListOutput<K, V>(codec), args);
     }
 
-    public Future<List<ScoredValue<V>>> zrangeWithScores(K key, long start, long stop) {
+    public FutureWithPromise<List<ScoredValue<V>>> zrangeWithScores(K key, long start, long stop) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec);
         args.addKey(key).add(start).add(stop).add(WITHSCORES);
         return dispatch(ZRANGE, new ScoredValueListOutput<K, V>(codec), args);
     }
 
-    public Future<List<V>> zrangebyscore(K key, double min, double max) {
+    public FutureWithPromise<List<V>> zrangebyscore(K key, double min, double max) {
         return zrangebyscore(key, string(min), string(max));
     }
 
-    public Future<List<V>> zrangebyscore(K key, String min, String max) {
+    public FutureWithPromise<List<V>> zrangebyscore(K key, String min, String max) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).add(min).add(max);
         return dispatch(ZRANGEBYSCORE, new ValueListOutput<K, V>(codec), args);
     }
 
-    public Future<List<V>> zrangebyscore(K key, double min, double max, long offset, long count) {
+    public FutureWithPromise<List<V>> zrangebyscore(K key, double min, double max, long offset, long count) {
         return zrangebyscore(key, string(min), string(max), offset, count);
     }
 
-    public Future<List<V>> zrangebyscore(K key, String min, String max, long offset, long count) {
+    public FutureWithPromise<List<V>> zrangebyscore(K key, String min, String max, long offset, long count) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec);
         args.addKey(key).add(min).add(max).add(LIMIT).add(offset).add(count);
         return dispatch(ZRANGEBYSCORE, new ValueListOutput<K, V>(codec), args);
     }
 
-    public Future<List<ScoredValue<V>>> zrangebyscoreWithScores(K key, double min, double max) {
+    public FutureWithPromise<List<ScoredValue<V>>> zrangebyscoreWithScores(K key, double min, double max) {
         return zrangebyscoreWithScores(key, string(min), string(max));
     }
 
-    public Future<List<ScoredValue<V>>> zrangebyscoreWithScores(K key, String min, String max) {
+    public FutureWithPromise<List<ScoredValue<V>>> zrangebyscoreWithScores(K key, String min, String max) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec);
         args.addKey(key).add(min).add(max).add(WITHSCORES);
         return dispatch(ZRANGEBYSCORE, new ScoredValueListOutput<K, V>(codec), args);
     }
 
-    public Future<List<ScoredValue<V>>> zrangebyscoreWithScores(K key, double min, double max, long offset, long count) {
+    public FutureWithPromise<List<ScoredValue<V>>> zrangebyscoreWithScores(K key, double min, double max, long offset, long count) {
         return zrangebyscoreWithScores(key, string(min), string(max), offset, count);
     }
 
-    public Future<List<ScoredValue<V>>> zrangebyscoreWithScores(K key, String min, String max, long offset, long count) {
+    public FutureWithPromise<List<ScoredValue<V>>> zrangebyscoreWithScores(K key, String min, String max, long offset, long count) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec);
         args.addKey(key).add(min).add(max).add(WITHSCORES).add(LIMIT).add(offset).add(count);
         return dispatch(ZRANGEBYSCORE, new ScoredValueListOutput<K, V>(codec), args);
     }
 
-    public Future<Long> zrank(K key, V member) {
+    public FutureWithPromise<Long> zrank(K key, V member) {
         return dispatch(ZRANK, new IntegerOutput<K, V>(codec), key, member);
     }
 
-    public Future<Long> zrem(K key, V... members) {
+    public FutureWithPromise<Long> zrem(K key, V... members) {
         return dispatch(ZREM, new IntegerOutput<K, V>(codec), key, members);
     }
 
-    public Future<Long> zremrangebyrank(K key, long start, long stop) {
+    public FutureWithPromise<Long> zremrangebyrank(K key, long start, long stop) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).add(start).add(stop);
         return dispatch(ZREMRANGEBYRANK, new IntegerOutput<K, V>(codec), args);
     }
 
-    public Future<Long> zremrangebyscore(K key, double min, double max) {
+    public FutureWithPromise<Long> zremrangebyscore(K key, double min, double max) {
         return zremrangebyscore(key, string(min), string(max));
     }
 
-    public Future<Long> zremrangebyscore(K key, String min, String max) {
+    public FutureWithPromise<Long> zremrangebyscore(K key, String min, String max) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).add(min).add(max);
         return dispatch(ZREMRANGEBYSCORE, new IntegerOutput<K, V>(codec), args);
     }
 
-    public Future<List<V>> zrevrange(K key, long start, long stop) {
+    public FutureWithPromise<List<V>> zrevrange(K key, long start, long stop) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).add(start).add(stop);
         return dispatch(ZREVRANGE, new ValueListOutput<K, V>(codec), args);
     }
 
-    public Future<List<ScoredValue<V>>> zrevrangeWithScores(K key, long start, long stop) {
+    public FutureWithPromise<List<ScoredValue<V>>> zrevrangeWithScores(K key, long start, long stop) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec);
         args.addKey(key).add(start).add(stop).add(WITHSCORES);
         return dispatch(ZREVRANGE, new ScoredValueListOutput<K, V>(codec), args);
     }
 
-    public Future<List<V>> zrevrangebyscore(K key, double max, double min) {
+    public FutureWithPromise<List<V>> zrevrangebyscore(K key, double max, double min) {
         return zrevrangebyscore(key, string(max), string(min));
     }
 
-    public Future<List<V>> zrevrangebyscore(K key, String max, String min) {
+    public FutureWithPromise<List<V>> zrevrangebyscore(K key, String max, String min) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec).addKey(key).add(max).add(min);
         return dispatch(ZREVRANGEBYSCORE, new ValueListOutput<K, V>(codec), args);
     }
 
-    public Future<List<V>> zrevrangebyscore(K key, double max, double min, long offset, long count) {
+    public FutureWithPromise<List<V>> zrevrangebyscore(K key, double max, double min, long offset, long count) {
         return zrevrangebyscore(key, string(max), string(min), offset, count);
     }
 
-    public Future<List<V>> zrevrangebyscore(K key, String max, String min, long offset, long count) {
+    public FutureWithPromise<List<V>> zrevrangebyscore(K key, String max, String min, long offset, long count) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec);
         args.addKey(key).add(max).add(min).add(LIMIT).add(offset).add(count);
         return dispatch(ZREVRANGEBYSCORE, new ValueListOutput<K, V>(codec), args);
     }
 
-    public Future<List<ScoredValue<V>>> zrevrangebyscoreWithScores(K key, double max, double min) {
+    public FutureWithPromise<List<ScoredValue<V>>> zrevrangebyscoreWithScores(K key, double max, double min) {
         return zrevrangebyscoreWithScores(key, string(max), string(min));
     }
 
-    public Future<List<ScoredValue<V>>> zrevrangebyscoreWithScores(K key, String max, String min) {
+    public FutureWithPromise<List<ScoredValue<V>>> zrevrangebyscoreWithScores(K key, String max, String min) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec);
         args.addKey(key).add(max).add(min).add(WITHSCORES);
         return dispatch(ZREVRANGEBYSCORE, new ScoredValueListOutput<K, V>(codec), args);
     }
 
-    public Future<List<ScoredValue<V>>> zrevrangebyscoreWithScores(K key, double max, double min, long offset, long count) {
+    public FutureWithPromise<List<ScoredValue<V>>> zrevrangebyscoreWithScores(K key, double max, double min, long offset, long count) {
         return zrevrangebyscoreWithScores(key, string(max), string(min), offset, count);
     }
 
-    public Future<List<ScoredValue<V>>> zrevrangebyscoreWithScores(K key, String max, String min, long offset, long count) {
+    public FutureWithPromise<List<ScoredValue<V>>> zrevrangebyscoreWithScores(K key, String max, String min, long offset, long count) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec);
         args.addKey(key).add(max).add(min).add(WITHSCORES).add(LIMIT).add(offset).add(count);
         return dispatch(ZREVRANGEBYSCORE, new ScoredValueListOutput<K, V>(codec), args);
     }
 
-    public Future<Long> zrevrank(K key, V member) {
+    public FutureWithPromise<Long> zrevrank(K key, V member) {
         return dispatch(ZREVRANK, new IntegerOutput<K, V>(codec), key, member);
     }
 
-    public Future<Double> zscore(K key, V member) {
+    public FutureWithPromise<Double> zscore(K key, V member) {
         return dispatch(ZSCORE, new DoubleOutput<K, V>(codec), key, member);
     }
 
-    public Future<Long> zunionstore(K destination, K... keys) {
+    public FutureWithPromise<Long> zunionstore(K destination, K... keys) {
         return zunionstore(destination, new ZStoreArgs(), keys);
     }
 
-    public Future<Long> zunionstore(K destination, ZStoreArgs storeArgs, K... keys) {
+    public FutureWithPromise<Long> zunionstore(K destination, ZStoreArgs storeArgs, K... keys) {
         CommandArgs<K, V> args = new CommandArgs<K, V>(codec);
         args.addKey(destination).add(keys.length).addKeys(keys);
         storeArgs.build(args);

--- a/src/main/java/com/lambdaworks/redis/protocol/FutureWithPromise.java
+++ b/src/main/java/com/lambdaworks/redis/protocol/FutureWithPromise.java
@@ -1,0 +1,9 @@
+package com.lambdaworks.redis.protocol;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
+@SuppressWarnings("UnusedDeclaration")
+public interface FutureWithPromise<T> extends Future<T> {
+    CompletableFuture<T> getPromise();
+}


### PR DESCRIPTION
Hi Nikita,

Please find my pull request for issue #5 and comments.

One option was to make Command class extending CompletableFuture instead of implementing Future. But doing this I had to resolve conflicts between both implementations. Should I simply override CompletableFuture's methods? I guess not. Especially considering strange semantics of cancel(boolean) method. Formally it doesn't violate any contract, but seems implying double calls of this method. Also it seems thread unsafe hence it uses check-and-act pattern:

```
if (latch.getCount() == 1) {
    latch.countDown();
    ...
}
```

This is suspicious. Probably we need to contact Will Glozer to clarify.
Thus I introduced FutureWithPromise interface and propose RedisAsyncConnection to return it instead of sheer Future. Thus we get less intrusive implementation and some separation of concerns. Of course it's not perfect, because getPromise() returns CompletableFuture instead of sheer promise object. But Java 8 has such a bloated class and nothing else.
I considered using other promise implementations (rx-promises, jdeferred), but Java's is the only full-fledged currently. Guava has cool ListenableFuture and so on, but they are not promises, while I wanted to get promises right off the bat.
Probably it's worth considering Guava's futures to make the library Java-version-agnostic. Then one may provide satellite library specially for promises.
Anyway dealing with simple Futures neutralize non-blocking I/O benefits. To use Future#get() we have to spawn new thread. This brings us back to threading overhead. In proposed implementation callbacks are called within nettyEventLoopGroup threads.

Tests will be provided when agreed on implementation, but here's the code snippet in Groovy to demonstrate how it works:

```
def client = new RedisClient(..., ...)
def connection = client.connectAsync()

connection.flushdb().promise.thenCompose { x ->
    connection.get('foo').promise
}.thenCompose { x ->
    assertThat x, nullValue()
    connection.set('foo', 'bar').promise
}.thenCompose {
    connection.get('foo').promise
}.thenAccept { x ->
    assertThat x, is('bar')
}.join() // join() is only for unit-testing purposes
```

Similar code will be in Java 8.

Could you also explain your comment on multiple operations? As far as I can see proposed solution doesn't affect the sequence of operations.

Cheers,
Denis
