### PR TITLE
Add test coverage for org.redisson.codec.AvroJacksonCodec

### DIFF
--- a/redisson/src/test/java/org/redisson/RedissonCodecTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonCodecTest.java
@@ -14,6 +14,7 @@ import org.redisson.codec.KryoCodec;
 import org.redisson.codec.LZ4Codec;
 import org.redisson.codec.MsgPackJacksonCodec;
 import org.redisson.codec.SerializationCodec;
+import org.redisson.codec.AvroJacksonCodec;
 import org.redisson.codec.SmileJacksonCodec;
 import org.redisson.codec.SnappyCodec;
 import org.redisson.config.Config;
@@ -28,7 +29,7 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class RedissonCodecTest extends BaseTest {
-    private Codec avroCodec = new SmileJacksonCodec();
+    private Codec avroCodec = new AvroJacksonCodec();
     private Codec smileCodec = new SmileJacksonCodec();
     private Codec codec = new SerializationCodec();
     private Codec kryoCodec = new KryoCodec();


### PR DESCRIPTION
On this pull request we add test coverage for org.redisson.codec.AvroJacksonCodec by fixing an wrong variable assignment at org.redisson.RedissonCodecTest

There is already an open issue raising this point: #799