### PR TITLE
Separate client construction into separate method

### DIFF
--- a/redisson-tomcat/redisson-tomcat-6/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-6/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -162,6 +162,12 @@ public class RedissonSessionManager extends ManagerBase implements Lifecycle {
     
     @Override
     public void start() throws LifecycleException {
+        redisson = buildClient();
+        
+        lifecycle.fireLifecycleEvent(START_EVENT, null);
+    }
+    
+    protected RedissonClient buildClient() throws LifecycleException {
         Config config = null;
         try {
             config = Config.fromJSON(new File(configPath), getClass().getClassLoader());
@@ -176,12 +182,10 @@ public class RedissonSessionManager extends ManagerBase implements Lifecycle {
         }
 
         try {
-            redisson = Redisson.create(config);
+            return Redisson.create(config);
         } catch (Exception e) {
             throw new LifecycleException(e);
         }
-        
-        lifecycle.fireLifecycleEvent(START_EVENT, null);
     }
 
     @Override

--- a/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -143,6 +143,13 @@ public class RedissonSessionManager extends ManagerBase {
     @Override
     protected void startInternal() throws LifecycleException {
         super.startInternal();
+        
+        redisson = buildClient();
+        
+        setState(LifecycleState.STARTING);
+    }
+    
+    protected RedissonClient buildClient() throws LifecycleException {
         Config config = null;
         try {
             config = Config.fromJSON(new File(configPath), getClass().getClassLoader());
@@ -166,12 +173,10 @@ public class RedissonSessionManager extends ManagerBase {
                 throw new IllegalStateException("Unable to initialize codec with ClassLoader parameter", e);
             }
             
-            redisson = Redisson.create(config);
+            return Redisson.create(config);
         } catch (Exception e) {
             throw new LifecycleException(e);
         }
-        
-        setState(LifecycleState.STARTING);
     }
 
     @Override

--- a/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -144,6 +144,12 @@ public class RedissonSessionManager extends ManagerBase {
     @Override
     protected void startInternal() throws LifecycleException {
         super.startInternal();
+        redisson = buildClient();
+
+        setState(LifecycleState.STARTING);
+    }
+
+    protected RedissonClient buildClient() throws LifecycleException {
         Config config = null;
         try {
             config = Config.fromJSON(new File(configPath), getClass().getClassLoader());
@@ -163,12 +169,10 @@ public class RedissonSessionManager extends ManagerBase {
                             .newInstance(Thread.currentThread().getContextClassLoader());
             config.setCodec(codec);
             
-            redisson = Redisson.create(config);
+            return Redisson.create(config);
         } catch (Exception e) {
             throw new LifecycleException(e);
         }
-        
-        setState(LifecycleState.STARTING);
     }
 
     @Override


### PR DESCRIPTION
This is to support child classes that can override the configuration behavior to do something different than just read a file. In our case we need to be able to programmatically configure the client so we can't rely on a static file somewhere.

I only changed the tomcat 8 session manager, but I would gladly change the older tomcat 6 & 7 managers to make them consistent if you want.

I could also submit a new manager extending this with the properties directly on the manager similar to https://github.com/chexagon/redis-session-manager.