### PR TITLE
Add an autoconfigured Spring Boot CacheStatisticsProvider implementation

### DIFF
--- a/redisson/pom.xml
+++ b/redisson/pom.xml
@@ -244,6 +244,12 @@
             <version>1.2.2.RELEASE</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-actuator</artifactId>
+            <version>[1.4,)</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/redisson/src/main/java/org/redisson/spring/cache/RedissonCacheStatisticsAutoConfiguration.java
+++ b/redisson/src/main/java/org/redisson/spring/cache/RedissonCacheStatisticsAutoConfiguration.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2017 Craig Andrews
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.spring.cache;
+
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.cache.CacheAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ *
+ * @author Craig Andrews
+ *
+ * {@link EnableAutoConfiguration Auto-configuration} for {@link RedissonCacheStatisticsProvider}
+ *
+ */
+@Configuration
+@AutoConfigureAfter(CacheAutoConfiguration.class)
+@ConditionalOnBean(CacheManager.class)
+public class RedissonCacheStatisticsAutoConfiguration {
+    @Bean
+    public RedissonCacheStatisticsProvider redissonCacheStatisticsProvider(){
+        return new RedissonCacheStatisticsProvider();
+    }
+}

--- a/redisson/src/main/java/org/redisson/spring/cache/RedissonCacheStatisticsProvider.java
+++ b/redisson/src/main/java/org/redisson/spring/cache/RedissonCacheStatisticsProvider.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2017 Craig Andrews
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.spring.cache;
+
+import org.springframework.boot.actuate.cache.CacheStatistics;
+import org.springframework.boot.actuate.cache.CacheStatisticsProvider;
+import org.springframework.boot.actuate.cache.DefaultCacheStatistics;
+import org.springframework.cache.CacheManager;
+
+/**
+ *
+ * @author Craig Andrews
+ *
+ */
+public class RedissonCacheStatisticsProvider implements CacheStatisticsProvider<RedissonCache> {
+
+    @Override
+    public CacheStatistics getCacheStatistics(final CacheManager cacheManager, final RedissonCache cache) {
+        final DefaultCacheStatistics defaultCacheStatistics = new DefaultCacheStatistics();
+        defaultCacheStatistics.setSize((long) cache.getNativeCache().size());
+        defaultCacheStatistics.setGetCacheCounts(cache.getCacheHits(), cache.getCacheMisses());
+        return defaultCacheStatistics;
+    }
+
+}

--- a/redisson/src/main/resources/META-INF/spring.factories
+++ b/redisson/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=org.redisson.spring.cache.RedissonCacheStatisticsAutoConfiguration


### PR DESCRIPTION
Support Spring Boot Actuator cache metrics: https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-datasource-cache

With this change, Spring Boot will automatically (via RedissonCacheStatisticsAutoConfiguration) pick up the Redisson cache statistics provider. If the user doesn't use Spring Boot, nothing changes - Spring Boot is not a required dependency (just like how Spring itself isn't a Redisson required dependency).