### PR TITLE
Bugfix: accessor methods in Live Objects break if they start with 'is'

### DIFF
--- a/redisson/src/main/java/org/redisson/liveobject/core/AccessorInterceptor.java
+++ b/redisson/src/main/java/org/redisson/liveobject/core/AccessorInterceptor.java
@@ -148,7 +148,9 @@ public class AccessorInterceptor {
     }
 
     private String getFieldName(Method method) {
-        return method.getName().substring(3, 4).toLowerCase() + method.getName().substring(4);
+        String name = method.getName();
+        int i = name.startsWith("is") ? 3 : 4;
+        return name.substring(i - 1, i).toLowerCase() + name.substring(i);
     }
 
     private boolean isGetter(Method method, String fieldName) {

--- a/redisson/src/test/java/org/redisson/RedissonLiveObjectServiceTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonLiveObjectServiceTest.java
@@ -1613,5 +1613,28 @@ public class RedissonLiveObjectServiceTest extends BaseTest {
         assertThat(so.getName()).isEqualTo("name");
     }
 
+    @REntity
+    public static class HasIsAccessor {
+        @RId(generator = LongGenerator.class)
+        private Long id;
+
+        boolean good;
+
+        public boolean isGood() {
+            return good;
+        }
+
+        public void setGood(boolean good) {
+            this.good = good;
+        }
+    }
+
+    @Test
+    public void testIsAccessor() {
+        HasIsAccessor o = new HasIsAccessor();
+        o.setGood(true);
+        o = redisson.getLiveObjectService().persist(o);
+        assertThat(o.isGood()).isEqualTo(true);
+    }
 
 }


### PR DESCRIPTION
Objects cannot be detached from RedissonLiveObjectService if they have accessors in the `isBooleanValue()` style - this will cause an exception. This PR addresses that issue.