### PR TITLE
Try and AcquireConnection when entry is FreezeReason SYSTEM not only for MASTER

### DIFF
--- a/redisson/src/main/java/org/redisson/connection/pool/ConnectionPool.java
+++ b/redisson/src/main/java/org/redisson/connection/pool/ConnectionPool.java
@@ -198,8 +198,8 @@ abstract class ConnectionPool<T extends RedisConnection> {
     }
 
     public RFuture<T> get(RedisCommand<?> command, ClientConnectionsEntry entry) {
-        if (((entry.getNodeType() == NodeType.MASTER && entry.getFreezeReason() == FreezeReason.SYSTEM) || !entry.isFreezed())
-                && tryAcquireConnection(entry)) {
+        if ((!entry.isFreezed() || entry.getFreezeReason() == FreezeReason.SYSTEM) && 
+        		tryAcquireConnection(entry)) {
             return acquireConnection(command, entry);
         }
 


### PR DESCRIPTION
Following my issue: https://github.com/redisson/redisson/issues/1077

I think that the acquireConnection() should be call when a connexion is freezed with the reason entry.getFreezeReason() == FreezeReason.SYSTEM for MASTER and SLAVE too.

With this modification I have the good behavior in test mode: 1 master and 1 slave, 1 sentinel.

If I kill the slave, and then restart it, the slave come back in the pool and can be used for read-only operations.