### PR TITLE
Fix RLock's entries

### DIFF
--- a/src/main/java/org/redisson/RedissonLockEntry.java
+++ b/src/main/java/org/redisson/RedissonLockEntry.java
@@ -34,7 +34,7 @@ public class RedissonLockEntry {
     
     public RedissonLockEntry(Promise<Boolean> promise) {
         super();
-        this.latch = new Semaphore(1);
+        this.latch = new Semaphore(0);
         this.promise = promise;
     }
     


### PR DESCRIPTION
- Changed the semaphore initial value to 0, since every time
  we try to acquire it is because we subscribed and know we have
  to wait for another thread to signal it. This way, we just acquire
  it once, and avoid useless operations.
- Since the value was 1, the first thread to subscribe would go through
  the subscribe() method twice, meaning the entry's counter would be raised
  to 2, and on unsubscribe() decremented to 1, therefore, it would
  never be removed from ENTRIES.

All tests are still passing, it's just slightly faster and allows the ENTRIES map to be cleaned up, which in turn means PubSub Connections are released.
