### PR TITLE
Additional namespace refinement

### DIFF
--- a/redisson/src/main/java/org/redisson/spring/support/RedissonDefinitionParser.java
+++ b/redisson/src/main/java/org/redisson/spring/support/RedissonDefinitionParser.java
@@ -18,6 +18,7 @@ package org.redisson.spring.support;
 import java.util.List;
 import org.redisson.Redisson;
 import org.redisson.config.Config;
+import org.redisson.misc.URLBuilder;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.parsing.BeanComponentDefinition;
 import org.springframework.beans.factory.parsing.CompositeComponentDefinition;
@@ -159,12 +160,17 @@ public final class RedissonDefinitionParser
                     builder.addPropertyReference(propertyName,
                             attribute.getValue());
                 } else {
-                    String value = attribute.getValue();
+                    Object value = attribute.getValue();
                     String localName = helper.getName(element);
                     if ("masterAddress".equals(propertyName)
                             && ConfigType.masterSlaveServers.name()
                                     .equals(localName)) {
-                        value = "redis://" + value;
+                        try {
+                            value = URLBuilder.create((String) value);
+                        } catch (Exception e) {
+                            //value may be a placeholder
+                            value = "redis://" + value;
+                        }
                     }
                     builder.addPropertyValue(propertyName, value);
                 }

--- a/redisson/src/main/java/org/redisson/spring/support/RedissonMultiLockDefinitionParser.java
+++ b/redisson/src/main/java/org/redisson/spring/support/RedissonMultiLockDefinitionParser.java
@@ -44,7 +44,6 @@ public class RedissonMultiLockDefinitionParser
     protected void parseNested(Element element, ParserContext parserContext, BeanDefinitionBuilder builder, BeanDefinition bd) {
         bd.setDependsOn(element.getAttribute(
                 RedissonNamespaceParserSupport.REDISSON_REF_ATTRIBUTE));
-        bd.setLazyInit(true);
         List<Element> childElements = DomUtils.getChildElements(element);
         for (Element elt : childElements) {
             String localName = elt.getLocalName();

--- a/redisson/src/main/resources/org/redisson/spring/support/redisson-1.0.xsd
+++ b/redisson/src/main/resources/org/redisson/spring/support/redisson-1.0.xsd
@@ -221,7 +221,7 @@
                     ]]></xsd:documentation>
                     </xsd:annotation>
                 </xsd:attribute>
-                <xsd:attribute name="use-linuxN-native-epoll"
+                <xsd:attribute name="use-linux-native-epoll"
                                type="xsd:boolean">
                     <xsd:annotation>
                         <xsd:documentation><![CDATA[
@@ -796,6 +796,15 @@
         support this.</em> e.g., http://docs.aws.amazon.com/AWSSdkDocsJava/latest/DeveloperGuide/java-dg-jvm-ttl.html
                             
         Default: false
+                        ]]></xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:attribute>
+                    <xsd:attribute name="dns-monitoring-interval" type="xsd:long">
+                        <xsd:annotation>
+                            <xsd:documentation><![CDATA[
+        DNS change monitoring interval in milliseconds.
+                            
+        Default: 5000
                         ]]></xsd:documentation>
                         </xsd:annotation>
                     </xsd:attribute>

--- a/redisson/src/main/resources/org/redisson/spring/support/redisson-1.0.xsd
+++ b/redisson/src/main/resources/org/redisson/spring/support/redisson-1.0.xsd
@@ -57,6 +57,26 @@
         </xsd:restriction>
     </xsd:simpleType>
     
+    
+    <xsd:simpleType name="subscriptionMode"> 
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="SLAVE">
+                <xsd:annotation>
+                    <xsd:documentation><![CDATA[
+        Subscribe with slave nodes.
+                 ]]></xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="MASTER">
+                <xsd:annotation>
+                    <xsd:documentation><![CDATA[
+        Subscribe with master node.
+                 ]]></xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+        </xsd:restriction>
+    </xsd:simpleType>
+    
     <xsd:simpleType name="evictionPolicy"> 
         <xsd:restriction base="xsd:string">
             <xsd:enumeration value="NONE">
