### PR TITLE
A random delay is added when the lock is repeatedly acquired

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,12 @@ Include the following to your dependency list:
     <dependency>
        <groupId>org.redisson</groupId>
        <artifactId>redisson</artifactId>
-       <version>2.2.21</version>
+       <version>2.2.22</version>
     </dependency>
 
 ### Gradle
 
-    compile 'org.redisson:redisson:2.2.21'
+    compile 'org.redisson:redisson:2.2.22'
 
 ### Supported by
 


### PR DESCRIPTION
When a client to acquire the lock failure, the client should retry after a random delay, the reason why the use of random delay is to avoid different client and try again. The results all clients can't get the lock.
