### PR TITLE
Configurable Tomcat Session Key Prefix for Redis

### DIFF
--- a/redisson-tomcat/redisson-tomcat-6/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-6/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -54,7 +54,7 @@ public class RedissonSessionManager extends ManagerBase implements Lifecycle {
     private String configPath;
     private ReadMode readMode = ReadMode.MEMORY;
     private UpdateMode updateMode = UpdateMode.DEFAULT;
-    private String keySpace = "";
+    private String keyPrefix = "";
     
     public String getUpdateMode() {
         return updateMode.toString();
@@ -80,14 +80,14 @@ public class RedissonSessionManager extends ManagerBase implements Lifecycle {
         return configPath;
     }
 
-    public String getKeySpace() {
-        return this.keySpace;
+    public String getKeyPrefix() {
+        return keyPrefix;
     }
 
-    public void setKeySpace(String keySpace) {
-        this.keySpace = keySpace;
+    public void setKeyPrefix(String keyPrefix) {
+        this.keyPrefix = keyPrefix;
     }
-    
+
     @Override
     public int getRejectedSessions() {
         return 0;
@@ -140,7 +140,7 @@ public class RedissonSessionManager extends ManagerBase implements Lifecycle {
     }
 
     public RMap<String, Object> getMap(String sessionId) {
-        return redisson.getMap(keySpace + "redisson_tomcat_session:" + sessionId);
+        return redisson.getMap(keyPrefix + "redisson_tomcat_session:" + sessionId);
     }
     
     @Override

--- a/redisson-tomcat/redisson-tomcat-6/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-6/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -54,6 +54,7 @@ public class RedissonSessionManager extends ManagerBase implements Lifecycle {
     private String configPath;
     private ReadMode readMode = ReadMode.MEMORY;
     private UpdateMode updateMode = UpdateMode.DEFAULT;
+    private String keySpace = "";
     
     public String getUpdateMode() {
         return updateMode.toString();
@@ -77,6 +78,14 @@ public class RedissonSessionManager extends ManagerBase implements Lifecycle {
     
     public String getConfigPath() {
         return configPath;
+    }
+
+    public String getKeySpace() {
+        return this.keySpace;
+    }
+
+    public void setKeySpace(String keySpace) {
+        this.keySpace = keySpace;
     }
     
     @Override
@@ -131,7 +140,7 @@ public class RedissonSessionManager extends ManagerBase implements Lifecycle {
     }
 
     public RMap<String, Object> getMap(String sessionId) {
-        return redisson.getMap("redisson_tomcat_session:" + sessionId);
+        return redisson.getMap(keySpace + "redisson_tomcat_session:" + sessionId);
     }
     
     @Override

--- a/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -52,6 +52,8 @@ public class RedissonSessionManager extends ManagerBase {
     
     private ReadMode readMode = ReadMode.MEMORY;
     private UpdateMode updateMode = UpdateMode.DEFAULT;
+
+    private String keySpace = "";
     
     public String getUpdateMode() {
         return updateMode.toString();
@@ -75,6 +77,14 @@ public class RedissonSessionManager extends ManagerBase {
     
     public String getConfigPath() {
         return configPath;
+    }
+
+    public String getKeySpace() {
+        return this.keySpace;
+    }
+
+    public void setKeySpace(String keySpace) {
+        this.keySpace = keySpace;
     }
     
     @Override
@@ -110,7 +120,7 @@ public class RedissonSessionManager extends ManagerBase {
     }
 
     public RMap<String, Object> getMap(String sessionId) {
-        return redisson.getMap("redisson_tomcat_session:" + sessionId);
+        return redisson.getMap(keySpace + "redisson_tomcat_session:" + sessionId);
     }
     
     @Override

--- a/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -53,7 +53,7 @@ public class RedissonSessionManager extends ManagerBase {
     private ReadMode readMode = ReadMode.MEMORY;
     private UpdateMode updateMode = UpdateMode.DEFAULT;
 
-    private String keySpace = "";
+    private String keyPrefix = "";
     
     public String getUpdateMode() {
         return updateMode.toString();
@@ -79,14 +79,14 @@ public class RedissonSessionManager extends ManagerBase {
         return configPath;
     }
 
-    public String getKeySpace() {
-        return this.keySpace;
+    public String getKeyPrefix() {
+        return keyPrefix;
     }
 
-    public void setKeySpace(String keySpace) {
-        this.keySpace = keySpace;
+    public void setKeyPrefix(String keyPrefix) {
+        this.keyPrefix = keyPrefix;
     }
-    
+
     @Override
     public String getName() {
         return RedissonSessionManager.class.getSimpleName();
@@ -120,7 +120,7 @@ public class RedissonSessionManager extends ManagerBase {
     }
 
     public RMap<String, Object> getMap(String sessionId) {
-        return redisson.getMap(keySpace + "redisson_tomcat_session:" + sessionId);
+        return redisson.getMap(keyPrefix + "redisson_tomcat_session:" + sessionId);
     }
     
     @Override

--- a/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -52,7 +52,7 @@ public class RedissonSessionManager extends ManagerBase {
     private ReadMode readMode = ReadMode.MEMORY;
     private UpdateMode updateMode = UpdateMode.DEFAULT;
 
-    private String keySpace = "";
+    private String keyPrefix = "";
     
     public String getUpdateMode() {
         return updateMode.toString();
@@ -78,14 +78,14 @@ public class RedissonSessionManager extends ManagerBase {
         return configPath;
     }
 
-    public String getKeySpace() {
-        return this.keySpace;
+    public String getKeyPrefix() {
+        return keyPrefix;
     }
 
-    public void setKeySpace(String keySpace) {
-        this.keySpace = keySpace;
+    public void setKeyPrefix(String keyPrefix) {
+        this.keyPrefix = keyPrefix;
     }
-    
+
     @Override
     public String getName() {
         return RedissonSessionManager.class.getSimpleName();
@@ -119,7 +119,7 @@ public class RedissonSessionManager extends ManagerBase {
     }
 
     public RMap<String, Object> getMap(String sessionId) {
-        return redisson.getMap(keySpace + "redisson_tomcat_session:" + sessionId);
+        return redisson.getMap(keyPrefix + "redisson_tomcat_session:" + sessionId);
     }
     
     @Override

--- a/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -51,6 +51,8 @@ public class RedissonSessionManager extends ManagerBase {
     
     private ReadMode readMode = ReadMode.MEMORY;
     private UpdateMode updateMode = UpdateMode.DEFAULT;
+
+    private String keySpace = "";
     
     public String getUpdateMode() {
         return updateMode.toString();
@@ -74,6 +76,14 @@ public class RedissonSessionManager extends ManagerBase {
     
     public String getConfigPath() {
         return configPath;
+    }
+
+    public String getKeySpace() {
+        return this.keySpace;
+    }
+
+    public void setKeySpace(String keySpace) {
+        this.keySpace = keySpace;
     }
     
     @Override
@@ -109,7 +119,7 @@ public class RedissonSessionManager extends ManagerBase {
     }
 
     public RMap<String, Object> getMap(String sessionId) {
-        return redisson.getMap("redisson_tomcat_session:" + sessionId);
+        return redisson.getMap(keySpace + "redisson_tomcat_session:" + sessionId);
     }
     
     @Override

--- a/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -52,7 +52,7 @@ public class RedissonSessionManager extends ManagerBase {
     private ReadMode readMode = ReadMode.MEMORY;
     private UpdateMode updateMode = UpdateMode.DEFAULT;
 
-    private String keySpace = "";
+    private String keyPrefix = "";
     
     public String getUpdateMode() {
         return updateMode.toString();
@@ -78,14 +78,14 @@ public class RedissonSessionManager extends ManagerBase {
         return configPath;
     }
 
-    public String getKeySpace() {
-        return this.keySpace;
+    public String getKeyPrefix() {
+        return keyPrefix;
     }
 
-    public void setKeySpace(String keySpace) {
-        this.keySpace = keySpace;
+    public void setKeyPrefix(String keyPrefix) {
+        this.keyPrefix = keyPrefix;
     }
-    
+
     @Override
     public String getName() {
         return RedissonSessionManager.class.getSimpleName();
@@ -119,7 +119,7 @@ public class RedissonSessionManager extends ManagerBase {
     }
 
     public RMap<String, Object> getMap(String sessionId) {
-        return redisson.getMap(keySpace + "redisson_tomcat_session:" + sessionId);
+        return redisson.getMap(keyPrefix + "redisson_tomcat_session:" + sessionId);
     }
     
     @Override

--- a/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -51,6 +51,8 @@ public class RedissonSessionManager extends ManagerBase {
     
     private ReadMode readMode = ReadMode.MEMORY;
     private UpdateMode updateMode = UpdateMode.DEFAULT;
+
+    private String keySpace = "";
     
     public String getUpdateMode() {
         return updateMode.toString();
@@ -74,6 +76,14 @@ public class RedissonSessionManager extends ManagerBase {
     
     public String getConfigPath() {
         return configPath;
+    }
+
+    public String getKeySpace() {
+        return this.keySpace;
+    }
+
+    public void setKeySpace(String keySpace) {
+        this.keySpace = keySpace;
     }
     
     @Override
@@ -109,7 +119,7 @@ public class RedissonSessionManager extends ManagerBase {
     }
 
     public RMap<String, Object> getMap(String sessionId) {
-        return redisson.getMap("redisson_tomcat_session:" + sessionId);
+        return redisson.getMap(keySpace + "redisson_tomcat_session:" + sessionId);
     }
     
     @Override

--- a/redisson/src/main/java/org/redisson/RedissonLocalCachedMap.java
+++ b/redisson/src/main/java/org/redisson/RedissonLocalCachedMap.java
@@ -1190,7 +1190,7 @@ public class RedissonLocalCachedMap<K, V> extends RedissonMap<K, V> implements R
     }
 
     @Override
-    protected ByteBuf encode(Object value) {
+    public ByteBuf encode(Object value) {
         try {
             return topicCodec.getValueEncoder().encode(value);
         } catch (IOException e) {


### PR DESCRIPTION
Currently there is no way to customise tomcat session key for redis, which is always "redisson_tomcat_session:" + sessionId.

But in environment where multiple tomcat instances are using same redis cluster in it not possible to distinguish different tomcat instances.

In this pull request I have added configuration option for tomcat session key prefix, while configuring session manager use following configuration to customise tomcat session key prefix.

`<Manager className="org.redisson.tomcat.RedissonSessionManager" 
        configPath="${catalina.base}/redisson.conf" 
        readMode="MEMORY" updateMode="DEFAULT" keyPrefix="this_is_a_test_prefix"/>`

this will allow redisson to store tomcat session keys using following keys

`this_is_a_test_prefix:redisson_tomcat_session:E61653A9FEE61CB5D0967C2C40451363`