### PR TITLE
try again after delaying a very small random time

### DIFF
--- a/src/main/java/org/redisson/RedissonLock.java
+++ b/src/main/java/org/redisson/RedissonLock.java
@@ -15,8 +15,10 @@
  */
 package org.redisson;
 
+import java.awt.*;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
@@ -122,7 +124,7 @@ public class RedissonLock extends RedissonExpirable implements RLock {
         long threadId = Thread.currentThread().getId();
         Future<RedissonLockEntry> future = subscribe(threadId);
         get(future);
-
+        Random random = new Random();
         try {
             while (true) {
                 ttl = tryAcquire(leaseTime, unit);
@@ -137,6 +139,8 @@ public class RedissonLock extends RedissonExpirable implements RLock {
                 } else {
                     getEntry(threadId).getLatch().acquire();
                 }
+                // try again after delaying a very small random time
+                Thread.currentThread().sleep(random.nextInt(5));//毫秒
             }
         } finally {
             unsubscribe(future, threadId);

--- a/src/main/java/org/redisson/RedissonLock.java
+++ b/src/main/java/org/redisson/RedissonLock.java
@@ -124,7 +124,6 @@ public class RedissonLock extends RedissonExpirable implements RLock {
         long threadId = Thread.currentThread().getId();
         Future<RedissonLockEntry> future = subscribe(threadId);
         get(future);
-        Random random = new Random();
         try {
             while (true) {
                 ttl = tryAcquire(leaseTime, unit);
@@ -139,8 +138,6 @@ public class RedissonLock extends RedissonExpirable implements RLock {
                 } else {
                     getEntry(threadId).getLatch().acquire();
                 }
-                // try again after delaying a very small random time
-                Thread.currentThread().sleep(random.nextInt(5));//毫秒
             }
         } finally {
             unsubscribe(future, threadId);


### PR DESCRIPTION
When a client to acquire the lock failure, the client should retry after a random delay, the reason why the use of random delay is to avoid different client and try again. The results all clients can't get the lock.