### PR TITLE
Allow LiveObjectService to work with classes that inherit from REntities

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonReference.java
+++ b/redisson/src/main/java/org/redisson/RedissonReference.java
@@ -20,6 +20,7 @@ import org.redisson.client.codec.Codec;
 import org.redisson.api.RObject;
 import org.redisson.api.RObjectReactive;
 import org.redisson.api.annotation.REntity;
+import org.redisson.liveobject.misc.ClassUtils;
 import org.redisson.misc.BiHashMap;
 import org.redisson.reactive.RedissonAtomicLongReactive;
 import org.redisson.reactive.RedissonBitSetReactive;
@@ -77,7 +78,7 @@ public class RedissonReference implements Serializable {
     }
 
     public RedissonReference(Class type, String keyName, Codec codec) {
-        if (!type.isAnnotationPresent(REntity.class) && !RObject.class.isAssignableFrom(type) && !RObjectReactive.class.isAssignableFrom(type)) {
+        if (!ClassUtils.isAnnotationPresent(type, REntity.class) && !RObject.class.isAssignableFrom(type) && !RObjectReactive.class.isAssignableFrom(type)) {
             throw new IllegalArgumentException("Class reference has to be a type of either RObject or RLiveObject or RObjectReactive");
         }
         this.type = RObjectReactive.class.isAssignableFrom(type)
@@ -130,7 +131,7 @@ public class RedissonReference implements Serializable {
      * @param type the type to set
      */
     public void setType(Class<?> type) {
-        if (!type.isAnnotationPresent(REntity.class) && (!RObject.class.isAssignableFrom(type) || !RObjectReactive.class.isAssignableFrom(type))) {
+        if (!ClassUtils.isAnnotationPresent(type, REntity.class) && (!RObject.class.isAssignableFrom(type) || !RObjectReactive.class.isAssignableFrom(type))) {
             throw new IllegalArgumentException("Class reference has to be a type of either RObject or RLiveObject or RObjectReactive");
         }
         this.type = type.getName();

--- a/redisson/src/main/java/org/redisson/codec/DefaultCodecProvider.java
+++ b/redisson/src/main/java/org/redisson/codec/DefaultCodecProvider.java
@@ -21,6 +21,7 @@ import org.redisson.client.codec.Codec;
 import org.redisson.api.RObject;
 import org.redisson.api.annotation.REntity;
 import org.redisson.api.annotation.RObjectField;
+import org.redisson.liveobject.misc.ClassUtils;
 
 /**
  *
@@ -44,7 +45,7 @@ public class DefaultCodecProvider implements CodecProvider {
 
     @Override
     public <T extends Codec> T getCodec(REntity anno, Class<?> cls) {
-        if (!cls.isAnnotationPresent(anno.annotationType())) {
+        if (!ClassUtils.isAnnotationPresent(cls, anno.annotationType())) {
             throw new IllegalArgumentException("Annotation REntity does not present on type [" + cls.getCanonicalName() + "]");
         }
         return this.<T>getCodec((Class<T>) anno.codec());
@@ -53,7 +54,7 @@ public class DefaultCodecProvider implements CodecProvider {
     @Override
     public <T extends Codec, K extends RObject> T getCodec(RObjectField anno, Class<?> cls, Class<K> rObjectClass, String fieldName) {
         try {
-            if (!cls.getField(fieldName).isAnnotationPresent(anno.getClass())) {
+            if (!ClassUtils.getDeclaredField(cls, fieldName).isAnnotationPresent(anno.getClass())) {
                 throw new IllegalArgumentException("Annotation RObjectField does not present on field " + fieldName + " of type [" + cls.getCanonicalName() + "]");
             }
         } catch (Exception ex) {

--- a/redisson/src/main/java/org/redisson/liveobject/core/LiveObjectInterceptor.java
+++ b/redisson/src/main/java/org/redisson/liveobject/core/LiveObjectInterceptor.java
@@ -30,6 +30,7 @@ import org.redisson.api.RMap;
 import org.redisson.api.RedissonClient;
 import org.redisson.api.annotation.REntity;
 import org.redisson.codec.CodecProvider;
+import org.redisson.liveobject.misc.ClassUtils;
 import org.redisson.liveobject.resolver.NamingScheme;
 
 /**
@@ -61,11 +62,11 @@ public class LiveObjectInterceptor {
         this.codecProvider = codecProvider;
         this.originalClass = entityClass;
         this.idFieldName = idFieldName;
-        REntity anno = (REntity) entityClass.getAnnotation(REntity.class);
+        REntity anno = (REntity) ClassUtils.getAnnotation(entityClass, REntity.class);
         this.codecClass = anno.codec();
         try {
             this.namingScheme = anno.namingScheme().getDeclaredConstructor(Codec.class).newInstance(codecProvider.getCodec(anno, originalClass));
-            this.idFieldType = originalClass.getDeclaredField(idFieldName).getType();
+            this.idFieldType = ClassUtils.getDeclaredField(originalClass, idFieldName).getType();
         } catch (Exception e) {
             throw new IllegalArgumentException(e);
         }

--- a/redisson/src/main/java/org/redisson/liveobject/core/RedissonObjectBuilder.java
+++ b/redisson/src/main/java/org/redisson/liveobject/core/RedissonObjectBuilder.java
@@ -44,6 +44,7 @@ import org.redisson.api.annotation.REntity;
 import org.redisson.api.annotation.RObjectField;
 import org.redisson.client.codec.Codec;
 import org.redisson.codec.CodecProvider;
+import org.redisson.liveobject.misc.ClassUtils;
 import org.redisson.liveobject.resolver.NamingScheme;
 import org.redisson.misc.RedissonObjectFactory;
 
@@ -116,12 +117,12 @@ public class RedissonObjectBuilder {
      * WARNING: rEntity has to be the class of @This object.
      */
     private Codec getFieldCodec(Class<?> rEntity, Class<? extends RObject> rObjectClass, String fieldName) throws Exception {
-        Field field = rEntity.getDeclaredField(fieldName);
+        Field field = ClassUtils.getDeclaredField(rEntity, fieldName);
         if (field.isAnnotationPresent(RObjectField.class)) {
             RObjectField anno = field.getAnnotation(RObjectField.class);
             return codecProvider.getCodec(anno, rEntity, rObjectClass, fieldName);
         } else {
-            REntity anno = rEntity.getAnnotation(REntity.class);
+            REntity anno = ClassUtils.getAnnotation(rEntity, REntity.class);
             return codecProvider.getCodec(anno, (Class<?>) rEntity);
         }
     }
@@ -131,7 +132,7 @@ public class RedissonObjectBuilder {
      */
     private NamingScheme getFieldNamingScheme(Class<?> rEntity, String fieldName, Codec c) throws Exception {
         if (!namingSchemeCache.containsKey(fieldName)) {
-            REntity anno = rEntity.getAnnotation(REntity.class);
+            REntity anno = ClassUtils.getAnnotation(rEntity, REntity.class);
             namingSchemeCache.putIfAbsent(fieldName, anno.namingScheme()
                     .getDeclaredConstructor(Codec.class)
                     .newInstance(c));

--- a/redisson/src/main/java/org/redisson/liveobject/misc/Introspectior.java
+++ b/redisson/src/main/java/org/redisson/liveobject/misc/Introspectior.java
@@ -16,6 +16,11 @@
 package org.redisson.liveobject.misc;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import net.bytebuddy.description.field.FieldDescription;
 import net.bytebuddy.description.field.FieldList;
 import net.bytebuddy.description.method.MethodDescription;
@@ -59,8 +64,15 @@ public class Introspectior {
     }
 
     public static FieldList<FieldDescription.InDefinedShape> getFieldsWithAnnotation(Class<?> c, Class<? extends Annotation> a) {
-        return getTypeDescription(c)
-                .getDeclaredFields()
+        return getAllFields(c)
                 .filter(ElementMatchers.isAnnotatedWith(a));
+    }
+
+    public static FieldList<FieldDescription.InDefinedShape> getAllFields(Class<?> cls) {
+        List<Field> fields = new ArrayList<>();
+        for (Class<?> c = cls; c != null; c = c.getSuperclass()) {
+            Collections.addAll(fields, c.getDeclaredFields());
+        }
+        return new FieldList.ForLoadedFields(fields);
     }
 }

--- a/redisson/src/test/java/org/redisson/RedissonLiveObjectServiceTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonLiveObjectServiceTest.java
@@ -1129,11 +1129,9 @@ public class RedissonLiveObjectServiceTest extends BaseTest {
 
         SimpleObject s = new SimpleObject();
         s = service.persist(s);
-        
         so.setSo(s);
         assertThat(s.getId()).isNotNull();
         so.getObjects().add(s);
-        
         so = redisson.getLiveObjectService().detach(so);
         assertThat(so.getSo().getId()).isEqualTo(s.getId());
         assertThat(so.getObjects().get(0).getId()).isEqualTo(so.getSo().getId());
@@ -1462,5 +1460,158 @@ public class RedissonLiveObjectServiceTest extends BaseTest {
         sg = redisson.getLiveObjectService().persist(sg);
         assertThat(sg.getName()).isEqualTo("1234");
     }
+
+    @REntity
+    public static class Animal {
+
+        @RId(generator = LongGenerator.class)
+        private Long id;
+
+        private String name;
+
+        protected Animal() {
+        }
+
+        public Animal(String name) {
+            super();
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+    }
+
+    public static class Dog extends Animal {
+        private String breed;
+
+        public Dog(String name) {
+            super(name);
+        }
+
+        protected Dog() {
+        }
+
+        public void setBreed(String breed) {
+            this.breed = breed;
+        }
+
+        public String getBreed() {
+            return breed;
+        }
+    }
+
+    @Test
+    public void testInheritedREntity() {
+        Dog d = new Dog("Fido");
+        d.setBreed("lab");
+
+        d = redisson.getLiveObjectService().persist(d);
+
+        assertThat(d.getName()).isEqualTo("Fido");
+        assertThat(d.getBreed()).isEqualTo("lab");
+    }
+
+    @Test
+    public void testMapOfInheritedEntity() {
+        RMap<String, Dog> dogs = redisson.getMap("dogs");
+        Dog d = new Dog("Fido");
+        d = redisson.getLiveObjectService().persist(d);
+        d.setBreed("lab");
+        dogs.put("key", d);
+        dogs = redisson.getMap("dogs");
+        assertThat(dogs.size()).isEqualTo(1);
+        assertThat(dogs.get("key").getBreed()).isEqualTo("lab");
+    }
+
+    public static class MyCustomer extends Customer {
+
+        @RCascade(RCascadeType.ALL)
+        private List<Order> specialOrders = new ArrayList<>();
+
+        public MyCustomer() {
+        }
+
+        public MyCustomer(String id) {
+            super(id);
+        }
+
+        public void addSpecialOrder(Order order) {
+            getSpecialOrders().add(order);
+        }
+
+        public void setSpecialOrders(List<Order> orders) {
+            this.specialOrders = orders;
+        }
+
+        public List<Order> getSpecialOrders() {
+            return specialOrders;
+        }
+    }
     
+    @Test
+    public void testCyclicRefsWithInheritedREntity() {
+        MyCustomer customer = new MyCustomer("12");
+        customer = redisson.getLiveObjectService().persist(customer);
+        Order order = new Order();
+        order = redisson.getLiveObjectService().persist(order);
+        order.setCustomer(customer);
+        customer.getOrders().add(order);
+        Order special = new Order();
+        special = redisson.getLiveObjectService().persist(special);
+        order.setCustomer(customer);
+        customer.addSpecialOrder(special);
+
+        customer = redisson.getLiveObjectService().detach(customer);
+        assertThat(customer.getClass()).isSameAs(MyCustomer.class);
+        assertThat(customer.getId()).isNotNull();
+        List<Order> orders = customer.getOrders();
+        assertThat(orders.get(0)).isNotNull();
+        List<Order> specials = customer.getSpecialOrders();
+        assertThat(specials.get(0)).isNotNull();
+
+        customer = redisson.getLiveObjectService().get(MyCustomer.class, customer.getId());
+        assertThat(customer.getId()).isNotNull();
+        assertThat(customer.getOrders().get(0)).isNotNull();
+        assertThat(customer.getSpecialOrders().get(0)).isNotNull();
+    }
+
+    public static class MyObjectWithList extends ObjectWithList {
+        protected MyObjectWithList() {
+            super();
+        }
+
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    @Test
+    public void testStoreInnerObjectWithInheritedREntity() {
+        RLiveObjectService service = redisson.getLiveObjectService();
+        MyObjectWithList so = new MyObjectWithList();
+        so = service.persist(so);
+
+        SimpleObject s = new SimpleObject();
+        s = service.persist(s);
+
+        so.setSo(s);
+        assertThat(s.getId()).isNotNull();
+        so.getObjects().add(s);
+        so.setName("name");
+
+        so = redisson.getLiveObjectService().detach(so);
+        assertThat(so.getSo().getId()).isEqualTo(s.getId());
+        assertThat(so.getObjects().get(0).getId()).isEqualTo(so.getSo().getId());
+        assertThat(so.getName()).isEqualTo("name");
+    }
+
+
 }


### PR DESCRIPTION
Addresses issue #930 

I hope I caught all the relevant usages of `@REntity` and `@RId`. See the additional test `RedissonLiveObjectServiceTest.testInheritedREntity()` to see an example.