### PR TITLE
Timer should be stopped on shutdown

### DIFF
--- a/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
+++ b/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
@@ -501,6 +501,8 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
     public void shutdown() {
         entry.shutdown();
 
+        timer.stop();
+
         group.shutdownGracefully().syncUninterruptibly();
     }
 


### PR DESCRIPTION
Application which runs with Redisson is not stopped gracefully because all threads used by Redisson are not stopped. I think MasterSlaveConnectionManager should stop HashedWheelTimer on shutdown.
