### PR TITLE
Decouple max size from Redis server

### DIFF
--- a/redisson/src/main/java/org/redisson/Redisson.java
+++ b/redisson/src/main/java/org/redisson/Redisson.java
@@ -317,6 +317,11 @@ public class Redisson implements RedissonClient {
     }
 
     @Override
+    public <K, V> RMapCache<K, V> getMapCache(String name, int maxSize, MapOptions<K, V> options) {
+        return new RedissonMapCache<K, V>(evictionScheduler, connectionManager.getCommandExecutor(), name, this, maxSize, options);
+    }
+
+    @Override
     public <K, V> RMapCache<K, V> getMapCache(String name, MapOptions<K, V> options) {
         return new RedissonMapCache<K, V>(evictionScheduler, connectionManager.getCommandExecutor(), name, this, options);
     }
@@ -328,6 +333,11 @@ public class Redisson implements RedissonClient {
     
     @Override
     public <K, V> RMapCache<K, V> getMapCache(String name, Codec codec, MapOptions<K, V> options) {
+        return new RedissonMapCache<K, V>(codec, evictionScheduler, connectionManager.getCommandExecutor(), name, this, options);
+    }
+
+    @Override
+    public <K, V> RMapCache<K, V> getMapCache(String name, Codec codec, int maxSize, MapOptions<K, V> options) {
         return new RedissonMapCache<K, V>(codec, evictionScheduler, connectionManager.getCommandExecutor(), name, this, options);
     }
 

--- a/redisson/src/main/java/org/redisson/RedissonMapCache.java
+++ b/redisson/src/main/java/org/redisson/RedissonMapCache.java
@@ -86,26 +86,26 @@ public class RedissonMapCache<K, V> extends RedissonMap<K, V> implements RMapCac
 
     public RedissonMapCache(EvictionScheduler evictionScheduler, CommandAsyncExecutor commandExecutor,
                             String name, RedissonClient redisson, MapOptions<K, V> options) {
-        super(commandExecutor, name, redisson, options);
-        evictionScheduler.schedule(getName(), getTimeoutSetName(), getIdleSetName(), getExpiredChannelName());
+        this(evictionScheduler, commandExecutor, name, redisson, 0, options);
+    }
 
-        if (options != null) {
-            this.maxSize = options.getMaxSize();
-        } else {
-            this.maxSize = 0;
-        }
+    public RedissonMapCache(EvictionScheduler evictionScheduler, CommandAsyncExecutor commandExecutor,
+                            String name, RedissonClient redisson, int maxSize, MapOptions<K, V> options) {
+        super(commandExecutor, name, redisson, options);
+        this.maxSize = maxSize;
+        evictionScheduler.schedule(getName(), getTimeoutSetName(), getIdleSetName(), getExpiredChannelName());
     }
 
     public RedissonMapCache(Codec codec, EvictionScheduler evictionScheduler, CommandAsyncExecutor commandExecutor,
                             String name, RedissonClient redisson, MapOptions<K, V> options) {
-        super(codec, commandExecutor, name, redisson, options);
-        evictionScheduler.schedule(getName(), getTimeoutSetName(), getIdleSetName(), getExpiredChannelName());
+        this(codec, evictionScheduler, commandExecutor, name, redisson, 0, options);
+    }
 
-        if (options != null) {
-            this.maxSize = options.getMaxSize();
-        } else {
-            this.maxSize = 0;
-        }
+    public RedissonMapCache(Codec codec, EvictionScheduler evictionScheduler, CommandAsyncExecutor commandExecutor,
+                            String name, RedissonClient redisson, int maxSize, MapOptions<K, V> options) {
+        super(codec, commandExecutor, name, redisson, options);
+        this.maxSize = maxSize;
+        evictionScheduler.schedule(getName(), getTimeoutSetName(), getIdleSetName(), getExpiredChannelName());
     }
 
     @Override

--- a/redisson/src/main/java/org/redisson/api/MapOptions.java
+++ b/redisson/src/main/java/org/redisson/api/MapOptions.java
@@ -49,8 +49,7 @@ public class MapOptions<K, V> {
     private MapWriter<K, V> writer;
     private WriteMode writeMode = WriteMode.WRITE_THROUGH;
     private int writeBehindThreads = 1;
-    private int maxSize = 0;
-    
+
     protected MapOptions() {
     }
     
@@ -134,21 +133,5 @@ public class MapOptions<K, V> {
     }
     public MapLoader<K, V> getLoader() {
         return loader;
-    }
-
-    /**
-     * Sets max size of the map.
-     * <p>
-     * Currently only RedissonMapCache is supported.
-     *
-     * @param maxSize - max size
-     * @return MapOptions instance
-     */
-    public MapOptions<K, V> maxSize(int maxSize) {
-        this.maxSize = maxSize;
-        return this;
-    }
-    public int getMaxSize() {
-        return maxSize;
     }
 }

--- a/redisson/src/main/java/org/redisson/api/MapOptions.java
+++ b/redisson/src/main/java/org/redisson/api/MapOptions.java
@@ -49,6 +49,7 @@ public class MapOptions<K, V> {
     private MapWriter<K, V> writer;
     private WriteMode writeMode = WriteMode.WRITE_THROUGH;
     private int writeBehindThreads = 1;
+    private int maxSize = 0;
     
     protected MapOptions() {
     }
@@ -135,4 +136,19 @@ public class MapOptions<K, V> {
         return loader;
     }
 
+    /**
+     * Sets max size of the map.
+     * <p>
+     * Currently only RedissonMapCache is supported.
+     *
+     * @param maxSize - max size
+     * @return MapOptions instance
+     */
+    public MapOptions<K, V> maxSize(int maxSize) {
+        this.maxSize = maxSize;
+        return this;
+    }
+    public int getMaxSize() {
+        return maxSize;
+    }
 }

--- a/redisson/src/main/java/org/redisson/api/RMapCache.java
+++ b/redisson/src/main/java/org/redisson/api/RMapCache.java
@@ -40,14 +40,6 @@ import org.redisson.api.map.event.MapEntryListener;
 public interface RMapCache<K, V> extends RMap<K, V>, RMapCacheAsync<K, V> {
 
     /**
-     * Tries to set max size of the map.
-     *
-     * @param maxSize - max size
-     * @return <code>true</code> if max size has been successfully set, otherwise <code>false</code>.
-     */
-    boolean trySetMaxSize(int maxSize);
-    
-    /**
      * If the specified key is not already associated
      * with a value, associate it with the given value.
      * <p>

--- a/redisson/src/main/java/org/redisson/api/RMapCacheAsync.java
+++ b/redisson/src/main/java/org/redisson/api/RMapCacheAsync.java
@@ -38,14 +38,6 @@ import java.util.concurrent.TimeUnit;
 public interface RMapCacheAsync<K, V> extends RMapAsync<K, V> {
 
     /**
-     * Tries to set max size of the map.
-     *
-     * @param maxSize - max size
-     * @return <code>true</code> if max size has been successfully set, otherwise <code>false</code>.
-     */
-    RFuture<Boolean> trySetMaxSizeAsync(int maxSize);
-    
-    /**
      * If the specified key is not already associated
      * with a value, associate it with the given value.
      * <p>

--- a/redisson/src/main/java/org/redisson/api/RedissonClient.java
+++ b/redisson/src/main/java/org/redisson/api/RedissonClient.java
@@ -98,6 +98,23 @@ public interface RedissonClient {
      * @return MapCache object
      */
     <K, V> RMapCache<K, V> getMapCache(String name, Codec codec);
+
+    /**
+     * Returns map-based cache instance by <code>name</code>
+     * using provided <code>codec</code> for both cache keys and values.
+     * Supports entry eviction with a given MaxIdleTime and TTL settings.
+     * <p>
+     * If eviction is not required then it's better to use regular map {@link #getMap(String, Codec)}.
+     *
+     * @param <K> type of key
+     * @param <V> type of value
+     * @param name - object name
+     * @param codec - codec for keys and values
+     * @param maxSize - map max size in Redis
+     * @param options - map options
+     * @return MapCache object
+     */
+    <K, V> RMapCache<K, V> getMapCache(String name, Codec codec, int maxSize, MapOptions<K, V> options);
     
     /**
      * Returns map-based cache instance by <code>name</code>
@@ -127,6 +144,21 @@ public interface RedissonClient {
      * @return MapCache object
      */
     <K, V> RMapCache<K, V> getMapCache(String name);
+
+    /**
+     * Returns map-based cache instance by name.
+     * Supports entry eviction with a given MaxIdleTime and TTL settings.
+     * <p>
+     * If eviction is not required then it's better to use regular map {@link #getMap(String)}.</p>
+     *
+     * @param <K> type of key
+     * @param <V> type of value
+     * @param name - name of object
+     * @param maxSize - map max size in Redis
+     * @param options - map options
+     * @return MapCache object
+     */
+    <K, V> RMapCache<K, V> getMapCache(String name, int maxSize, MapOptions<K, V> options);
     
     /**
      * Returns map-based cache instance by name.

--- a/redisson/src/test/java/org/redisson/RedissonMapCacheTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonMapCacheTest.java
@@ -217,7 +217,7 @@ public class RedissonMapCacheTest extends BaseMapTest {
     }
 
     @Test
-    public void testFastPutMaxSize() {
+    public void testMaxSize() {
         final int maxSize = 2;
         Map<String, String> store = new LinkedHashMap<String, String>() {
             @Override
@@ -225,13 +225,15 @@ public class RedissonMapCacheTest extends BaseMapTest {
                 return size() > maxSize;
             }
         };
-        MapOptions<String, String> options = MapOptions.<String, String>defaults().writer(createMapWriter(store));
-        options.maxSize(maxSize);
-        RMapCache<String, String> map = redisson.getMapCache("test", options);
+        RMapCache<String, String> map = redisson.getMapCache("test", maxSize, null);
 
-        map.fastPut("1", "11", 10, TimeUnit.SECONDS);
-        map.fastPut("2", "22", 10, TimeUnit.SECONDS);
-        map.fastPut("3", "33", 10, TimeUnit.SECONDS);
+        assertThat(map.fastPutIfAbsent("01", "00")).isTrue();
+        assertThat(map.fastPutIfAbsent("02", "00")).isTrue();
+        assertThat(map.put("03", "00")).isNull();
+        assertThat(map.fastPutIfAbsent("04", "00", 10, TimeUnit.SECONDS)).isTrue();
+        assertThat(map.fastPut("1", "11", 10, TimeUnit.SECONDS)).isTrue();
+        assertThat(map.fastPut("2", "22", 10, TimeUnit.SECONDS)).isTrue();
+        assertThat(map.fastPut("3", "33", 10, TimeUnit.SECONDS)).isTrue();
 
         assertThat(map.size()).isEqualTo(maxSize);
 
@@ -239,6 +241,20 @@ public class RedissonMapCacheTest extends BaseMapTest {
         expected.put("2", "22");
         expected.put("3", "33");
         assertThat(store).isEqualTo(expected);
+
+        assertThat(map.get("2")).isEqualTo("22");
+        assertThat(map.get("0")).isNull();
+        assertThat(map.putIfAbsent("2", "3")).isEqualTo("22");
+        assertThat(map.putIfAbsent("3", "4", 10, TimeUnit.SECONDS, 10, TimeUnit.SECONDS)).isEqualTo("33");
+        assertThat(map.containsKey("2")).isTrue();
+        assertThat(map.containsKey("0")).isFalse();
+        assertThat(map.containsValue("22")).isTrue();
+        assertThat(map.containsValue("00")).isFalse();
+        assertThat(map.getAll(new HashSet<String>(Arrays.asList("2", "3")))).isEqualTo(expected);
+        assertThat(map.remove("2", "33")).isFalse();
+        assertThat(map.remove("2", "22")).isTrue();
+        assertThat(map.remove("0")).isNull();
+        assertThat(map.remove("3")).isEqualTo("33");
     }
     
     @Test

--- a/redisson/src/test/java/org/redisson/RedissonMapCacheTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonMapCacheTest.java
@@ -217,7 +217,7 @@ public class RedissonMapCacheTest extends BaseMapTest {
     }
 
     @Test
-    public void testMaxSize() {
+    public void testFastPutMaxSize() {
         final int maxSize = 2;
         Map<String, String> store = new LinkedHashMap<String, String>() {
             @Override
@@ -226,16 +226,12 @@ public class RedissonMapCacheTest extends BaseMapTest {
             }
         };
         MapOptions<String, String> options = MapOptions.<String, String>defaults().writer(createMapWriter(store));
+        options.maxSize(maxSize);
         RMapCache<String, String> map = redisson.getMapCache("test", options);
-        map.trySetMaxSize(maxSize);
 
-        assertThat(map.fastPutIfAbsent("01", "00")).isTrue();
-        assertThat(map.fastPutIfAbsent("02", "00")).isTrue();
-        assertThat(map.put("03", "00")).isNull();
-        assertThat(map.fastPutIfAbsent("04", "00", 10, TimeUnit.SECONDS)).isTrue();
-        assertThat(map.fastPut("1", "11", 10, TimeUnit.SECONDS)).isTrue();
-        assertThat(map.fastPut("2", "22", 10, TimeUnit.SECONDS)).isTrue();
-        assertThat(map.fastPut("3", "33", 10, TimeUnit.SECONDS)).isTrue();
+        map.fastPut("1", "11", 10, TimeUnit.SECONDS);
+        map.fastPut("2", "22", 10, TimeUnit.SECONDS);
+        map.fastPut("3", "33", 10, TimeUnit.SECONDS);
 
         assertThat(map.size()).isEqualTo(maxSize);
 
@@ -243,20 +239,6 @@ public class RedissonMapCacheTest extends BaseMapTest {
         expected.put("2", "22");
         expected.put("3", "33");
         assertThat(store).isEqualTo(expected);
-        
-        assertThat(map.get("2")).isEqualTo("22");
-        assertThat(map.get("0")).isNull();
-        assertThat(map.putIfAbsent("2", "3")).isEqualTo("22");
-        assertThat(map.putIfAbsent("3", "4", 10, TimeUnit.SECONDS, 10, TimeUnit.SECONDS)).isEqualTo("33");
-        assertThat(map.containsKey("2")).isTrue();
-        assertThat(map.containsKey("0")).isFalse();
-        assertThat(map.containsValue("22")).isTrue();
-        assertThat(map.containsValue("00")).isFalse();
-        assertThat(map.getAll(new HashSet<String>(Arrays.asList("2", "3")))).isEqualTo(expected);
-        assertThat(map.remove("2", "33")).isFalse();
-        assertThat(map.remove("2", "22")).isTrue();
-        assertThat(map.remove("0")).isNull();
-        assertThat(map.remove("3")).isEqualTo("33");
     }
     
     @Test
@@ -1261,4 +1243,3 @@ public class RedissonMapCacheTest extends BaseMapTest {
 
     }
 }
-


### PR DESCRIPTION
While I agree MapOptions was not the correct place for the maxSize configuration I feel coupling it to the Redis server could result in undetermined behaviour of the cache if the key is deleted, please consider the revised implementation with maxSize being added to the "factory" methods.