### PR TITLE
Support STORE parameter for GEORADIUS and GEORADIUSBYMEMBER

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonGeo.java
+++ b/redisson/src/main/java/org/redisson/RedissonGeo.java
@@ -443,7 +443,7 @@ public class RedissonGeo<V> extends RedissonScoredSortedSet<V> implements RGeo<V
 
 	@Override
 	public RFuture<Integer> radiusStoreAsync(String fromKey, V member, double radius, GeoUnit geoUnit) {
-        return commandExecutor.writeAsync(fromKey, LongCodec.INSTANCE, RedisCommands.GEORADIUSBYMEMBER_STORE_INT, fromKey, member, radius, geoUnit, "STORE", getName());
+        return commandExecutor.writeAsync(fromKey, codec, RedisCommands.GEORADIUSBYMEMBER_STORE_INT, fromKey, member, radius, geoUnit, "STORE", getName());
 	}
 
 	@Override
@@ -453,7 +453,7 @@ public class RedissonGeo<V> extends RedissonScoredSortedSet<V> implements RGeo<V
 
 	@Override
 	public RFuture<Integer> radiusStoreAsync(String fromKey, V member, double radius, GeoUnit geoUnit, int count) {
-        return commandExecutor.writeAsync(fromKey, LongCodec.INSTANCE, RedisCommands.GEORADIUSBYMEMBER_STORE_INT, fromKey, member, radius, geoUnit, "COUNT", count, "STORE", getName());
+        return commandExecutor.writeAsync(fromKey, codec, RedisCommands.GEORADIUSBYMEMBER_STORE_INT, fromKey, member, radius, geoUnit, "COUNT", count, "STORE", getName());
 	}
 
 	@Override
@@ -463,7 +463,7 @@ public class RedissonGeo<V> extends RedissonScoredSortedSet<V> implements RGeo<V
 
 	@Override
 	public RFuture<Integer> radiusStoreAsync(String fromKey, V member, double radius, GeoUnit geoUnit, GeoOrder geoOrder, int count) {
-        return commandExecutor.writeAsync(fromKey, LongCodec.INSTANCE, RedisCommands.GEORADIUSBYMEMBER_STORE_INT, fromKey, member, radius, geoUnit, geoOrder, "COUNT", count, "STORE", getName());
+        return commandExecutor.writeAsync(fromKey, codec, RedisCommands.GEORADIUSBYMEMBER_STORE_INT, fromKey, member, radius, geoUnit, geoOrder, "COUNT", count, "STORE", getName());
 	}
 
 }

--- a/redisson/src/main/java/org/redisson/RedissonGeo.java
+++ b/redisson/src/main/java/org/redisson/RedissonGeo.java
@@ -407,63 +407,63 @@ public class RedissonGeo<V> extends RedissonScoredSortedSet<V> implements RGeo<V
     }
 
 	@Override
