### PR TITLE
Make sure the pubsub listener is subscribed

### DIFF
--- a/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
+++ b/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
@@ -450,6 +450,7 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
     public <K, V> PubSubConnectionEntry subscribeOnce(RedisPubSubAdapter<V> listener, String channelName) {
         PubSubConnectionEntry сonnEntry = name2PubSubConnection.get(channelName);
         if (сonnEntry != null) {
+            сonnEntry.subscribe(listener, channelName);
             return сonnEntry;
         }
 


### PR DESCRIPTION
- When a connection is reused, the listener should still be subscribed.

This, along with all previous fixes, finally removes all known deadlock conditions for #89 
