### PR TITLE
Late initialization of default RedissonCodec (JsonJacksonCodec).

### DIFF
--- a/src/main/java/org/redisson/Config.java
+++ b/src/main/java/org/redisson/Config.java
@@ -41,7 +41,7 @@ public class Config {
     /**
      * Redis key/value codec
      */
-    private RedissonCodec codec = new JsonJacksonCodec();
+    private RedissonCodec codec = null;
 
     /**
      * Subscriptions per Redis connection limit
@@ -82,6 +82,11 @@ public class Config {
         this.codec = codec;
     }
     public RedissonCodec getCodec() {
+
+        if(codec == null) {
+            return new JsonJacksonCodec();
+        }
+
         return codec;
     }
 


### PR DESCRIPTION
This change allows to omit Jackson libraries. The situation before forced every user of reddison to have the jackson libraries on the class path, which were necessary to boot the class, even a different codec should be used.