@@ -388,29 +408,6 @@
                      ]]></xsd:documentation>
                     </xsd:annotation>
                 </xsd:attribute>
-                <xsd:attribute
-                    name="slave-subscription-connection-minimum-idle-size"
-                    type="xsd:int">
-                    <xsd:annotation>
-                        <xsd:documentation><![CDATA[
-        Redis 'slave' node minimum idle subscription (pub/sub) connection amount
-        for <b>each</b> slave node.
-        
-        Default: 1
-                     ]]></xsd:documentation>
-                    </xsd:annotation>
-                </xsd:attribute>
-                <xsd:attribute name="slave-subscription-connection-pool-size"
-                               type="xsd:int">
-                    <xsd:annotation>
-                        <xsd:documentation><![CDATA[
-        Redis 'slave' node maximum subscription (pub/sub) connection pool size
-        for <b>each</b> slave node.
-        
-        Default: 50
-                     ]]></xsd:documentation>
-                    </xsd:annotation>
-                </xsd:attribute>
                 <xsd:attribute name="slave-connection-minimum-idle-size"
                                type="xsd:int">
                     <xsd:annotation>
@@ -462,6 +459,36 @@
                      ]]></xsd:documentation>
                     </xsd:annotation>
                 </xsd:attribute>
+                <xsd:attribute name="subscription-mode" type="subscriptionMode">
+                    <xsd:annotation>
+                        <xsd:documentation><![CDATA[
+        Set node type used for subscription operation.
+        
+        Default: SLAVE
+                     ]]></xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute
+                        name="subscription-connection-minimum-idle-size"
+                        type="xsd:int">
+                        <xsd:annotation>
+                            <xsd:documentation><![CDATA[
+        Minimum idle subscription connection amount.
+        
+        Default: 1
+                        ]]></xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:attribute>
+                    <xsd:attribute name="subscription-connection-pool-size"
+                                   type="xsd:int">
+                        <xsd:annotation>
+                            <xsd:documentation><![CDATA[
+        Redis subscription connection maximum pool size.
+                            
+        Default: 50
+                        ]]></xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:attribute>
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>
@@ -477,7 +504,7 @@
                     <xsd:annotation>
                         <xsd:documentation><![CDATA[
         Replication group scan interval in milliseconds.
-                            
+        
         Default: 1000
                         ]]></xsd:documentation>
                     </xsd:annotation>