-	public int radiusStore(String fromKey, double longitude, double latitude, double radius, GeoUnit geoUnit) {
-		return get(radiusStoreAsync(fromKey, longitude, latitude, radius, geoUnit));
+	public int radiusStoreTo(String destName, double longitude, double latitude, double radius, GeoUnit geoUnit) {
+		return get(radiusStoreToAsync(destName, longitude, latitude, radius, geoUnit));
 	}
 
 	@Override
-	public RFuture<Integer> radiusStoreAsync(String fromKey, double longitude, double latitude, double radius, GeoUnit geoUnit) {
-        return commandExecutor.writeAsync(getName(), LongCodec.INSTANCE, RedisCommands.GEORADIUS_STORE_INT, fromKey, convert(longitude), convert(latitude), radius, geoUnit, "STORE", getName());
+	public RFuture<Integer> radiusStoreToAsync(String destName, double longitude, double latitude, double radius, GeoUnit geoUnit) {
+        return commandExecutor.writeAsync(getName(), LongCodec.INSTANCE, RedisCommands.GEORADIUS_STORE_INT, getName(), convert(longitude), convert(latitude), radius, geoUnit, "STORE", destName);
 	}
 
 	@Override
-	public int radiusStore(String fromKey, double longitude, double latitude, double radius, GeoUnit geoUnit, int count) {
-		return get(radiusStoreAsync(fromKey, longitude, latitude, radius, geoUnit, count));
+	public int radiusStoreTo(String destName, double longitude, double latitude, double radius, GeoUnit geoUnit, int count) {
+		return get(radiusStoreToAsync(destName, longitude, latitude, radius, geoUnit, count));
 	}
 
 	@Override
-	public RFuture<Integer> radiusStoreAsync(String fromKey, double longitude, double latitude, double radius, GeoUnit geoUnit, int count) {
-        return commandExecutor.writeAsync(getName(), LongCodec.INSTANCE, RedisCommands.GEORADIUS_STORE_INT, fromKey, convert(longitude), convert(latitude), radius, geoUnit, "COUNT", count, "STORE", getName());
+	public RFuture<Integer> radiusStoreToAsync(String destName, double longitude, double latitude, double radius, GeoUnit geoUnit, int count) {
+        return commandExecutor.writeAsync(getName(), LongCodec.INSTANCE, RedisCommands.GEORADIUS_STORE_INT, getName(), convert(longitude), convert(latitude), radius, geoUnit, "COUNT", count, "STORE", destName);
 	}
 
 	@Override
-	public int radiusStore(String fromKey, double longitude, double latitude, double radius, GeoUnit geoUnit, GeoOrder geoOrder, int count) {
-		return get(radiusStoreAsync(fromKey, longitude, latitude, radius, geoUnit, geoOrder, count));
+	public int radiusStoreTo(String destName, double longitude, double latitude, double radius, GeoUnit geoUnit, GeoOrder geoOrder, int count) {
+		return get(radiusStoreToAsync(destName, longitude, latitude, radius, geoUnit, geoOrder, count));
 	}
 
 	@Override
-	public RFuture<Integer> radiusStoreAsync(String fromKey, double longitude, double latitude, double radius, GeoUnit geoUnit, GeoOrder geoOrder, int count) {
-        return commandExecutor.writeAsync(getName(), LongCodec.INSTANCE, RedisCommands.GEORADIUS_STORE_INT, fromKey, convert(longitude), convert(latitude), radius, geoUnit, geoOrder, "COUNT", count, "STORE", getName());
+	public RFuture<Integer> radiusStoreToAsync(String destName, double longitude, double latitude, double radius, GeoUnit geoUnit, GeoOrder geoOrder, int count) {
+        return commandExecutor.writeAsync(getName(), LongCodec.INSTANCE, RedisCommands.GEORADIUS_STORE_INT, getName(), convert(longitude), convert(latitude), radius, geoUnit, geoOrder, "COUNT", count, "STORE", destName);
 	}
 
 	@Override
-	public int radiusStore(String fromKey, V member, double radius, GeoUnit geoUnit) {
-		return get(radiusStoreAsync(fromKey, member, radius, geoUnit));
+	public int radiusStoreTo(String destName, V member, double radius, GeoUnit geoUnit) {
+		return get(radiusStoreToAsync(destName, member, radius, geoUnit));
 	}
 
 	@Override
-	public RFuture<Integer> radiusStoreAsync(String fromKey, V member, double radius, GeoUnit geoUnit) {
-        return commandExecutor.writeAsync(getName(), codec, RedisCommands.GEORADIUSBYMEMBER_STORE_INT, fromKey, member, radius, geoUnit, "STORE", getName());
+	public RFuture<Integer> radiusStoreToAsync(String destName, V member, double radius, GeoUnit geoUnit) {
+        return commandExecutor.writeAsync(getName(), codec, RedisCommands.GEORADIUSBYMEMBER_STORE_INT, getName(), member, radius, geoUnit, "STORE", destName);
 	}
 
 	@Override
-	public int radiusStore(String fromKey, V member, double radius, GeoUnit geoUnit, int count) {
-		return get(radiusStoreAsync(fromKey, member, radius, geoUnit, count));
+	public int radiusStoreTo(String destName, V member, double radius, GeoUnit geoUnit, int count) {
+		return get(radiusStoreToAsync(destName, member, radius, geoUnit, count));
 	}
 
 	@Override
-	public RFuture<Integer> radiusStoreAsync(String fromKey, V member, double radius, GeoUnit geoUnit, int count) {
-        return commandExecutor.writeAsync(getName(), codec, RedisCommands.GEORADIUSBYMEMBER_STORE_INT, fromKey, member, radius, geoUnit, "COUNT", count, "STORE", getName());
+	public RFuture<Integer> radiusStoreToAsync(String destName, V member, double radius, GeoUnit geoUnit, int count) {
+        return commandExecutor.writeAsync(getName(), codec, RedisCommands.GEORADIUSBYMEMBER_STORE_INT, getName(), member, radius, geoUnit, "COUNT", count, "STORE", destName);
 	}
 
 	@Override
-	public int radiusStore(String fromKey, V member, double radius, GeoUnit geoUnit, GeoOrder geoOrder, int count) {
-        return get(radiusStoreAsync(fromKey, member, radius, geoUnit, geoOrder, count));
+	public int radiusStoreTo(String destName, V member, double radius, GeoUnit geoUnit, GeoOrder geoOrder, int count) {
+        return get(radiusStoreToAsync(destName, member, radius, geoUnit, geoOrder, count));
 	}
 
 	@Override
-	public RFuture<Integer> radiusStoreAsync(String fromKey, V member, double radius, GeoUnit geoUnit, GeoOrder geoOrder, int count) {
-        return commandExecutor.writeAsync(getName(), codec, RedisCommands.GEORADIUSBYMEMBER_STORE_INT, fromKey, member, radius, geoUnit, geoOrder, "COUNT", count, "STORE", getName());
+	public RFuture<Integer> radiusStoreToAsync(String destName, V member, double radius, GeoUnit geoUnit, GeoOrder geoOrder, int count) {
+        return commandExecutor.writeAsync(getName(), codec, RedisCommands.GEORADIUSBYMEMBER_STORE_INT, getName(), member, radius, geoUnit, geoOrder, "COUNT", count, "STORE", destName);
 	}
 
 }

--- a/redisson/src/main/java/org/redisson/RedissonGeo.java
+++ b/redisson/src/main/java/org/redisson/RedissonGeo.java
@@ -30,6 +30,7 @@ import org.redisson.api.RGeo;
 import org.redisson.api.RedissonClient;
 import org.redisson.client.codec.Codec;
 import org.redisson.client.codec.GeoEntryCodec;
+import org.redisson.client.codec.LongCodec;
 import org.redisson.client.codec.ScoredCodec;
 import org.redisson.client.protocol.RedisCommand;
 import org.redisson.client.protocol.RedisCommand.ValueType;
@@ -404,5 +405,65 @@ public class RedissonGeo<V> extends RedissonScoredSortedSet<V> implements RGeo<V
         RedisCommand<Map<Object, Object>> command = new RedisCommand<Map<Object, Object>>("GEORADIUSBYMEMBER", postitionDecoder, 2);
         return commandExecutor.readAsync(getName(), codec, command, getName(), member, radius, geoUnit, "WITHCOORD", "COUNT", count, geoOrder);
     }
-    
+
+	@Override
+	public int radiusStore(String fromKey, double longitude, double latitude, double radius, GeoUnit geoUnit) {
+		return get(radiusStoreAsync(fromKey, longitude, latitude, radius, geoUnit));
+	}
+
+	@Override
+	public RFuture<Integer> radiusStoreAsync(String fromKey, double longitude, double latitude, double radius, GeoUnit geoUnit) {
+        return commandExecutor.writeAsync(fromKey, LongCodec.INSTANCE, RedisCommands.GEORADIUS_STORE_INT, fromKey, convert(longitude), convert(latitude), radius, geoUnit, "STORE", getName());
+	}
+
+	@Override
+	public int radiusStore(String fromKey, double longitude, double latitude, double radius, GeoUnit geoUnit, int count) {
+		return get(radiusStoreAsync(fromKey, longitude, latitude, radius, geoUnit, count));
+	}
+
+	@Override
+	public RFuture<Integer> radiusStoreAsync(String fromKey, double longitude, double latitude, double radius, GeoUnit geoUnit, int count) {
+        return commandExecutor.writeAsync(fromKey, LongCodec.INSTANCE, RedisCommands.GEORADIUS_STORE_INT, fromKey, convert(longitude), convert(latitude), radius, geoUnit, "COUNT", count, "STORE", getName());
+	}
+
+	@Override
+	public int radiusStore(String fromKey, double longitude, double latitude, double radius, GeoUnit geoUnit, GeoOrder geoOrder, int count) {
+		return get(radiusStoreAsync(fromKey, longitude, latitude, radius, geoUnit, geoOrder, count));
+	}
+
+	@Override
+	public RFuture<Integer> radiusStoreAsync(String fromKey, double longitude, double latitude, double radius, GeoUnit geoUnit, GeoOrder geoOrder, int count) {
+        return commandExecutor.writeAsync(fromKey, LongCodec.INSTANCE, RedisCommands.GEORADIUS_STORE_INT, fromKey, convert(longitude), convert(latitude), radius, geoUnit, geoOrder, "COUNT", count, "STORE", getName());
+	}
+
+	@Override
+	public int radiusStore(String fromKey, V member, double radius, GeoUnit geoUnit) {
+		return get(radiusStoreAsync(fromKey, member, radius, geoUnit));
+	}
+
+	@Override
+	public RFuture<Integer> radiusStoreAsync(String fromKey, V member, double radius, GeoUnit geoUnit) {
+        return commandExecutor.writeAsync(fromKey, LongCodec.INSTANCE, RedisCommands.GEORADIUSBYMEMBER_STORE_INT, fromKey, member, radius, geoUnit, "STORE", getName());
+	}
+
+	@Override
+	public int radiusStore(String fromKey, V member, double radius, GeoUnit geoUnit, int count) {
+		return get(radiusStoreAsync(fromKey, member, radius, geoUnit, count));
+	}
+
+	@Override
+	public RFuture<Integer> radiusStoreAsync(String fromKey, V member, double radius, GeoUnit geoUnit, int count) {
+        return commandExecutor.writeAsync(fromKey, LongCodec.INSTANCE, RedisCommands.GEORADIUSBYMEMBER_STORE_INT, fromKey, member, radius, geoUnit, "COUNT", count, "STORE", getName());
+	}
+
+	@Override
+	public int radiusStore(String fromKey, V member, double radius, GeoUnit geoUnit, GeoOrder geoOrder, int count) {
+		return get(radiusStoreAsync(fromKey, member, radius, geoUnit, count));
+	}
+
+	@Override
+	public RFuture<Integer> radiusStoreAsync(String fromKey, V member, double radius, GeoUnit geoUnit, GeoOrder geoOrder, int count) {
+        return commandExecutor.writeAsync(fromKey, LongCodec.INSTANCE, RedisCommands.GEORADIUSBYMEMBER_STORE_INT, fromKey, member, radius, geoUnit, geoOrder, "COUNT", count, "STORE", getName());
+	}
+
 }

--- a/redisson/src/main/java/org/redisson/RedissonGeo.java
+++ b/redisson/src/main/java/org/redisson/RedissonGeo.java
@@ -413,7 +413,7 @@ public class RedissonGeo<V> extends RedissonScoredSortedSet<V> implements RGeo<V
 
 	@Override
 	public RFuture<Integer> radiusStoreAsync(String fromKey, double longitude, double latitude, double radius, GeoUnit geoUnit) {
-        return commandExecutor.writeAsync(fromKey, LongCodec.INSTANCE, RedisCommands.GEORADIUS_STORE_INT, fromKey, convert(longitude), convert(latitude), radius, geoUnit, "STORE", getName());
+        return commandExecutor.writeAsync(getName(), LongCodec.INSTANCE, RedisCommands.GEORADIUS_STORE_INT, fromKey, convert(longitude), convert(latitude), radius, geoUnit, "STORE", getName());
 	}
 
 	@Override
@@ -423,7 +423,7 @@ public class RedissonGeo<V> extends RedissonScoredSortedSet<V> implements RGeo<V
 
 	@Override
 	public RFuture<Integer> radiusStoreAsync(String fromKey, double longitude, double latitude, double radius, GeoUnit geoUnit, int count) {
-        return commandExecutor.writeAsync(fromKey, LongCodec.INSTANCE, RedisCommands.GEORADIUS_STORE_INT, fromKey, convert(longitude), convert(latitude), radius, geoUnit, "COUNT", count, "STORE", getName());
+        return commandExecutor.writeAsync(getName(), LongCodec.INSTANCE, RedisCommands.GEORADIUS_STORE_INT, fromKey, convert(longitude), convert(latitude), radius, geoUnit, "COUNT", count, "STORE", getName());
 	}
 
 	@Override
@@ -433,7 +433,7 @@ public class RedissonGeo<V> extends RedissonScoredSortedSet<V> implements RGeo<V
 
 	@Override
 	public RFuture<Integer> radiusStoreAsync(String fromKey, double longitude, double latitude, double radius, GeoUnit geoUnit, GeoOrder geoOrder, int count) {
-        return commandExecutor.writeAsync(fromKey, LongCodec.INSTANCE, RedisCommands.GEORADIUS_STORE_INT, fromKey, convert(longitude), convert(latitude), radius, geoUnit, geoOrder, "COUNT", count, "STORE", getName());
+        return commandExecutor.writeAsync(getName(), LongCodec.INSTANCE, RedisCommands.GEORADIUS_STORE_INT, fromKey, convert(longitude), convert(latitude), radius, geoUnit, geoOrder, "COUNT", count, "STORE", getName());
 	}
 
 	@Override
@@ -443,7 +443,7 @@ public class RedissonGeo<V> extends RedissonScoredSortedSet<V> implements RGeo<V
 
 	@Override
 	public RFuture<Integer> radiusStoreAsync(String fromKey, V member, double radius, GeoUnit geoUnit) {
-        return commandExecutor.writeAsync(fromKey, codec, RedisCommands.GEORADIUSBYMEMBER_STORE_INT, fromKey, member, radius, geoUnit, "STORE", getName());
+        return commandExecutor.writeAsync(getName(), codec, RedisCommands.GEORADIUSBYMEMBER_STORE_INT, fromKey, member, radius, geoUnit, "STORE", getName());
 	}
 
 	@Override
@@ -453,17 +453,17 @@ public class RedissonGeo<V> extends RedissonScoredSortedSet<V> implements RGeo<V
 
 	@Override
 	public RFuture<Integer> radiusStoreAsync(String fromKey, V member, double radius, GeoUnit geoUnit, int count) {
-        return commandExecutor.writeAsync(fromKey, codec, RedisCommands.GEORADIUSBYMEMBER_STORE_INT, fromKey, member, radius, geoUnit, "COUNT", count, "STORE", getName());
+        return commandExecutor.writeAsync(getName(), codec, RedisCommands.GEORADIUSBYMEMBER_STORE_INT, fromKey, member, radius, geoUnit, "COUNT", count, "STORE", getName());
 	}
 
 	@Override
 	public int radiusStore(String fromKey, V member, double radius, GeoUnit geoUnit, GeoOrder geoOrder, int count) {
-		return get(radiusStoreAsync(fromKey, member, radius, geoUnit, count));
+        return get(radiusStoreAsync(fromKey, member, radius, geoUnit, geoOrder, count));
 	}
 
 	@Override
 	public RFuture<Integer> radiusStoreAsync(String fromKey, V member, double radius, GeoUnit geoUnit, GeoOrder geoOrder, int count) {
-        return commandExecutor.writeAsync(fromKey, codec, RedisCommands.GEORADIUSBYMEMBER_STORE_INT, fromKey, member, radius, geoUnit, geoOrder, "COUNT", count, "STORE", getName());
+        return commandExecutor.writeAsync(getName(), codec, RedisCommands.GEORADIUSBYMEMBER_STORE_INT, fromKey, member, radius, geoUnit, geoOrder, "COUNT", count, "STORE", getName());
 	}
 
 }

--- a/redisson/src/main/java/org/redisson/api/RGeo.java
+++ b/redisson/src/main/java/org/redisson/api/RGeo.java
@@ -444,5 +444,99 @@ public interface RGeo<V> extends RScoredSortedSet<V>, RGeoAsync<V> {
      * @return geo position mapped by object
      */
     Map<V, GeoPosition> radiusWithPosition(V member, double radius, GeoUnit geoUnit, GeoOrder geoOrder, int count);
-    
+
+    /**
+     * Finds the members of a sorted set, which are within the 
+     * borders of the area specified with the center location 
+     * and the maximum distance from the center (the radius) 
+     * in <code>GeoUnit</code> units. 
+     * Store result to current Geo.
+     * 
+     * @param longitude - longitude of object
+     * @param latitude - latitude of object
+     * @param radius - radius in geo units
+     * @param geoUnit - geo unit
+     * @return length of result
+     */
+    int radiusStore(String fromKey, double longitude, double latitude, double radius, GeoUnit geoUnit);
+
+    /**
+     * Finds the members of a sorted set, which are within the 
+     * borders of the area specified with the center location 
+     * and the maximum distance from the center (the radius) 
+     * in <code>GeoUnit</code> units and limited by count 
+     * Store result to current Geo.
+     * 
+     * @param longitude - longitude of object
+     * @param latitude - latitude of object
+     * @param radius - radius in geo units
+     * @param geoUnit - geo unit
+     * @param count - result limit
+     * @return length of result
+     */
+    int radiusStore(String fromKey, double longitude, double latitude, double radius, GeoUnit geoUnit, int count);
+
+    /**
+     * Finds the members of a sorted set, which are within the 
+     * borders of the area specified with the center location 
+     * and the maximum distance from the center (the radius) 
+     * in <code>GeoUnit</code> units with <code>GeoOrder</code> 
+     * and limited by count 
+     * Store result to current Geo.
+     * 
+     * @param longitude - longitude of object
+     * @param latitude - latitude of object
+     * @param radius - radius in geo units
+     * @param geoUnit - geo unit
+     * @param geoOrder - order of result
+     * @param count - result limit
+     * @return length of result
+     */
+    int radiusStore(String fromKey, double longitude, double latitude, double radius, GeoUnit geoUnit, GeoOrder geoOrder, int count);
+
+    /**
+     * Finds the members of a sorted set, which are within the 
+     * borders of the area specified with the defined member location
+     * and the maximum distance from the defined member location (the radius) 
+     * in <code>GeoUnit</code> units. 
+     * Store result to current Geo.
+     * 
+     * @param member - object
+     * @param radius - radius in geo units
+     * @param geoUnit - geo unit
+     * @return length of result
+     */
+    int radiusStore(String fromKey, V member, double radius, GeoUnit geoUnit);
+
+    /**
+     * Finds the members of a sorted set, which are within the 
+     * borders of the area specified with the defined member location
+     * and the maximum distance from the defined member location (the radius) 
+     * in <code>GeoUnit</code> units and limited by count
+     * Store result to current Geo.
+     * 
+     * @param member - object
+     * @param radius - radius in geo units
+     * @param geoUnit - geo unit
+     * @param count - result limit
+     * @return length of result
+     */
+    int radiusStore(String fromKey, V member, double radius, GeoUnit geoUnit, int count);
+
+    /**
+     * Finds the members of a sorted set, which are within the 
+     * borders of the area specified with the defined member location 
+     * and the maximum distance from the defined member location (the radius) 
+     * in <code>GeoUnit</code> units with <code>GeoOrder</code> 
+     * Store result to current Geo.
+     * 
+     * @param member - object
+     * @param radius - radius in geo units
+     * @param geoUnit - geo unit
+     * @param geoOrder - geo order
+     * @param count - result limit
+     * @return length of result
+     */
+    int radiusStore(String fromKey, V member, double radius, GeoUnit geoUnit, GeoOrder geoOrder, int count);
+
 }

--- a/redisson/src/main/java/org/redisson/api/RGeo.java
+++ b/redisson/src/main/java/org/redisson/api/RGeo.java
@@ -450,25 +450,25 @@ public interface RGeo<V> extends RScoredSortedSet<V>, RGeoAsync<V> {
      * borders of the area specified with the center location 
      * and the maximum distance from the center (the radius) 
      * in <code>GeoUnit</code> units. 
-     * Store result to current Geo.
+     * Store result to <code>destName</code>.
      * 
-     * @param fromKey - source Geo key
+     * @param destName - Geo object destination
      * @param longitude - longitude of object
      * @param latitude - latitude of object
      * @param radius - radius in geo units
      * @param geoUnit - geo unit
      * @return length of result
      */
-    int radiusStore(String fromKey, double longitude, double latitude, double radius, GeoUnit geoUnit);
+    int radiusStoreTo(String destName, double longitude, double latitude, double radius, GeoUnit geoUnit);
 
     /**
      * Finds the members of a sorted set, which are within the 
      * borders of the area specified with the center location 
      * and the maximum distance from the center (the radius) 
      * in <code>GeoUnit</code> units and limited by count 
-     * Store result to current Geo.
+     * Store result to <code>destName</code>.
      * 
-     * @param fromKey - source Geo key
+     * @param destName - Geo object destination
      * @param longitude - longitude of object
      * @param latitude - latitude of object
      * @param radius - radius in geo units
@@ -476,7 +476,7 @@ public interface RGeo<V> extends RScoredSortedSet<V>, RGeoAsync<V> {
      * @param count - result limit
      * @return length of result
      */
-    int radiusStore(String fromKey, double longitude, double latitude, double radius, GeoUnit geoUnit, int count);
+    int radiusStoreTo(String destName, double longitude, double latitude, double radius, GeoUnit geoUnit, int count);
 
     /**
      * Finds the members of a sorted set, which are within the 
@@ -484,9 +484,9 @@ public interface RGeo<V> extends RScoredSortedSet<V>, RGeoAsync<V> {
      * and the maximum distance from the center (the radius) 
      * in <code>GeoUnit</code> units with <code>GeoOrder</code> 
      * and limited by count 
-     * Store result to current Geo.
+     * Store result to <code>destName</code>.
      * 
-     * @param fromKey - source Geo key
+     * @param destName - Geo object destination
      * @param longitude - longitude of object
      * @param latitude - latitude of object
      * @param radius - radius in geo units
@@ -495,47 +495,47 @@ public interface RGeo<V> extends RScoredSortedSet<V>, RGeoAsync<V> {
      * @param count - result limit
      * @return length of result
      */
-    int radiusStore(String fromKey, double longitude, double latitude, double radius, GeoUnit geoUnit, GeoOrder geoOrder, int count);
+    int radiusStoreTo(String destName, double longitude, double latitude, double radius, GeoUnit geoUnit, GeoOrder geoOrder, int count);
 
     /**
      * Finds the members of a sorted set, which are within the 
      * borders of the area specified with the defined member location
      * and the maximum distance from the defined member location (the radius) 
      * in <code>GeoUnit</code> units. 
-     * Store result to current Geo.
+     * Store result to <code>destName</code>.
      * 
-     * @param fromKey - source Geo key
+     * @param destName - Geo object destination
      * @param member - object
      * @param radius - radius in geo units
      * @param geoUnit - geo unit
      * @return length of result
      */
-    int radiusStore(String fromKey, V member, double radius, GeoUnit geoUnit);
+    int radiusStoreTo(String destName, V member, double radius, GeoUnit geoUnit);
 
     /**
      * Finds the members of a sorted set, which are within the 
      * borders of the area specified with the defined member location
      * and the maximum distance from the defined member location (the radius) 
      * in <code>GeoUnit</code> units and limited by count
-     * Store result to current Geo.
+     * Store result to <code>destName</code>.
      * 
-     * @param fromKey - source Geo key
+     * @param destName - Geo object destination
      * @param member - object
      * @param radius - radius in geo units
      * @param geoUnit - geo unit
      * @param count - result limit
      * @return length of result
      */
-    int radiusStore(String fromKey, V member, double radius, GeoUnit geoUnit, int count);
+    int radiusStoreTo(String destName, V member, double radius, GeoUnit geoUnit, int count);
 
     /**
      * Finds the members of a sorted set, which are within the 
      * borders of the area specified with the defined member location 
      * and the maximum distance from the defined member location (the radius) 
      * in <code>GeoUnit</code> units with <code>GeoOrder</code> 
-     * Store result to current Geo.
+     * Store result to <code>destName</code>.
      * 
-     * @param fromKey - source Geo key
+     * @param destName - Geo object destination
      * @param member - object
      * @param radius - radius in geo units
      * @param geoUnit - geo unit
@@ -543,6 +543,6 @@ public interface RGeo<V> extends RScoredSortedSet<V>, RGeoAsync<V> {
      * @param count - result limit
      * @return length of result
      */
-    int radiusStore(String fromKey, V member, double radius, GeoUnit geoUnit, GeoOrder geoOrder, int count);
+    int radiusStoreTo(String destName, V member, double radius, GeoUnit geoUnit, GeoOrder geoOrder, int count);
 
 }

--- a/redisson/src/main/java/org/redisson/api/RGeo.java
+++ b/redisson/src/main/java/org/redisson/api/RGeo.java
@@ -452,6 +452,7 @@ public interface RGeo<V> extends RScoredSortedSet<V>, RGeoAsync<V> {
      * in <code>GeoUnit</code> units. 
      * Store result to current Geo.
      * 
+     * @param fromKey - source Geo key
      * @param longitude - longitude of object
      * @param latitude - latitude of object
      * @param radius - radius in geo units
@@ -467,6 +468,7 @@ public interface RGeo<V> extends RScoredSortedSet<V>, RGeoAsync<V> {
      * in <code>GeoUnit</code> units and limited by count 
      * Store result to current Geo.
      * 
+     * @param fromKey - source Geo key
      * @param longitude - longitude of object
      * @param latitude - latitude of object
      * @param radius - radius in geo units
@@ -484,6 +486,7 @@ public interface RGeo<V> extends RScoredSortedSet<V>, RGeoAsync<V> {
      * and limited by count 
      * Store result to current Geo.
      * 
+     * @param fromKey - source Geo key
      * @param longitude - longitude of object
      * @param latitude - latitude of object
      * @param radius - radius in geo units
@@ -501,6 +504,7 @@ public interface RGeo<V> extends RScoredSortedSet<V>, RGeoAsync<V> {
      * in <code>GeoUnit</code> units. 
      * Store result to current Geo.
      * 
+     * @param fromKey - source Geo key
      * @param member - object
      * @param radius - radius in geo units
      * @param geoUnit - geo unit
@@ -515,6 +519,7 @@ public interface RGeo<V> extends RScoredSortedSet<V>, RGeoAsync<V> {
      * in <code>GeoUnit</code> units and limited by count
      * Store result to current Geo.
      * 
+     * @param fromKey - source Geo key
      * @param member - object
      * @param radius - radius in geo units
      * @param geoUnit - geo unit
@@ -530,6 +535,7 @@ public interface RGeo<V> extends RScoredSortedSet<V>, RGeoAsync<V> {
      * in <code>GeoUnit</code> units with <code>GeoOrder</code> 
      * Store result to current Geo.
      * 
+     * @param fromKey - source Geo key
      * @param member - object
      * @param radius - radius in geo units
      * @param geoUnit - geo unit

--- a/redisson/src/main/java/org/redisson/api/RGeoAsync.java
+++ b/redisson/src/main/java/org/redisson/api/RGeoAsync.java
@@ -442,5 +442,99 @@ public interface RGeoAsync<V> extends RScoredSortedSetAsync<V> {
      * @return geo position mapped by object
      */
     RFuture<Map<V, GeoPosition>> radiusWithPositionAsync(V member, double radius, GeoUnit geoUnit, GeoOrder geoOrder, int count);
-    
+
+    /**
+     * Finds the members of a sorted set, which are within the 
+     * borders of the area specified with the center location 
+     * and the maximum distance from the center (the radius) 
+     * in <code>GeoUnit</code> units. 
+     * Store result to current Geo.
+     * 
+     * @param longitude - longitude of object
+     * @param latitude - latitude of object
+     * @param radius - radius in geo units
+     * @param geoUnit - geo unit
+     * @return length of result
+     */
+    RFuture<Integer> radiusStoreAsync(String fromKey, double longitude, double latitude, double radius, GeoUnit geoUnit);
+
+    /**
+     * Finds the members of a sorted set, which are within the 
+     * borders of the area specified with the center location 
+     * and the maximum distance from the center (the radius) 
+     * in <code>GeoUnit</code> units and limited by count 
+     * Store result to current Geo.
+     * 
+     * @param longitude - longitude of object
+     * @param latitude - latitude of object
+     * @param radius - radius in geo units
+     * @param geoUnit - geo unit
+     * @param count - result limit
+     * @return length of result
+     */
+    RFuture<Integer> radiusStoreAsync(String fromKey, double longitude, double latitude, double radius, GeoUnit geoUnit, int count);
+
+    /**
+     * Finds the members of a sorted set, which are within the 
+     * borders of the area specified with the center location 
+     * and the maximum distance from the center (the radius) 
+     * in <code>GeoUnit</code> units with <code>GeoOrder</code> 
+     * and limited by count 
+     * Store result to current Geo.
+     * 
+     * @param longitude - longitude of object
+     * @param latitude - latitude of object
+     * @param radius - radius in geo units
+     * @param geoUnit - geo unit
+     * @param geoOrder - order of result
+     * @param count - result limit
+     * @return length of result
+     */
+    RFuture<Integer> radiusStoreAsync(String fromKey, double longitude, double latitude, double radius, GeoUnit geoUnit, GeoOrder geoOrder, int count);
+
+    /**
+     * Finds the members of a sorted set, which are within the 
+     * borders of the area specified with the defined member location
+     * and the maximum distance from the defined member location (the radius) 
+     * in <code>GeoUnit</code> units. 
+     * Store result to current Geo.
+     * 
+     * @param member - object
+     * @param radius - radius in geo units
+     * @param geoUnit - geo unit
+     * @return length of result
+     */
+    RFuture<Integer> radiusStoreAsync(String fromKey, V member, double radius, GeoUnit geoUnit);
+
+    /**
+     * Finds the members of a sorted set, which are within the 
+     * borders of the area specified with the defined member location
+     * and the maximum distance from the defined member location (the radius) 
+     * in <code>GeoUnit</code> units and limited by count
+     * Store result to current Geo.
+     * 
+     * @param member - object
+     * @param radius - radius in geo units
+     * @param geoUnit - geo unit
+     * @param count - result limit
+     * @return length of result
+     */
+    RFuture<Integer> radiusStoreAsync(String fromKey, V member, double radius, GeoUnit geoUnit, int count);
+
+    /**
+     * Finds the members of a sorted set, which are within the 
+     * borders of the area specified with the defined member location 
+     * and the maximum distance from the defined member location (the radius) 
+     * in <code>GeoUnit</code> units with <code>GeoOrder</code> 
+     * Store result to current Geo.
+     * 
+     * @param member - object
+     * @param radius - radius in geo units
+     * @param geoUnit - geo unit
+     * @param geoOrder - geo order
+     * @param count - result limit
+     * @return length of result
+     */
+    RFuture<Integer> radiusStoreAsync(String fromKey, V member, double radius, GeoUnit geoUnit, GeoOrder geoOrder, int count);
+
 }

--- a/redisson/src/main/java/org/redisson/api/RGeoAsync.java
+++ b/redisson/src/main/java/org/redisson/api/RGeoAsync.java
@@ -448,25 +448,25 @@ public interface RGeoAsync<V> extends RScoredSortedSetAsync<V> {
      * borders of the area specified with the center location 
      * and the maximum distance from the center (the radius) 
      * in <code>GeoUnit</code> units. 
-     * Store result to current Geo.
+     * Store result to <code>destName</code>.
      * 
-     * @param fromKey - source Geo key
+     * @param destName - Geo object destination
      * @param longitude - longitude of object
      * @param latitude - latitude of object
      * @param radius - radius in geo units
      * @param geoUnit - geo unit
      * @return length of result
      */
-    RFuture<Integer> radiusStoreAsync(String fromKey, double longitude, double latitude, double radius, GeoUnit geoUnit);
+    RFuture<Integer> radiusStoreToAsync(String destName, double longitude, double latitude, double radius, GeoUnit geoUnit);
 
     /**
      * Finds the members of a sorted set, which are within the 
      * borders of the area specified with the center location 
      * and the maximum distance from the center (the radius) 
      * in <code>GeoUnit</code> units and limited by count 
-     * Store result to current Geo.
+     * Store result to <code>destName</code>.
      * 
-     * @param fromKey - source Geo key
+     * @param destName - Geo object destination
      * @param longitude - longitude of object
      * @param latitude - latitude of object
      * @param radius - radius in geo units
@@ -474,7 +474,7 @@ public interface RGeoAsync<V> extends RScoredSortedSetAsync<V> {
      * @param count - result limit
      * @return length of result
      */
-    RFuture<Integer> radiusStoreAsync(String fromKey, double longitude, double latitude, double radius, GeoUnit geoUnit, int count);
+    RFuture<Integer> radiusStoreToAsync(String destName, double longitude, double latitude, double radius, GeoUnit geoUnit, int count);
 
     /**
      * Finds the members of a sorted set, which are within the 
@@ -482,9 +482,9 @@ public interface RGeoAsync<V> extends RScoredSortedSetAsync<V> {
      * and the maximum distance from the center (the radius) 
      * in <code>GeoUnit</code> units with <code>GeoOrder</code> 
      * and limited by count 
-     * Store result to current Geo.
+     * Store result to <code>destName</code>.
      * 
-     * @param fromKey - source Geo key
+     * @param destName - Geo object destination
      * @param longitude - longitude of object
      * @param latitude - latitude of object
      * @param radius - radius in geo units
@@ -493,47 +493,47 @@ public interface RGeoAsync<V> extends RScoredSortedSetAsync<V> {
      * @param count - result limit
      * @return length of result
      */
-    RFuture<Integer> radiusStoreAsync(String fromKey, double longitude, double latitude, double radius, GeoUnit geoUnit, GeoOrder geoOrder, int count);
+    RFuture<Integer> radiusStoreToAsync(String destName, double longitude, double latitude, double radius, GeoUnit geoUnit, GeoOrder geoOrder, int count);
 
     /**
      * Finds the members of a sorted set, which are within the 
      * borders of the area specified with the defined member location
      * and the maximum distance from the defined member location (the radius) 
      * in <code>GeoUnit</code> units. 
-     * Store result to current Geo.
+     * Store result to <code>destName</code>.
      * 
-     * @param fromKey - source Geo key
+     * @param destName - Geo object destination
      * @param member - object
      * @param radius - radius in geo units
      * @param geoUnit - geo unit
      * @return length of result
      */
-    RFuture<Integer> radiusStoreAsync(String fromKey, V member, double radius, GeoUnit geoUnit);
+    RFuture<Integer> radiusStoreToAsync(String destName, V member, double radius, GeoUnit geoUnit);
 
     /**
      * Finds the members of a sorted set, which are within the 
      * borders of the area specified with the defined member location
      * and the maximum distance from the defined member location (the radius) 
      * in <code>GeoUnit</code> units and limited by count
-     * Store result to current Geo.
+     * Store result to <code>destName</code>.
      * 
-     * @param fromKey - source Geo key
+     * @param destName - Geo object destination
      * @param member - object
      * @param radius - radius in geo units
      * @param geoUnit - geo unit
      * @param count - result limit
      * @return length of result
      */
-    RFuture<Integer> radiusStoreAsync(String fromKey, V member, double radius, GeoUnit geoUnit, int count);
+    RFuture<Integer> radiusStoreToAsync(String destName, V member, double radius, GeoUnit geoUnit, int count);
 
     /**
      * Finds the members of a sorted set, which are within the 
      * borders of the area specified with the defined member location 
      * and the maximum distance from the defined member location (the radius) 
      * in <code>GeoUnit</code> units with <code>GeoOrder</code> 
-     * Store result to current Geo.
+     * Store result to <code>destName</code>.
      * 
-     * @param fromKey - source Geo key
+     * @param destName - Geo object destination
      * @param member - object
      * @param radius - radius in geo units
      * @param geoUnit - geo unit
@@ -541,6 +541,6 @@ public interface RGeoAsync<V> extends RScoredSortedSetAsync<V> {
      * @param count - result limit
      * @return length of result
      */
-    RFuture<Integer> radiusStoreAsync(String fromKey, V member, double radius, GeoUnit geoUnit, GeoOrder geoOrder, int count);
+    RFuture<Integer> radiusStoreToAsync(String destName, V member, double radius, GeoUnit geoUnit, GeoOrder geoOrder, int count);
 
 }

--- a/redisson/src/main/java/org/redisson/api/RGeoAsync.java
+++ b/redisson/src/main/java/org/redisson/api/RGeoAsync.java
@@ -450,6 +450,7 @@ public interface RGeoAsync<V> extends RScoredSortedSetAsync<V> {
      * in <code>GeoUnit</code> units. 
      * Store result to current Geo.
      * 
+     * @param fromKey - source Geo key
      * @param longitude - longitude of object
      * @param latitude - latitude of object
      * @param radius - radius in geo units
@@ -465,6 +466,7 @@ public interface RGeoAsync<V> extends RScoredSortedSetAsync<V> {
      * in <code>GeoUnit</code> units and limited by count 
      * Store result to current Geo.
      * 
+     * @param fromKey - source Geo key
      * @param longitude - longitude of object
      * @param latitude - latitude of object
      * @param radius - radius in geo units
@@ -482,6 +484,7 @@ public interface RGeoAsync<V> extends RScoredSortedSetAsync<V> {
      * and limited by count 
      * Store result to current Geo.
      * 
+     * @param fromKey - source Geo key
      * @param longitude - longitude of object
      * @param latitude - latitude of object
      * @param radius - radius in geo units
@@ -499,6 +502,7 @@ public interface RGeoAsync<V> extends RScoredSortedSetAsync<V> {
      * in <code>GeoUnit</code> units. 
      * Store result to current Geo.
      * 
+     * @param fromKey - source Geo key
      * @param member - object
      * @param radius - radius in geo units
      * @param geoUnit - geo unit
@@ -513,6 +517,7 @@ public interface RGeoAsync<V> extends RScoredSortedSetAsync<V> {
      * in <code>GeoUnit</code> units and limited by count
      * Store result to current Geo.
      * 
+     * @param fromKey - source Geo key
      * @param member - object
      * @param radius - radius in geo units
      * @param geoUnit - geo unit
@@ -528,6 +533,7 @@ public interface RGeoAsync<V> extends RScoredSortedSetAsync<V> {
      * in <code>GeoUnit</code> units with <code>GeoOrder</code> 
      * Store result to current Geo.
      * 
+     * @param fromKey - source Geo key
      * @param member - object
      * @param radius - radius in geo units
      * @param geoUnit - geo unit

--- a/redisson/src/main/java/org/redisson/client/protocol/RedisCommands.java
+++ b/redisson/src/main/java/org/redisson/client/protocol/RedisCommands.java
@@ -76,6 +76,8 @@ public interface RedisCommands {
     RedisCommand<Double> GEODIST = new RedisCommand<Double>("GEODIST", new DoubleReplayConvertor(), 2, Arrays.asList(ValueType.OBJECT, ValueType.OBJECT, ValueType.STRING));
     RedisCommand<List<Object>> GEORADIUS = new RedisCommand<List<Object>>("GEORADIUS", new ObjectListReplayDecoder<Object>());
     RedisCommand<List<Object>> GEORADIUSBYMEMBER = new RedisCommand<List<Object>>("GEORADIUSBYMEMBER", new ObjectListReplayDecoder<Object>(), 2);
+    RedisCommand<Integer> GEORADIUS_STORE_INT = new RedisStrictCommand<Integer>("GEORADIUS", new IntegerReplayConvertor());
+    RedisCommand<Integer> GEORADIUSBYMEMBER_STORE_INT = new RedisStrictCommand<Integer>("GEORADIUSBYMEMBER", new IntegerReplayConvertor(), 2);
     
     RedisStrictCommand<Integer> KEYSLOT = new RedisStrictCommand<Integer>("CLUSTER", "KEYSLOT", new IntegerReplayConvertor());
     RedisStrictCommand<RType> TYPE = new RedisStrictCommand<RType>("TYPE", new TypeConvertor());

--- a/redisson/src/main/java/org/redisson/client/protocol/RedisCommands.java
+++ b/redisson/src/main/java/org/redisson/client/protocol/RedisCommands.java
@@ -76,8 +76,8 @@ public interface RedisCommands {
     RedisCommand<Double> GEODIST = new RedisCommand<Double>("GEODIST", new DoubleReplayConvertor(), 2, Arrays.asList(ValueType.OBJECT, ValueType.OBJECT, ValueType.STRING));
     RedisCommand<List<Object>> GEORADIUS = new RedisCommand<List<Object>>("GEORADIUS", new ObjectListReplayDecoder<Object>());
     RedisCommand<List<Object>> GEORADIUSBYMEMBER = new RedisCommand<List<Object>>("GEORADIUSBYMEMBER", new ObjectListReplayDecoder<Object>(), 2);
-    RedisCommand<Integer> GEORADIUS_STORE_INT = new RedisStrictCommand<Integer>("GEORADIUS", new IntegerReplayConvertor());
-    RedisCommand<Integer> GEORADIUSBYMEMBER_STORE_INT = new RedisStrictCommand<Integer>("GEORADIUSBYMEMBER", new IntegerReplayConvertor(), 2);
+    RedisStrictCommand<Integer> GEORADIUS_STORE_INT = new RedisStrictCommand<Integer>("GEORADIUS", new IntegerReplayConvertor());
+    RedisStrictCommand<Integer> GEORADIUSBYMEMBER_STORE_INT = new RedisStrictCommand<Integer>("GEORADIUSBYMEMBER", new IntegerReplayConvertor(), 2);
     
     RedisStrictCommand<Integer> KEYSLOT = new RedisStrictCommand<Integer>("CLUSTER", "KEYSLOT", new IntegerReplayConvertor());
     RedisStrictCommand<RType> TYPE = new RedisStrictCommand<RType>("TYPE", new TypeConvertor());

--- a/redisson/src/test/java/org/redisson/RedissonGeoTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonGeoTest.java
@@ -482,7 +482,7 @@ public class RedissonGeoTest extends BaseTest {
         RGeo<String> geoDest = redisson.getGeo("test-store");
         geoSource.add(new GeoEntry(13.361389, 38.115556, "Palermo"), new GeoEntry(15.087269, 37.502669, "Catania"));
 
-        assertThat(geoDest.radiusStore(geoSource.getName(), 15, 37, 200, GeoUnit.KILOMETERS)).isEqualTo(2);
+        assertThat(geoSource.radiusStoreTo(geoDest.getName(), 15, 37, 200, GeoUnit.KILOMETERS)).isEqualTo(2);
         assertThat(geoDest.readAll()).containsExactlyInAnyOrder("Palermo", "Catania");
     }
 
@@ -492,7 +492,7 @@ public class RedissonGeoTest extends BaseTest {
         RGeo<String> geoDest = redisson.getGeo("test-store");
         geoSource.add(new GeoEntry(13.361389, 38.115556, "Palermo"), new GeoEntry(15.087269, 37.502669, "Catania"));
 
-        assertThat(geoDest.radiusStore(geoSource.getName(), 15, 37, 200, GeoUnit.KILOMETERS, 1)).isEqualTo(1);
+        assertThat(geoSource.radiusStoreTo(geoDest.getName(), 15, 37, 200, GeoUnit.KILOMETERS, 1)).isEqualTo(1);
         assertThat(geoDest.readAll()).containsExactly("Catania");
     }
 
@@ -502,10 +502,10 @@ public class RedissonGeoTest extends BaseTest {
         RGeo<String> geoDest = redisson.getGeo("test-store");
         geoSource.add(new GeoEntry(13.361389, 38.115556, "Palermo"), new GeoEntry(15.087269, 37.502669, "Catania"));
 
-        assertThat(geoDest.radiusStore(geoSource.getName(), 15, 37, 200, GeoUnit.KILOMETERS, GeoOrder.DESC, 1)).isEqualTo(1);
+        assertThat(geoSource.radiusStoreTo(geoDest.getName(), 15, 37, 200, GeoUnit.KILOMETERS, GeoOrder.DESC, 1)).isEqualTo(1);
         assertThat(geoDest.readAll()).containsExactly("Palermo");
 
-        assertThat(geoDest.radiusStore(geoSource.getName(), 15, 37, 200, GeoUnit.KILOMETERS, GeoOrder.ASC, 1)).isEqualTo(1);
+        assertThat(geoSource.radiusStoreTo(geoDest.getName(), 15, 37, 200, GeoUnit.KILOMETERS, GeoOrder.ASC, 1)).isEqualTo(1);
         assertThat(geoDest.readAll()).containsExactly("Catania");
     }
 
@@ -514,7 +514,7 @@ public class RedissonGeoTest extends BaseTest {
         RGeo<String> geoSource = redisson.getGeo("test");
         RGeo<String> geoDest = redisson.getGeo("test-store");
 
-        assertThat(geoDest.radiusStore(geoSource.getName(), 15, 37, 200, GeoUnit.KILOMETERS)).isEqualTo(0);
+        assertThat(geoSource.radiusStoreTo(geoDest.getName(), 15, 37, 200, GeoUnit.KILOMETERS)).isEqualTo(0);
         assertThat(geoDest.readAll()).isEmpty();
     }
 
@@ -524,7 +524,7 @@ public class RedissonGeoTest extends BaseTest {
         RGeo<String> geoDest = redisson.getGeo("test-store");
         geoSource.add(new GeoEntry(13.361389, 38.115556, "Palermo"), new GeoEntry(15.087269, 37.502669, "Catania"));
 
-        assertThat(geoDest.radiusStore(geoSource.getName(), "Palermo", 200, GeoUnit.KILOMETERS)).isEqualTo(2);
+        assertThat(geoSource.radiusStoreTo(geoDest.getName(), "Palermo", 200, GeoUnit.KILOMETERS)).isEqualTo(2);
         assertThat(geoDest.readAll()).containsExactlyInAnyOrder("Palermo", "Catania");
     }
 
@@ -534,7 +534,7 @@ public class RedissonGeoTest extends BaseTest {
         RGeo<String> geoDest = redisson.getGeo("test-store");
         geoSource.add(new GeoEntry(13.361389, 38.115556, "Palermo"), new GeoEntry(15.087269, 37.502669, "Catania"));
 
-        assertThat(geoDest.radiusStore(geoSource.getName(), "Palermo", 200, GeoUnit.KILOMETERS, 1)).isEqualTo(1);
+        assertThat(geoSource.radiusStoreTo(geoDest.getName(), "Palermo", 200, GeoUnit.KILOMETERS, 1)).isEqualTo(1);
         assertThat(geoDest.readAll()).containsExactly("Palermo");
     }
 
@@ -544,10 +544,10 @@ public class RedissonGeoTest extends BaseTest {
         RGeo<String> geoDest = redisson.getGeo("test-store");
         geoSource.add(new GeoEntry(13.361389, 38.115556, "Palermo"), new GeoEntry(15.087269, 37.502669, "Catania"));
 
-        assertThat(geoDest.radiusStore(geoSource.getName(), "Palermo", 200, GeoUnit.KILOMETERS, GeoOrder.DESC, 1)).isEqualTo(1);
+        assertThat(geoSource.radiusStoreTo(geoDest.getName(), "Palermo", 200, GeoUnit.KILOMETERS, GeoOrder.DESC, 1)).isEqualTo(1);
         assertThat(geoDest.readAll()).containsExactly("Catania");
 
-        assertThat(geoDest.radiusStore(geoSource.getName(), "Palermo", 200, GeoUnit.KILOMETERS, GeoOrder.ASC, 1)).isEqualTo(1);
+        assertThat(geoSource.radiusStoreTo(geoDest.getName(), "Palermo", 200, GeoUnit.KILOMETERS, GeoOrder.ASC, 1)).isEqualTo(1);
         assertThat(geoDest.readAll()).containsExactly("Palermo");
     }
 
@@ -556,7 +556,7 @@ public class RedissonGeoTest extends BaseTest {
         RGeo<String> geoSource = redisson.getGeo("test");
         RGeo<String> geoDest = redisson.getGeo("test-store");
 
-        assertThat(geoDest.radiusStore(geoSource.getName(), "Palermo", 200, GeoUnit.KILOMETERS)).isEqualTo(0);
+        assertThat(geoSource.radiusStoreTo(geoDest.getName(), "Palermo", 200, GeoUnit.KILOMETERS)).isEqualTo(0);
         assertThat(geoDest.readAll()).isEmpty();
     }
 

--- a/redisson/src/test/java/org/redisson/RedissonGeoTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonGeoTest.java
@@ -476,4 +476,88 @@ public class RedissonGeoTest extends BaseTest {
         assertThat(geo.radiusWithPosition("Palermo", 200, GeoUnit.KILOMETERS)).isEmpty();
     }
 
+    @Test
+    public void testRadiusStore() {
+        RGeo<String> geoSource = redisson.getGeo("test");
+        RGeo<String> geoDest = redisson.getGeo("test-store");
+        geoSource.add(new GeoEntry(13.361389, 38.115556, "Palermo"), new GeoEntry(15.087269, 37.502669, "Catania"));
+
+        assertThat(geoDest.radiusStore(geoSource.getName(), 15, 37, 200, GeoUnit.KILOMETERS)).isEqualTo(2);
+        assertThat(geoDest.readAll()).containsExactlyInAnyOrder("Palermo", "Catania");
+    }
+
+    @Test
+    public void testRadiusStoreCount() {
+        RGeo<String> geoSource = redisson.getGeo("test");
+        RGeo<String> geoDest = redisson.getGeo("test-store");
+        geoSource.add(new GeoEntry(13.361389, 38.115556, "Palermo"), new GeoEntry(15.087269, 37.502669, "Catania"));
+
+        assertThat(geoDest.radiusStore(geoSource.getName(), 15, 37, 200, GeoUnit.KILOMETERS, 1)).isEqualTo(1);
+        assertThat(geoDest.readAll()).containsExactly("Catania");
+    }
+
+    @Test
+    public void testRadiusStoreOrderCount() {
+        RGeo<String> geoSource = redisson.getGeo("test");
+        RGeo<String> geoDest = redisson.getGeo("test-store");
+        geoSource.add(new GeoEntry(13.361389, 38.115556, "Palermo"), new GeoEntry(15.087269, 37.502669, "Catania"));
+
+        assertThat(geoDest.radiusStore(geoSource.getName(), 15, 37, 200, GeoUnit.KILOMETERS, GeoOrder.DESC, 1)).isEqualTo(1);
+        assertThat(geoDest.readAll()).containsExactly("Palermo");
+
+        assertThat(geoDest.radiusStore(geoSource.getName(), 15, 37, 200, GeoUnit.KILOMETERS, GeoOrder.ASC, 1)).isEqualTo(1);
+        assertThat(geoDest.readAll()).containsExactly("Catania");
+    }
+
+    @Test
+    public void testRadiusStoreEmpty() {
+        RGeo<String> geoSource = redisson.getGeo("test");
+        RGeo<String> geoDest = redisson.getGeo("test-store");
+
+        assertThat(geoDest.radiusStore(geoSource.getName(), 15, 37, 200, GeoUnit.KILOMETERS)).isEqualTo(0);
+        assertThat(geoDest.readAll()).isEmpty();
+    }
+
+    @Test
+    public void testRadiusStoreMember() {
+        RGeo<String> geoSource = redisson.getGeo("test");
+        RGeo<String> geoDest = redisson.getGeo("test-store");
+        geoSource.add(new GeoEntry(13.361389, 38.115556, "Palermo"), new GeoEntry(15.087269, 37.502669, "Catania"));
+
+        assertThat(geoDest.radiusStore(geoSource.getName(), "Palermo", 200, GeoUnit.KILOMETERS)).isEqualTo(2);
+        assertThat(geoDest.readAll()).containsExactlyInAnyOrder("Palermo", "Catania");
+    }
+
+    @Test
+    public void testRadiusStoreMemberCount() {
+        RGeo<String> geoSource = redisson.getGeo("test");
+        RGeo<String> geoDest = redisson.getGeo("test-store");
+        geoSource.add(new GeoEntry(13.361389, 38.115556, "Palermo"), new GeoEntry(15.087269, 37.502669, "Catania"));
+
+        assertThat(geoDest.radiusStore(geoSource.getName(), "Palermo", 200, GeoUnit.KILOMETERS, 1)).isEqualTo(1);
+        assertThat(geoDest.readAll()).containsExactly("Palermo");
+    }
+
+    @Test
+    public void testRadiusStoreMemberOrderCount() {
+        RGeo<String> geoSource = redisson.getGeo("test");
+        RGeo<String> geoDest = redisson.getGeo("test-store");
+        geoSource.add(new GeoEntry(13.361389, 38.115556, "Palermo"), new GeoEntry(15.087269, 37.502669, "Catania"));
+
+        assertThat(geoDest.radiusStore(geoSource.getName(), "Palermo", 200, GeoUnit.KILOMETERS, GeoOrder.DESC, 1)).isEqualTo(1);
+        assertThat(geoDest.readAll()).containsExactly("Catania");
+
+        assertThat(geoDest.radiusStore(geoSource.getName(), "Palermo", 200, GeoUnit.KILOMETERS, GeoOrder.ASC, 1)).isEqualTo(1);
+        assertThat(geoDest.readAll()).containsExactly("Palermo");
+    }
+
+    @Test
+    public void testRadiusStoreMemberEmpty() {
+        RGeo<String> geoSource = redisson.getGeo("test");
+        RGeo<String> geoDest = redisson.getGeo("test-store");
+
+        assertThat(geoDest.radiusStore(geoSource.getName(), "Palermo", 200, GeoUnit.KILOMETERS)).isEqualTo(0);
+        assertThat(geoDest.readAll()).isEmpty();
+    }
+
 }

--- a/redisson/src/test/java/org/redisson/RedissonScoredSortedSetTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonScoredSortedSetTest.java
@@ -975,6 +975,22 @@ public class RedissonScoredSortedSetTest extends BaseTest {
     }
     
     @Test
+    public void testIntersectionEmpty() {
+        RScoredSortedSet<String> set1 = redisson.getScoredSortedSet("simple1");
+        set1.add(1, "one");
+        set1.add(2, "two");
+
+        RScoredSortedSet<String> set2 = redisson.getScoredSortedSet("simple2");
+        set2.add(3, "three");
+        set2.add(4, "four");
+
+        RScoredSortedSet<String> out = redisson.getScoredSortedSet("out");
+        assertThat(out.intersection(set1.getName(), set2.getName())).isEqualTo(0);
+
+        assertThat(out.readAll()).isEmpty();
+    }
+
+    @Test
     public void testIntersectionWithWeight() {
         RScoredSortedSet<String> set1 = redisson.getScoredSortedSet("simple1");
         set1.add(1, "one");


### PR DESCRIPTION
See issue #855

This code mostly works, but there is a strange issue with empty results. When the result is empty (no members within this radius), the query times out instead of returning 0. I might have misused the Command or Codec?

Hopefully someone more familiar with Redisson internals can help.

Failed Tests:
```
1. RedissonGeoTest.testRadiusStoreMemberEmpty
    org.redisson.client.RedisTimeoutException: Redis server response timeout (3000 ms) occured for command: (GEORADIUSBYMEMBER) with params: [test, Palermo, 200.0, km, STORE, test-store]
        at org.redisson.command.CommandAsyncService$10.run(CommandAsyncService.java:646)
    ...

2. RedissonGeoTest.testRadiusStoreEmpty
    org.redisson.client.RedisTimeoutException: Redis server response timeout (3000 ms) occured for command: (GEORADIUS) with params: [test, 15.0, 37.0, 200.0, km, STORE, test-store]
        at org.redisson.command.CommandAsyncService$10.run(CommandAsyncService.java:646)
    ...
```