### PR TITLE
shutdown for netty WheelTimer added

### DIFF
--- a/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
+++ b/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
@@ -601,7 +601,7 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
         for (MasterSlaveEntry entry : entries.values()) {
             entry.shutdown();
         }
-
+        timer.stop();
         group.shutdownGracefully().syncUninterruptibly();
     }
 


### PR DESCRIPTION
MasterSlaveConnectionManager should stop HashedWheelTimer for correct Redisson shutdown. It looks like pr #63 was lost.