--- a/redisson/src/test/java/org/redisson/RedisRunner.java
+++ b/redisson/src/test/java/org/redisson/RedisRunner.java
@@ -68,7 +68,7 @@ public class RedisRunner {
         SLAVE_PRIORITY,
         MIN_SLAVES_TO_WRITE,
         MIN_SLAVES_MAX_LAG,
-        REQUREPASS,
+        REQUIREPASS,
         RENAME_COMMAND(true),
         MAXCLIENTS,
         MAXMEMORY,
@@ -552,7 +552,7 @@ public class RedisRunner {
     }
 
     public RedisRunner requirepass(String requirepass) {
-        addConfigOption(REDIS_OPTIONS.REQUREPASS, requirepass);
+        addConfigOption(REDIS_OPTIONS.REQUIREPASS, requirepass);
         return this;
     }
 

--- a/redisson/src/test/java/org/redisson/spring/support/SpringNamespaceWikiTest.java
+++ b/redisson/src/test/java/org/redisson/spring/support/SpringNamespaceWikiTest.java
@@ -1,0 +1,195 @@
+package org.redisson.spring.support;
+
+import java.io.IOException;
+import java.util.List;
+import org.junit.Test;
+import org.redisson.ClusterRunner;
+import org.redisson.RedisRunner;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+/**
+ *
+ * @author Rui Gu (https://github.com/jackygurui)
+ */
+public class SpringNamespaceWikiTest {
+    
+    @Test
+    public void testSingle() throws Exception {
+        RedisRunner.RedisProcess run = new RedisRunner()
+                .requirepass("do_not_use_if_it_is_not_set")
+                .nosave()
+                .randomDir()
+                .run();
+        try {
+            ((ConfigurableApplicationContext)
+                new ClassPathXmlApplicationContext("classpath:org/redisson/spring/support/namespace_wiki_single.xml"))
+                .close();
+        } finally {
+            run.stop();
+        }
+    }
+    
+    @Test
+    public void testMasterSlave() throws Exception {
+        RedisRunner.RedisProcess master = new RedisRunner()
+                .requirepass("do_not_use_if_it_is_not_set")
+                .nosave()
+                .randomDir()
+                .run();
+        RedisRunner.RedisProcess slave1 = new RedisRunner()
+                .requirepass("do_not_use_if_it_is_not_set")
+                .masterauth("do_not_use_if_it_is_not_set")
+                .port(6380)
+                .nosave()
+                .randomDir()
+                .slaveof("127.0.0.1", 6379)
+                .run();
+        RedisRunner.RedisProcess slave2 = new RedisRunner()
+                .requirepass("do_not_use_if_it_is_not_set")
+                .masterauth("do_not_use_if_it_is_not_set")
+                .port(6381)
+                .nosave()
+                .randomDir()
+                .slaveof("127.0.0.1", 6379)
+                .run();
+        try {
+            ((ConfigurableApplicationContext)
+                    new ClassPathXmlApplicationContext("classpath:org/redisson/spring/support/namespace_wiki_master_slave.xml"))
+                    .close();
+        } finally {
+            master.stop();
+            slave1.stop();
+            slave2.stop();
+        }
+    }
+    
+    @Test
+    public void testSentinel() throws Exception {
+        RedisRunner.RedisProcess master = new RedisRunner()
+                .requirepass("do_not_use_if_it_is_not_set")
+                .nosave()
+                .randomDir()
+                .run();
+        RedisRunner.RedisProcess slave1 = new RedisRunner()
+                .requirepass("do_not_use_if_it_is_not_set")
+                .masterauth("do_not_use_if_it_is_not_set")
+                .port(6380)
+                .nosave()
+                .randomDir()
+                .slaveof("127.0.0.1", 6379)
+                .run();
+        RedisRunner.RedisProcess slave2 = new RedisRunner()
+                .requirepass("do_not_use_if_it_is_not_set")
+                .masterauth("do_not_use_if_it_is_not_set")
+                .port(6381)
+                .nosave()
+                .randomDir()
+                .slaveof("127.0.0.1", 6379)
+                .run();
+        RedisRunner.RedisProcess sentinel1 = new RedisRunner()
+//                .requirepass("do_not_use_if_it_is_not_set")
+                .nosave()
+                .randomDir()
+                .port(26379)
+                .sentinel()
+                .sentinelMonitor("myMaster", "127.0.0.1", 6379, 2)
+                .sentinelAuthPass("myMaster", "do_not_use_if_it_is_not_set")
+                .run();
+        RedisRunner.RedisProcess sentinel2 = new RedisRunner()
+//                .requirepass("do_not_use_if_it_is_not_set")
+                .nosave()
+                .randomDir()
+                .port(26380)
+                .sentinel()
+                .sentinelMonitor("myMaster", "127.0.0.1", 6379, 2)
+                .sentinelAuthPass("myMaster", "do_not_use_if_it_is_not_set")
+                .run();
+        RedisRunner.RedisProcess sentinel3 = new RedisRunner()
+//                .requirepass("do_not_use_if_it_is_not_set")
+                .nosave()
+                .randomDir()
+                .port(26381)
+                .sentinel()
+                .sentinelMonitor("myMaster", "127.0.0.1", 6379, 2)
+                .sentinelAuthPass("myMaster", "do_not_use_if_it_is_not_set")
+                .run();
+        try {
+            ((ConfigurableApplicationContext)
+                    new ClassPathXmlApplicationContext("classpath:org/redisson/spring/support/namespace_wiki_sentinel.xml"))
+                    .close();
+        } finally {
+            master.stop();
+            slave1.stop();
+            slave2.stop();
+            sentinel1.stop();
+            sentinel2.stop();
+            sentinel3.stop();
+        }
+    }
+    
+    @Test
+    public void testReplicated() throws Exception {
+        RedisRunner.RedisProcess master = new RedisRunner()
+                .requirepass("do_not_use_if_it_is_not_set")
+                .nosave()
+                .randomDir()
+                .run();
+        RedisRunner.RedisProcess slave1 = new RedisRunner()
+                .requirepass("do_not_use_if_it_is_not_set")
+                .masterauth("do_not_use_if_it_is_not_set")
+                .port(6380)
+                .nosave()
+                .randomDir()
+                .slaveof("127.0.0.1", 6379)
+                .run();
+        RedisRunner.RedisProcess slave2 = new RedisRunner()
+                .requirepass("do_not_use_if_it_is_not_set")
+                .masterauth("do_not_use_if_it_is_not_set")
+                .port(6381)
+                .nosave()
+                .randomDir()
+                .slaveof("127.0.0.1", 6379)
+                .run();
+        try {
+            ((ConfigurableApplicationContext)
+                    new ClassPathXmlApplicationContext("classpath:org/redisson/spring/support/namespace_wiki_replicated.xml"))
+                    .close();
+        } finally {
+            master.stop();
+            slave1.stop();
+            slave2.stop();
+        }
+    }
+    
+    @Test
+    public void testCluster() throws Exception {
+        ClusterRunner clusterRunner = new ClusterRunner()
+                .addNode(new RedisRunner()
+                        .requirepass("do_not_use_if_it_is_not_set")
+                        .port(6379)
+                        .randomDir()
+                        .nosave())
+                .addNode(new RedisRunner()
+                        .requirepass("do_not_use_if_it_is_not_set")
+                        .port(6380)
+                        .randomDir()
+                        .nosave())
+                .addNode(new RedisRunner()
+                        .requirepass("do_not_use_if_it_is_not_set")
+                        .port(6381)
+                        .randomDir()
+                        .nosave());
+        List<RedisRunner.RedisProcess> nodes = clusterRunner.run();
+        
+        try {
+            ((ConfigurableApplicationContext)
+                    new ClassPathXmlApplicationContext("classpath:org/redisson/spring/support/namespace_wiki_cluster.xml"))
+                    .close();
+        } finally {
+            for (RedisRunner.RedisProcess node : nodes) {
+                node.stop();
+            }
+        }
+    }
+}

--- a/redisson/src/test/resources/org/redisson/spring/support/namespace_wiki_cluster.xml
+++ b/redisson/src/test/resources/org/redisson/spring/support/namespace_wiki_cluster.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:redisson="http://redisson.org/schema/redisson"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
+       http://redisson.org/schema/redisson classpath:org/redisson/spring/support/redisson-1.0.xsd
+">
+    <bean id="myCodec" class="org.redisson.codec.MsgPackJacksonCodec"/>
+    <bean id="myCodecProvider" class="org.redisson.codec.DefaultCodecProvider"/>
+    <bean id="myResolverProvider" class="org.redisson.liveobject.provider.DefaultResolverProvider"/>
+    <bean id="myExecutor" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+        <property name="staticMethod" value="java.util.concurrent.Executors.newFixedThreadPool"/>
+        <property name="arguments" value="8"/>
+    </bean>
+    <bean id="myEventLoopGroup" class="io.netty.channel.nio.NioEventLoopGroup"/>
+    <bean id="myLoadBalancer" class="org.redisson.connection.balancer.RoundRobinLoadBalancer"/>
+    
+    <redisson:client
+        id="redisson"
+        name="redisson1,redisson2"
+        threads="0"
+        netty-threads="0"
+        codec-ref="myCodec" 
+        use-linux-native-epoll="false"
+        redisson-reference-enabled="true"
+        codec-provider-ref="myCodecProvider"
+        resolver-provider-ref="myResolverProvider"
+        executor-ref="myExecutor"
+        event-loop-group-ref="myEventLoopGroup"
+    >
+        <!--
+        You can't have both name attribute and qualifier element at
+        the same time. 
+
+        Both id attribute and name attribute can be used as qualifier
+        candidates.
+        -->
+        <!--<qualifier value="redisson3"/>-->
+        <redisson:cluster-servers
+            idle-connection-timeout="10000"
+            ping-timeout="1000"
+            connect-timeout="10000"
+            timeout="3000"
+            retry-attempts="3"
+            retry-interval="1500"
+            reconnection-timeout="3000"
+            failed-attempts="3"
+            password="do_not_use_if_it_is_not_set"
+            subscriptions-per-connection="5"
+            client-name="none"
+            load-balancer-ref="myLoadBalancer"
+            subscription-connection-minimum-idle-size="1"
+            subscription-connection-pool-size="50"
+            slave-connection-minimum-idle-size="10"
+            slave-connection-pool-size="64"
+            master-connection-minimum-idle-size="10"
+            master-connection-pool-size="64"
+            read-mode="SLAVE"
+            subscription-mode="SLAVE"
+            scan-interval="1000"
+        >
+            <redisson:node-address value="127.0.0.1:6379" />
+            <redisson:node-address value="127.0.0.1:6380" />
+            <redisson:node-address value="127.0.0.1:6381" />
+        </redisson:cluster-servers>
+    </redisson:client>
+</beans>

--- a/redisson/src/test/resources/org/redisson/spring/support/namespace_wiki_master_slave.xml
+++ b/redisson/src/test/resources/org/redisson/spring/support/namespace_wiki_master_slave.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:redisson="http://redisson.org/schema/redisson"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
+       http://redisson.org/schema/redisson classpath:org/redisson/spring/support/redisson-1.0.xsd
+">
+    <bean id="myCodec" class="org.redisson.codec.MsgPackJacksonCodec"/>
+    <bean id="myCodecProvider" class="org.redisson.codec.DefaultCodecProvider"/>
+    <bean id="myResolverProvider" class="org.redisson.liveobject.provider.DefaultResolverProvider"/>
+    <bean id="myExecutor" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+        <property name="staticMethod" value="java.util.concurrent.Executors.newFixedThreadPool"/>
+        <property name="arguments" value="8"/>
+    </bean>
+    <bean id="myEventLoopGroup" class="io.netty.channel.nio.NioEventLoopGroup"/>
+    <bean id="myLoadBalancer" class="org.redisson.connection.balancer.RoundRobinLoadBalancer"/>
+    
+    <redisson:client
+        id="redisson"
+        name="redisson1,redisson2"
+        threads="0"
+        netty-threads="0"
+        codec-ref="myCodec" 
+        use-linux-native-epoll="false"
+        redisson-reference-enabled="true"
+        codec-provider-ref="myCodecProvider"
+        resolver-provider-ref="myResolverProvider"
+        executor-ref="myExecutor"
+        event-loop-group-ref="myEventLoopGroup"
+    >
+        <!--
+        You can't have both name attribute and qualifier element at
+        the same time. 
+
+        Both id attribute and name attribute can be used as qualifier
+        candidates.
+        -->
+        <!--<qualifier value="redisson3"/>-->
+        <redisson:master-slave-servers
+            idle-connection-timeout="10000"
+            ping-timeout="1000"
+            connect-timeout="10000"
+            timeout="3000"
+            retry-attempts="3"
+            retry-interval="1500"
+            reconnection-timeout="3000"
+            failed-attempts="3"
+            password="do_not_use_if_it_is_not_set"
+            subscriptions-per-connection="5"
+            client-name="none"
+            load-balancer-ref="myLoadBalancer"
+            subscription-connection-minimum-idle-size="1"
+            subscription-connection-pool-size="50"
+            slave-connection-minimum-idle-size="10"
+            slave-connection-pool-size="64"
+            master-connection-minimum-idle-size="10"
+            master-connection-pool-size="64"
+            read-mode="SLAVE"
+            subscription-mode="SLAVE"
+            master-address="127.0.0.1:6379"
+            database="0"
+        >
+            <redisson:slave-address value="127.0.0.1:6380" />
+            <redisson:slave-address value="127.0.0.1:6381" />
+        </redisson:master-slave-servers>
+    </redisson:client>
+</beans>

--- a/redisson/src/test/resources/org/redisson/spring/support/namespace_wiki_replicated.xml
+++ b/redisson/src/test/resources/org/redisson/spring/support/namespace_wiki_replicated.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:redisson="http://redisson.org/schema/redisson"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
+       http://redisson.org/schema/redisson classpath:org/redisson/spring/support/redisson-1.0.xsd
+">
+    <bean id="myCodec" class="org.redisson.codec.MsgPackJacksonCodec"/>
+    <bean id="myCodecProvider" class="org.redisson.codec.DefaultCodecProvider"/>
+    <bean id="myResolverProvider" class="org.redisson.liveobject.provider.DefaultResolverProvider"/>
+    <bean id="myExecutor" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+        <property name="staticMethod" value="java.util.concurrent.Executors.newFixedThreadPool"/>
+        <property name="arguments" value="8"/>
+    </bean>
+    <bean id="myEventLoopGroup" class="io.netty.channel.nio.NioEventLoopGroup"/>
+    <bean id="myLoadBalancer" class="org.redisson.connection.balancer.RoundRobinLoadBalancer"/>
+    
+    <redisson:client
+        id="redisson"
+        name="redisson1,redisson2"
+        threads="0"
+        netty-threads="0"
+        codec-ref="myCodec" 
+        use-linux-native-epoll="false"
+        redisson-reference-enabled="true"
+        codec-provider-ref="myCodecProvider"
+        resolver-provider-ref="myResolverProvider"
+        executor-ref="myExecutor"
+        event-loop-group-ref="myEventLoopGroup"
+    >
+        <!--
+        You can't have both name attribute and qualifier element at
+        the same time. 
+
+        Both id attribute and name attribute can be used as qualifier
+        candidates.
+        -->
+        <!--<qualifier value="redisson3"/>-->
+        <redisson:replicated-servers
+            idle-connection-timeout="10000"
+            ping-timeout="1000"
+            connect-timeout="10000"
+            timeout="3000"
+            retry-attempts="3"
+            retry-interval="1500"
+            reconnection-timeout="3000"
+            failed-attempts="3"
+            password="do_not_use_if_it_is_not_set"
+            subscriptions-per-connection="5"
+            client-name="none"
+            load-balancer-ref="myLoadBalancer"
+            subscription-connection-minimum-idle-size="1"
+            subscription-connection-pool-size="50"
+            slave-connection-minimum-idle-size="10"
+            slave-connection-pool-size="64"
+            master-connection-minimum-idle-size="10"
+            master-connection-pool-size="64"
+            read-mode="SLAVE"
+            subscription-mode="SLAVE"
+            scan-interval="1000"
+            database="0"
+        >
+            <redisson:node-address value="127.0.0.1:6379" />
+            <redisson:node-address value="127.0.0.1:6380" />
+            <redisson:node-address value="127.0.0.1:6381" />
+        </redisson:replicated-servers>
+    </redisson:client>
+</beans>

--- a/redisson/src/test/resources/org/redisson/spring/support/namespace_wiki_sentinel.xml
+++ b/redisson/src/test/resources/org/redisson/spring/support/namespace_wiki_sentinel.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:redisson="http://redisson.org/schema/redisson"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
+       http://redisson.org/schema/redisson classpath:org/redisson/spring/support/redisson-1.0.xsd
+">
+    <bean id="myCodec" class="org.redisson.codec.MsgPackJacksonCodec"/>
+    <bean id="myCodecProvider" class="org.redisson.codec.DefaultCodecProvider"/>
+    <bean id="myResolverProvider" class="org.redisson.liveobject.provider.DefaultResolverProvider"/>
+    <bean id="myExecutor" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+        <property name="staticMethod" value="java.util.concurrent.Executors.newFixedThreadPool"/>
+        <property name="arguments" value="8"/>
+    </bean>
+    <bean id="myEventLoopGroup" class="io.netty.channel.nio.NioEventLoopGroup"/>
+    <bean id="myLoadBalancer" class="org.redisson.connection.balancer.RoundRobinLoadBalancer"/>
+    
+    <redisson:client
+        id="redisson"
+        name="redisson1,redisson2"
+        threads="0"
+        netty-threads="0"
+        codec-ref="myCodec" 
+        use-linux-native-epoll="false"
+        redisson-reference-enabled="true"
+        codec-provider-ref="myCodecProvider"
+        resolver-provider-ref="myResolverProvider"
+        executor-ref="myExecutor"
+        event-loop-group-ref="myEventLoopGroup"
+    >
+        <!--
+        You can't have both name attribute and qualifier element at
+        the same time. 
+
+        Both id attribute and name attribute can be used as qualifier
+        candidates.
+        -->
+        <!--<qualifier value="redisson3"/>-->
+        <redisson:sentinel-servers
+            idle-connection-timeout="10000"
+            ping-timeout="1000"
+            connect-timeout="10000"
+            timeout="3000"
+            retry-attempts="3"
+            retry-interval="1500"
+            reconnection-timeout="3000"
+            failed-attempts="3"
+            password="do_not_use_if_it_is_not_set"
+            subscriptions-per-connection="5"
+            client-name="none"
+            load-balancer-ref="myLoadBalancer"
+            subscription-connection-minimum-idle-size="1"
+            subscription-connection-pool-size="50"
+            slave-connection-minimum-idle-size="10"
+            slave-connection-pool-size="64"
+            master-connection-minimum-idle-size="10"
+            master-connection-pool-size="64"
+            read-mode="SLAVE"
+            subscription-mode="SLAVE"
+            master-name="myMaster"
+            database="0"
+        >
+            <redisson:sentinel-address value="127.0.0.1:26379" />
+            <redisson:sentinel-address value="127.0.0.1:26380" />
+        </redisson:sentinel-servers>
+    </redisson:client>
+</beans>

--- a/redisson/src/test/resources/org/redisson/spring/support/namespace_wiki_single.xml
+++ b/redisson/src/test/resources/org/redisson/spring/support/namespace_wiki_single.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:redisson="http://redisson.org/schema/redisson"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
+       http://redisson.org/schema/redisson classpath:org/redisson/spring/support/redisson-1.0.xsd
+">
+    <bean id="myCodec" class="org.redisson.codec.MsgPackJacksonCodec"/>
+    <bean id="myCodecProvider" class="org.redisson.codec.DefaultCodecProvider"/>
+    <bean id="myResolverProvider" class="org.redisson.liveobject.provider.DefaultResolverProvider"/>
+    <bean id="myExecutor" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+        <property name="staticMethod" value="java.util.concurrent.Executors.newFixedThreadPool"/>
+        <property name="arguments" value="8"/>
+    </bean>
+    <bean id="myEventLoopGroup" class="io.netty.channel.nio.NioEventLoopGroup"/>
+    
+    <redisson:client
+        id="redisson"
+        name="redisson1,redisson2"
+        threads="0"
+        netty-threads="0"
+        codec-ref="myCodec" 
+        use-linux-native-epoll="false"
+        redisson-reference-enabled="true"
+        codec-provider-ref="myCodecProvider"
+        resolver-provider-ref="myResolverProvider"
+        executor-ref="myExecutor"
+        event-loop-group-ref="myEventLoopGroup"
+    >
+        <!--
+        You can't have both name attribute and qualifier element at
+        the same time. 
+
+        Both id attribute and name attribute can be used as qualifier
+        candidates.
+        -->
+        <!--<qualifier value="redisson3"/>-->
+        <redisson:single-server
+            idle-connection-timeout="10000"
+            ping-timeout="1000"
+            connect-timeout="10000"
+            timeout="3000"
+            retry-attempts="3"
+            retry-interval="1500"
+            reconnection-timeout="3000"
+            failed-attempts="3"
+            password="do_not_use_if_it_is_not_set"
+            subscriptions-per-connection="5"
+            client-name="none"            
+            address="127.0.0.1:6379"
+            subscription-connection-minimum-idle-size="1"
+            subscription-connection-pool-size="50"
+            connection-minimum-idle-size="10"
+            connection-pool-size="64"
+            database="0"
+            dns-monitoring="false"
+            dns-monitoring-interval="5000"
+        />            
+    </redisson:client>
+</beans>


### PR DESCRIPTION
Removed the workaround for multi-lock namespace definition

Employed proper solution where dependencies are explicitly defined to help spring create beans in a desired order.

Merged with master

Modified redisson.xsd to be inline with recent config changes

Fixed some typo

A better way to resolve master address URL

Added test cases to cover the examples mentioned in the wiki page.