### PR TITLE
Fix tomcat session topic update for memory replication synchronization

### DIFF
--- a/redisson-tomcat/redisson-tomcat-6/src/main/java/org/redisson/tomcat/AttributeMessage.java
+++ b/redisson-tomcat/redisson-tomcat-6/src/main/java/org/redisson/tomcat/AttributeMessage.java
@@ -15,24 +15,35 @@
  */
 package org.redisson.tomcat;
 
+import java.io.Serializable;
+
 /**
- * 
  * @author Nikita Koksharov
- *
  */
-public class AttributeMessage {
+public class AttributeMessage implements Serializable {
 
     private String sessionId;
 
+    private String nodeId;
+
     public AttributeMessage() {
     }
-    
+
     public AttributeMessage(String sessionId) {
         this.sessionId = sessionId;
     }
-    
+
+    public AttributeMessage(String nodeId, String sessionId) {
+        this(sessionId);
+        this.nodeId = nodeId;
+    }
+
     public String getSessionId() {
         return sessionId;
     }
-    
+
+    public String getNodeId() {
+        return nodeId;
+    }
+
 }

--- a/redisson-tomcat/redisson-tomcat-6/src/main/java/org/redisson/tomcat/AttributeRemoveMessage.java
+++ b/redisson-tomcat/redisson-tomcat-6/src/main/java/org/redisson/tomcat/AttributeRemoveMessage.java
@@ -33,6 +33,11 @@ public class AttributeRemoveMessage extends AttributeMessage {
         this.name = name;
     }
 
+    public AttributeRemoveMessage(String nodeId,String sessionId, String name) {
+        super(nodeId,sessionId);
+        this.name = name;
+    }
+
     public String getName() {
         return name;
     }

--- a/redisson-tomcat/redisson-tomcat-6/src/main/java/org/redisson/tomcat/AttributeUpdateMessage.java
+++ b/redisson-tomcat/redisson-tomcat-6/src/main/java/org/redisson/tomcat/AttributeUpdateMessage.java
@@ -16,7 +16,7 @@
 package org.redisson.tomcat;
 
 /**
- * 
+ *
  * @author Nikita Koksharov
  *
  */
@@ -27,9 +27,15 @@ public class AttributeUpdateMessage extends AttributeMessage {
 
     public AttributeUpdateMessage() {
     }
-    
+
     public AttributeUpdateMessage(String sessionId, String name, Object value) {
         super(sessionId);
+        this.name = name;
+        this.value = value;
+    }
+
+    public AttributeUpdateMessage(String nodeId, String sessionId, String name, Object value) {
+        super(nodeId, sessionId);
         this.name = name;
         this.value = value;
     }
@@ -37,9 +43,9 @@ public class AttributeUpdateMessage extends AttributeMessage {
     public String getName() {
         return name;
     }
-    
+
     public Object getValue() {
         return value;
     }
-    
+
 }

--- a/redisson-tomcat/redisson-tomcat-6/src/main/java/org/redisson/tomcat/AttributesClearMessage.java
+++ b/redisson-tomcat/redisson-tomcat-6/src/main/java/org/redisson/tomcat/AttributesClearMessage.java
@@ -16,7 +16,7 @@
 package org.redisson.tomcat;
 
 /**
- * 
+ *
  * @author Nikita Koksharov
  *
  */
@@ -27,6 +27,10 @@ public class AttributesClearMessage extends AttributeMessage {
 
     public AttributesClearMessage(String sessionId) {
         super(sessionId);
+    }
+
+    public AttributesClearMessage(String nodeId, String sessionId) {
+        super(nodeId, sessionId);
     }
 
 }

--- a/redisson-tomcat/redisson-tomcat-6/src/main/java/org/redisson/tomcat/AttributesPutAllMessage.java
+++ b/redisson-tomcat/redisson-tomcat-6/src/main/java/org/redisson/tomcat/AttributesPutAllMessage.java
@@ -18,14 +18,14 @@ package org.redisson.tomcat;
 import java.util.Map;
 
 /**
- * 
+ *
  * @author Nikita Koksharov
  *
  */
 public class AttributesPutAllMessage extends AttributeMessage {
 
     private Map<String, Object> attrs;
-    
+
     public AttributesPutAllMessage() {
     }
 
@@ -33,7 +33,12 @@ public class AttributesPutAllMessage extends AttributeMessage {
         super(sessionId);
         this.attrs = attrs;
     }
-    
+
+    public AttributesPutAllMessage(String nodeId, String sessionId, Map<String, Object> attrs) {
+        super(nodeId, sessionId);
+        this.attrs = attrs;
+    }
+
     public Map<String, Object> getAttrs() {
         return attrs;
     }

--- a/redisson-tomcat/redisson-tomcat-6/src/main/java/org/redisson/tomcat/RedissonSession.java
+++ b/redisson-tomcat/redisson-tomcat-6/src/main/java/org/redisson/tomcat/RedissonSession.java
@@ -15,21 +15,21 @@
  */
 package org.redisson.tomcat;
 
-import java.lang.reflect.Field;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.concurrent.TimeUnit;
-
 import org.apache.catalina.session.StandardSession;
 import org.redisson.api.RMap;
 import org.redisson.api.RTopic;
 import org.redisson.tomcat.RedissonSessionManager.ReadMode;
 import org.redisson.tomcat.RedissonSessionManager.UpdateMode;
 
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
+
 /**
  * Redisson Session object for Apache Tomcat
- * 
+ *
  * @author Nikita Koksharov
  *
  */
@@ -39,15 +39,15 @@ public class RedissonSession extends StandardSession {
     private final Map<String, Object> attrs;
     private RMap<String, Object> map;
     private RTopic<AttributeMessage> topic;
-    private final RedissonSessionManager.ReadMode readMode;
+    private final ReadMode readMode;
     private final UpdateMode updateMode;
-    
+
     public RedissonSession(RedissonSessionManager manager, ReadMode readMode, UpdateMode updateMode) {
         super(manager);
         this.redissonManager = manager;
         this.readMode = readMode;
         this.updateMode = updateMode;
-        
+
         try {
             Field attr = StandardSession.class.getDeclaredField("attributes");
             attrs = (Map<String, Object>) attr.get(this);
@@ -66,22 +66,22 @@ public class RedissonSession extends StandardSession {
 
         return super.getAttribute(name);
     }
-    
+
     @Override
     public void setId(String id, boolean notify) {
         super.setId(id, notify);
         map = redissonManager.getMap(id);
         topic = redissonManager.getTopic();
     }
-    
+
     public void delete() {
         map.delete();
         if (readMode == ReadMode.MEMORY) {
-            topic.publish(new AttributesClearMessage(getId()));
+            topic.publish(new AttributesClearMessage(redissonManager.getNodeId(), getId()));
         }
         map = null;
     }
-    
+
     @Override
     public void setCreationTime(long time) {
         super.setCreationTime(time);
@@ -93,33 +93,33 @@ public class RedissonSession extends StandardSession {
             newMap.put("session:thisAccessedTime", thisAccessedTime);
             map.putAll(newMap);
             if (readMode == ReadMode.MEMORY) {
-                topic.publish(new AttributesPutAllMessage(getId(), newMap));
+                topic.publish(new AttributesPutAllMessage(redissonManager.getNodeId(), getId(), newMap));
             }
         }
     }
-    
+
     @Override
     public void access() {
         super.access();
-        
+
         if (map != null) {
             Map<String, Object> newMap = new HashMap<String, Object>(2);
             newMap.put("session:lastAccessedTime", lastAccessedTime);
             newMap.put("session:thisAccessedTime", thisAccessedTime);
             map.putAll(newMap);
             if (readMode == ReadMode.MEMORY) {
-                topic.publish(new AttributesPutAllMessage(getId(), newMap));
+                topic.publish(new AttributesPutAllMessage(redissonManager.getNodeId(), getId(), newMap));
             }
             if (getMaxInactiveInterval() >= 0) {
                 map.expire(getMaxInactiveInterval(), TimeUnit.SECONDS);
             }
         }
     }
-    
+
     @Override
     public void setMaxInactiveInterval(int interval) {
         super.setMaxInactiveInterval(interval);
-        
+
         if (map != null) {
             fastPut("session:maxInactiveInterval", maxInactiveInterval);
             if (maxInactiveInterval >= 0) {
@@ -127,18 +127,18 @@ public class RedissonSession extends StandardSession {
             }
         }
     }
-    
+
     private void fastPut(String name, Object value) {
         map.fastPut(name, value);
         if (readMode == ReadMode.MEMORY) {
-            topic.publish(new AttributeUpdateMessage(getId(), name, value));
+            topic.publish(new AttributeUpdateMessage(redissonManager.getNodeId(), getId(), name, value));
         }
     }
-    
+
     @Override
     public void setValid(boolean isValid) {
         super.setValid(isValid);
-        
+
         if (map != null) {
             if (!isValid && !map.isExists()) {
                 return;
@@ -147,16 +147,16 @@ public class RedissonSession extends StandardSession {
             fastPut("session:isValid", isValid);
         }
     }
-    
+
     @Override
     public void setNew(boolean isNew) {
         super.setNew(isNew);
-        
+
         if (map != null) {
             fastPut("session:isNew", isNew);
         }
     }
-    
+
     @Override
     public void endAccess() {
         boolean oldValue = isNew;
@@ -166,36 +166,36 @@ public class RedissonSession extends StandardSession {
             fastPut("session:isNew", isNew);
         }
     }
-    
+
     public void superSetAttribute(String name, Object value, boolean notify) {
         super.setAttribute(name, value, notify);
     }
-    
+
     @Override
     public void setAttribute(String name, Object value, boolean notify) {
         super.setAttribute(name, value, notify);
-        
+
         if (updateMode == UpdateMode.DEFAULT && map != null && value != null) {
             fastPut(name, value);
         }
     }
-    
+
     public void superRemoveAttributeInternal(String name, boolean notify) {
         super.removeAttributeInternal(name, notify);
     }
-    
+
     @Override
     protected void removeAttributeInternal(String name, boolean notify) {
         super.removeAttributeInternal(name, notify);
-        
+
         if (updateMode == UpdateMode.DEFAULT && map != null) {
             map.fastRemove(name);
             if (readMode == ReadMode.MEMORY) {
-                topic.publish(new AttributeRemoveMessage(getId(), name));
+                topic.publish(new AttributeRemoveMessage(redissonManager.getNodeId(), getId(), name));
             }
         }
     }
-    
+
     public void save() {
         Map<String, Object> newMap = new HashMap<String, Object>();
         newMap.put("session:creationTime", creationTime);
@@ -204,23 +204,23 @@ public class RedissonSession extends StandardSession {
         newMap.put("session:maxInactiveInterval", maxInactiveInterval);
         newMap.put("session:isValid", isValid);
         newMap.put("session:isNew", isNew);
-        
+
         if (attrs != null) {
             for (Entry<String, Object> entry : attrs.entrySet()) {
                 newMap.put(entry.getKey(), entry.getValue());
             }
         }
-        
+
         map.putAll(newMap);
         if (readMode == ReadMode.MEMORY) {
-            topic.publish(new AttributesPutAllMessage(getId(), newMap));
+            topic.publish(new AttributesPutAllMessage(redissonManager.getNodeId(), getId(), newMap));
         }
-        
+
         if (maxInactiveInterval >= 0) {
             map.expire(getMaxInactiveInterval(), TimeUnit.SECONDS);
         }
     }
-    
+
     public void load(Map<String, Object> attrs) {
         Long creationTime = (Long) attrs.remove("session:creationTime");
         if (creationTime != null) {
@@ -251,5 +251,5 @@ public class RedissonSession extends StandardSession {
             super.setAttribute(entry.getKey(), entry.getValue(), false);
         }
     }
-    
+
 }

--- a/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/AttributeMessage.java
+++ b/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/AttributeMessage.java
@@ -15,24 +15,35 @@
  */
 package org.redisson.tomcat;
 
+import java.io.Serializable;
+
 /**
- * 
  * @author Nikita Koksharov
- *
  */
-public class AttributeMessage {
+public class AttributeMessage implements Serializable {
 
     private String sessionId;
 
+    private String nodeId;
+
     public AttributeMessage() {
     }
-    
+
     public AttributeMessage(String sessionId) {
         this.sessionId = sessionId;
     }
-    
+
+    public AttributeMessage(String nodeId, String sessionId) {
+        this(sessionId);
+        this.nodeId = nodeId;
+    }
+
     public String getSessionId() {
         return sessionId;
     }
-    
+
+    public String getNodeId() {
+        return nodeId;
+    }
+
 }

--- a/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/AttributeRemoveMessage.java
+++ b/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/AttributeRemoveMessage.java
@@ -33,6 +33,11 @@ public class AttributeRemoveMessage extends AttributeMessage {
         this.name = name;
     }
 
+    public AttributeRemoveMessage(String nodeId,String sessionId, String name) {
+        super(nodeId,sessionId);
+        this.name = name;
+    }
+
     public String getName() {
         return name;
     }

--- a/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/AttributeUpdateMessage.java
+++ b/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/AttributeUpdateMessage.java
@@ -16,7 +16,7 @@
 package org.redisson.tomcat;
 
 /**
- * 
+ *
  * @author Nikita Koksharov
  *
  */
@@ -27,9 +27,15 @@ public class AttributeUpdateMessage extends AttributeMessage {
 
     public AttributeUpdateMessage() {
     }
-    
+
     public AttributeUpdateMessage(String sessionId, String name, Object value) {
         super(sessionId);
+        this.name = name;
+        this.value = value;
+    }
+
+    public AttributeUpdateMessage(String nodeId, String sessionId, String name, Object value) {
+        super(nodeId, sessionId);
         this.name = name;
         this.value = value;
     }
@@ -37,9 +43,9 @@ public class AttributeUpdateMessage extends AttributeMessage {
     public String getName() {
         return name;
     }
-    
+
     public Object getValue() {
         return value;
     }
-    
+
 }

--- a/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/AttributesClearMessage.java
+++ b/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/AttributesClearMessage.java
@@ -16,7 +16,7 @@
 package org.redisson.tomcat;
 
 /**
- * 
+ *
  * @author Nikita Koksharov
  *
  */
@@ -27,6 +27,10 @@ public class AttributesClearMessage extends AttributeMessage {
 
     public AttributesClearMessage(String sessionId) {
         super(sessionId);
+    }
+
+    public AttributesClearMessage(String nodeId, String sessionId) {
+        super(nodeId, sessionId);
     }
 
 }

--- a/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/AttributesPutAllMessage.java
+++ b/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/AttributesPutAllMessage.java
@@ -18,14 +18,14 @@ package org.redisson.tomcat;
 import java.util.Map;
 
 /**
- * 
+ *
  * @author Nikita Koksharov
  *
  */
 public class AttributesPutAllMessage extends AttributeMessage {
 
     private Map<String, Object> attrs;
-    
+
     public AttributesPutAllMessage() {
     }
 
@@ -33,7 +33,12 @@ public class AttributesPutAllMessage extends AttributeMessage {
         super(sessionId);
         this.attrs = attrs;
     }
-    
+
+    public AttributesPutAllMessage(String nodeId, String sessionId, Map<String, Object> attrs) {
+        super(nodeId, sessionId);
+        this.attrs = attrs;
+    }
+
     public Map<String, Object> getAttrs() {
         return attrs;
     }

--- a/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSession.java
+++ b/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSession.java
@@ -15,21 +15,21 @@
  */
 package org.redisson.tomcat;
 
-import java.lang.reflect.Field;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.concurrent.TimeUnit;
-
 import org.apache.catalina.session.StandardSession;
 import org.redisson.api.RMap;
 import org.redisson.api.RTopic;
 import org.redisson.tomcat.RedissonSessionManager.ReadMode;
 import org.redisson.tomcat.RedissonSessionManager.UpdateMode;
 
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
+
 /**
  * Redisson Session object for Apache Tomcat
- * 
+ *
  * @author Nikita Koksharov
  *
  */
@@ -39,15 +39,15 @@ public class RedissonSession extends StandardSession {
     private final Map<String, Object> attrs;
     private RMap<String, Object> map;
     private RTopic<AttributeMessage> topic;
-    private final RedissonSessionManager.ReadMode readMode;
+    private final ReadMode readMode;
     private final UpdateMode updateMode;
-    
+
     public RedissonSession(RedissonSessionManager manager, ReadMode readMode, UpdateMode updateMode) {
         super(manager);
         this.redissonManager = manager;
         this.readMode = readMode;
         this.updateMode = updateMode;
-        
+
         try {
             Field attr = StandardSession.class.getDeclaredField("attributes");
             attrs = (Map<String, Object>) attr.get(this);
@@ -66,22 +66,22 @@ public class RedissonSession extends StandardSession {
 
         return super.getAttribute(name);
     }
-    
+
     @Override
     public void setId(String id, boolean notify) {
         super.setId(id, notify);
         map = redissonManager.getMap(id);
         topic = redissonManager.getTopic();
     }
-    
+
     public void delete() {
         map.delete();
         if (readMode == ReadMode.MEMORY) {
-            topic.publish(new AttributesClearMessage(getId()));
+            topic.publish(new AttributesClearMessage(redissonManager.getNodeId(), getId()));
         }
         map = null;
     }
-    
+
     @Override
     public void setCreationTime(long time) {
         super.setCreationTime(time);
@@ -93,33 +93,33 @@ public class RedissonSession extends StandardSession {
             newMap.put("session:thisAccessedTime", thisAccessedTime);
             map.putAll(newMap);
             if (readMode == ReadMode.MEMORY) {
-                topic.publish(new AttributesPutAllMessage(getId(), newMap));
+                topic.publish(new AttributesPutAllMessage(redissonManager.getNodeId(), getId(), newMap));
             }
         }
     }
-    
+
     @Override
     public void access() {
         super.access();
-        
+
         if (map != null) {
             Map<String, Object> newMap = new HashMap<String, Object>(2);
             newMap.put("session:lastAccessedTime", lastAccessedTime);
             newMap.put("session:thisAccessedTime", thisAccessedTime);
             map.putAll(newMap);
             if (readMode == ReadMode.MEMORY) {
-                topic.publish(new AttributesPutAllMessage(getId(), newMap));
+                topic.publish(new AttributesPutAllMessage(redissonManager.getNodeId(), getId(), newMap));
             }
             if (getMaxInactiveInterval() >= 0) {
                 map.expire(getMaxInactiveInterval(), TimeUnit.SECONDS);
             }
         }
     }
-    
+
     @Override
     public void setMaxInactiveInterval(int interval) {
         super.setMaxInactiveInterval(interval);
-        
+
         if (map != null) {
             fastPut("session:maxInactiveInterval", maxInactiveInterval);
             if (maxInactiveInterval >= 0) {
@@ -131,32 +131,32 @@ public class RedissonSession extends StandardSession {
     private void fastPut(String name, Object value) {
         map.fastPut(name, value);
         if (readMode == ReadMode.MEMORY) {
-            topic.publish(new AttributeUpdateMessage(getId(), name, value));
+            topic.publish(new AttributeUpdateMessage(redissonManager.getNodeId(), getId(), name, value));
         }
     }
-    
+
     @Override
     public void setValid(boolean isValid) {
         super.setValid(isValid);
-        
+
         if (map != null) {
             if (!isValid && !map.isExists()) {
                 return;
             }
-            
+
             fastPut("session:isValid", isValid);
         }
     }
-    
+
     @Override
     public void setNew(boolean isNew) {
         super.setNew(isNew);
-        
+
         if (map != null) {
             fastPut("session:isNew", isNew);
         }
     }
-    
+
     @Override
     public void endAccess() {
         boolean oldValue = isNew;
@@ -166,36 +166,36 @@ public class RedissonSession extends StandardSession {
             fastPut("session:isNew", isNew);
         }
     }
-    
+
     public void superSetAttribute(String name, Object value, boolean notify) {
         super.setAttribute(name, value, notify);
     }
-    
+
     @Override
     public void setAttribute(String name, Object value, boolean notify) {
         super.setAttribute(name, value, notify);
-        
+
         if (updateMode == UpdateMode.DEFAULT && map != null && value != null) {
             fastPut(name, value);
         }
     }
-    
+
     public void superRemoveAttributeInternal(String name, boolean notify) {
         super.removeAttributeInternal(name, notify);
     }
-    
+
     @Override
     protected void removeAttributeInternal(String name, boolean notify) {
         super.removeAttributeInternal(name, notify);
-        
+
         if (updateMode == UpdateMode.DEFAULT && map != null) {
             map.fastRemove(name);
             if (readMode == ReadMode.MEMORY) {
-                topic.publish(new AttributeRemoveMessage(getId(), name));
+                topic.publish(new AttributeRemoveMessage(redissonManager.getNodeId(), getId(), name));
             }
         }
     }
-    
+
     public void save() {
         Map<String, Object> newMap = new HashMap<String, Object>();
         newMap.put("session:creationTime", creationTime);
@@ -204,23 +204,23 @@ public class RedissonSession extends StandardSession {
         newMap.put("session:maxInactiveInterval", maxInactiveInterval);
         newMap.put("session:isValid", isValid);
         newMap.put("session:isNew", isNew);
-        
+
         if (attrs != null) {
             for (Entry<String, Object> entry : attrs.entrySet()) {
                 newMap.put(entry.getKey(), entry.getValue());
             }
         }
-        
+
         map.putAll(newMap);
         if (readMode == ReadMode.MEMORY) {
-            topic.publish(new AttributesPutAllMessage(getId(), newMap));
+            topic.publish(new AttributesPutAllMessage(redissonManager.getNodeId(), getId(), newMap));
         }
-        
+
         if (maxInactiveInterval >= 0) {
             map.expire(getMaxInactiveInterval(), TimeUnit.SECONDS);
         }
     }
-    
+
     public void load(Map<String, Object> attrs) {
         Long creationTime = (Long) attrs.remove("session:creationTime");
         if (creationTime != null) {
@@ -251,5 +251,5 @@ public class RedissonSession extends StandardSession {
             super.setAttribute(entry.getKey(), entry.getValue(), false);
         }
     }
-    
+
 }

--- a/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -15,14 +15,6 @@
  */
 package org.redisson.tomcat;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.Map;
-import java.util.Map.Entry;
-
-import javax.servlet.http.HttpSession;
-
-import org.apache.catalina.Context;
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.LifecycleState;
 import org.apache.catalina.Session;
@@ -37,27 +29,38 @@ import org.redisson.api.listener.MessageListener;
 import org.redisson.client.codec.Codec;
 import org.redisson.config.Config;
 
+import javax.servlet.http.HttpSession;
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.UUID;
+
 /**
  * Redisson Session Manager for Apache Tomcat
- * 
- * @author Nikita Koksharov
  *
+ * @author Nikita Koksharov
  */
 public class RedissonSessionManager extends ManagerBase {
 
     public enum ReadMode {REDIS, MEMORY}
+
     public enum UpdateMode {DEFAULT, AFTER_REQUEST}
-    
+
     private final Log log = LogFactory.getLog(RedissonSessionManager.class);
-    
+
     private RedissonClient redisson;
     private String configPath;
-    
+
     private ReadMode readMode = ReadMode.MEMORY;
     private UpdateMode updateMode = UpdateMode.DEFAULT;
 
     private String keyPrefix = "";
-    
+
+    private final String nodeId = UUID.randomUUID().toString();
+
+    public String getNodeId() { return nodeId; }
+
     public String getUpdateMode() {
         return updateMode.toString();
     }
@@ -73,11 +76,11 @@ public class RedissonSessionManager extends ManagerBase {
     public void setReadMode(String readMode) {
         this.readMode = ReadMode.valueOf(readMode);
     }
-    
+
     public void setConfigPath(String configPath) {
         this.configPath = configPath;
     }
-    
+
     public String getConfigPath() {
         return configPath;
     }
@@ -94,7 +97,7 @@ public class RedissonSessionManager extends ManagerBase {
     public String getName() {
         return RedissonSessionManager.class.getSimpleName();
     }
-    
+
     @Override
     public void load() throws ClassNotFoundException, IOException {
     }
@@ -106,19 +109,19 @@ public class RedissonSessionManager extends ManagerBase {
     @Override
     public Session createSession(String sessionId) {
         RedissonSession session = (RedissonSession) createEmptySession();
-        
+
         session.setNew(true);
         session.setValid(true);
         session.setCreationTime(System.currentTimeMillis());
-        session.setMaxInactiveInterval(((Context) getContainer()).getSessionTimeout() * 60);
+        session.setMaxInactiveInterval(getContext().getSessionTimeout() * 60);
 
         if (sessionId == null) {
             sessionId = generateSessionId();
         }
-        
+
         session.setId(sessionId);
         session.save();
-        
+
         return session;
     }
 
@@ -127,26 +130,26 @@ public class RedissonSessionManager extends ManagerBase {
         final String name = keyPrefix + separator + "redisson:tomcat_session:" + sessionId;
         return redisson.getMap(name);
     }
-    
+
     public RTopic<AttributeMessage> getTopic() {
         return redisson.getTopic("redisson:tomcat_session_updates");
     }
-    
+
     @Override
     public Session findSession(String id) throws IOException {
         Session result = super.findSession(id);
         if (result == null && id != null) {
             Map<String, Object> attrs = getMap(id).readAllMap();
-            
+
             if (attrs.isEmpty() || !Boolean.valueOf(String.valueOf(attrs.get("session:isValid")))) {
                 log.info("Session " + id + " can't be found");
                 return null;
             }
-            
+
             RedissonSession session = (RedissonSession) createEmptySession();
             session.setId(id);
             session.load(attrs);
-            
+
             session.access();
             session.endAccess();
             return session;
@@ -154,33 +157,33 @@ public class RedissonSessionManager extends ManagerBase {
 
         result.access();
         result.endAccess();
-        
+
         return result;
     }
-    
+
     @Override
     public Session createEmptySession() {
         return new RedissonSession(this, readMode, updateMode);
     }
-    
+
     @Override
     public void remove(Session session, boolean update) {
         super.remove(session, update);
-        
+
         if (session.getIdInternal() != null) {
-            ((RedissonSession)session).delete();
+            ((RedissonSession) session).delete();
         }
     }
-    
+
     public RedissonClient getRedisson() {
         return redisson;
     }
-    
+
     @Override
     protected void startInternal() throws LifecycleException {
         super.startInternal();
         redisson = buildClient();
-        
+
         if (updateMode == UpdateMode.AFTER_REQUEST) {
             getEngine().getPipeline().addValve(new UpdateValve(this));
         }
@@ -188,30 +191,30 @@ public class RedissonSessionManager extends ManagerBase {
         if (readMode == ReadMode.MEMORY) {
             RTopic<AttributeMessage> updatesTopic = getTopic();
             updatesTopic.addListener(new MessageListener<AttributeMessage>() {
-                
+
                 @Override
                 public void onMessage(String channel, AttributeMessage msg) {
                     try {
                         // TODO make it thread-safe
                         RedissonSession session = (RedissonSession) RedissonSessionManager.super.findSession(msg.getSessionId());
-                        if (session != null) {
+                        if (session != null && !msg.getNodeId().equals(nodeId)) {
                             if (msg instanceof AttributeRemoveMessage) {
-                                session.superRemoveAttributeInternal(((AttributeRemoveMessage)msg).getName(), true);
+                                session.superRemoveAttributeInternal(((AttributeRemoveMessage) msg).getName(), true);
                             }
 
                             if (msg instanceof AttributesClearMessage) {
                                 RedissonSessionManager.super.remove(session, false);
                             }
-                            
+
                             if (msg instanceof AttributesPutAllMessage) {
                                 AttributesPutAllMessage m = (AttributesPutAllMessage) msg;
                                 for (Entry<String, Object> entry : m.getAttrs().entrySet()) {
                                     session.superSetAttribute(entry.getKey(), entry.getValue(), true);
                                 }
                             }
-                            
+
                             if (msg instanceof AttributeUpdateMessage) {
-                                AttributeUpdateMessage m = (AttributeUpdateMessage)msg;
+                                AttributeUpdateMessage m = (AttributeUpdateMessage) msg;
                                 session.superSetAttribute(m.getName(), m.getValue(), true);
                             }
                         }
@@ -221,7 +224,7 @@ public class RedissonSessionManager extends ManagerBase {
                 }
             });
         }
-        
+
         setState(LifecycleState.STARTING);
     }
 
@@ -238,17 +241,13 @@ public class RedissonSessionManager extends ManagerBase {
                 throw new LifecycleException("Can't parse yaml config " + configPath, e1);
             }
         }
-        
+
         try {
-            try {
             Config c = new Config(config);
             Codec codec = c.getCodec().getClass().getConstructor(ClassLoader.class)
-                            .newInstance(Thread.currentThread().getContextClassLoader());
+                    .newInstance(Thread.currentThread().getContextClassLoader());
             config.setCodec(codec);
-            } catch (Exception e) {
-                throw new IllegalStateException("Unable to initialize codec with ClassLoader parameter", e);
-            }
-            
+
             return Redisson.create(config);
         } catch (Exception e) {
             throw new LifecycleException(e);
@@ -258,9 +257,9 @@ public class RedissonSessionManager extends ManagerBase {
     @Override
     protected void stopInternal() throws LifecycleException {
         super.stopInternal();
-        
+
         setState(LifecycleState.STOPPING);
-        
+
         try {
             if (redisson != null) {
                 redisson.shutdown();
@@ -268,18 +267,18 @@ public class RedissonSessionManager extends ManagerBase {
         } catch (Exception e) {
             throw new LifecycleException(e);
         }
-        
+
     }
 
     public void store(HttpSession session) throws IOException {
         if (session == null) {
             return;
         }
-        
+
         if (updateMode == UpdateMode.AFTER_REQUEST) {
             RedissonSession sess = (RedissonSession) findSession(session.getId());
-            sess.save();            
+            sess.save();
         }
     }
-    
+
 }

--- a/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/AttributeMessage.java
+++ b/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/AttributeMessage.java
@@ -15,24 +15,35 @@
  */
 package org.redisson.tomcat;
 
+import java.io.Serializable;
+
 /**
- * 
  * @author Nikita Koksharov
- *
  */
-public class AttributeMessage {
+public class AttributeMessage implements Serializable {
 
     private String sessionId;
 
+    private String nodeId;
+
     public AttributeMessage() {
     }
-    
+
     public AttributeMessage(String sessionId) {
         this.sessionId = sessionId;
     }
-    
+
+    public AttributeMessage(String nodeId, String sessionId) {
+        this(sessionId);
+        this.nodeId = nodeId;
+    }
+
     public String getSessionId() {
         return sessionId;
     }
-    
+
+    public String getNodeId() {
+        return nodeId;
+    }
+
 }

--- a/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/AttributeRemoveMessage.java
+++ b/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/AttributeRemoveMessage.java
@@ -33,6 +33,11 @@ public class AttributeRemoveMessage extends AttributeMessage {
         this.name = name;
     }
 
+    public AttributeRemoveMessage(String nodeId,String sessionId, String name) {
+        super(nodeId,sessionId);
+        this.name = name;
+    }
+
     public String getName() {
         return name;
     }

--- a/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/AttributeUpdateMessage.java
+++ b/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/AttributeUpdateMessage.java
@@ -16,7 +16,7 @@
 package org.redisson.tomcat;
 
 /**
- * 
+ *
  * @author Nikita Koksharov
  *
  */
@@ -27,9 +27,15 @@ public class AttributeUpdateMessage extends AttributeMessage {
 
     public AttributeUpdateMessage() {
     }
-    
+
     public AttributeUpdateMessage(String sessionId, String name, Object value) {
         super(sessionId);
+        this.name = name;
+        this.value = value;
+    }
+
+    public AttributeUpdateMessage(String nodeId, String sessionId, String name, Object value) {
+        super(nodeId, sessionId);
         this.name = name;
         this.value = value;
     }
@@ -37,9 +43,9 @@ public class AttributeUpdateMessage extends AttributeMessage {
     public String getName() {
         return name;
     }
-    
+
     public Object getValue() {
         return value;
     }
-    
+
 }

--- a/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/AttributesClearMessage.java
+++ b/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/AttributesClearMessage.java
@@ -16,7 +16,7 @@
 package org.redisson.tomcat;
 
 /**
- * 
+ *
  * @author Nikita Koksharov
  *
  */
@@ -27,6 +27,10 @@ public class AttributesClearMessage extends AttributeMessage {
 
     public AttributesClearMessage(String sessionId) {
         super(sessionId);
+    }
+
+    public AttributesClearMessage(String nodeId, String sessionId) {
+        super(nodeId, sessionId);
     }
 
 }

--- a/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/AttributesPutAllMessage.java
+++ b/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/AttributesPutAllMessage.java
@@ -18,14 +18,14 @@ package org.redisson.tomcat;
 import java.util.Map;
 
 /**
- * 
+ *
  * @author Nikita Koksharov
  *
  */
 public class AttributesPutAllMessage extends AttributeMessage {
 
     private Map<String, Object> attrs;
-    
+
     public AttributesPutAllMessage() {
     }
 
@@ -33,7 +33,12 @@ public class AttributesPutAllMessage extends AttributeMessage {
         super(sessionId);
         this.attrs = attrs;
     }
-    
+
+    public AttributesPutAllMessage(String nodeId, String sessionId, Map<String, Object> attrs) {
+        super(nodeId, sessionId);
+        this.attrs = attrs;
+    }
+
     public Map<String, Object> getAttrs() {
         return attrs;
     }

--- a/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -15,13 +15,6 @@
  */
 package org.redisson.tomcat;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.Map;
-import java.util.Map.Entry;
-
-import javax.servlet.http.HttpSession;
-
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.LifecycleState;
 import org.apache.catalina.Session;
@@ -36,27 +29,38 @@ import org.redisson.api.listener.MessageListener;
 import org.redisson.client.codec.Codec;
 import org.redisson.config.Config;
 
+import javax.servlet.http.HttpSession;
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.UUID;
+
 /**
  * Redisson Session Manager for Apache Tomcat
- * 
- * @author Nikita Koksharov
  *
+ * @author Nikita Koksharov
  */
 public class RedissonSessionManager extends ManagerBase {
 
     public enum ReadMode {REDIS, MEMORY}
+
     public enum UpdateMode {DEFAULT, AFTER_REQUEST}
-    
+
     private final Log log = LogFactory.getLog(RedissonSessionManager.class);
-    
+
     private RedissonClient redisson;
     private String configPath;
-    
+
     private ReadMode readMode = ReadMode.MEMORY;
     private UpdateMode updateMode = UpdateMode.DEFAULT;
 
     private String keyPrefix = "";
-    
+
+    private final String nodeId = UUID.randomUUID().toString();
+
+    public String getNodeId() { return nodeId; }
+
     public String getUpdateMode() {
         return updateMode.toString();
     }
@@ -72,11 +76,11 @@ public class RedissonSessionManager extends ManagerBase {
     public void setReadMode(String readMode) {
         this.readMode = ReadMode.valueOf(readMode);
     }
-    
+
     public void setConfigPath(String configPath) {
         this.configPath = configPath;
     }
-    
+
     public String getConfigPath() {
         return configPath;
     }
@@ -93,7 +97,7 @@ public class RedissonSessionManager extends ManagerBase {
     public String getName() {
         return RedissonSessionManager.class.getSimpleName();
     }
-    
+
     @Override
     public void load() throws ClassNotFoundException, IOException {
     }
@@ -105,7 +109,7 @@ public class RedissonSessionManager extends ManagerBase {
     @Override
     public Session createSession(String sessionId) {
         RedissonSession session = (RedissonSession) createEmptySession();
-        
+
         session.setNew(true);
         session.setValid(true);
         session.setCreationTime(System.currentTimeMillis());
@@ -114,10 +118,10 @@ public class RedissonSessionManager extends ManagerBase {
         if (sessionId == null) {
             sessionId = generateSessionId();
         }
-        
+
         session.setId(sessionId);
         session.save();
-        
+
         return session;
     }
 
@@ -126,26 +130,26 @@ public class RedissonSessionManager extends ManagerBase {
         final String name = keyPrefix + separator + "redisson:tomcat_session:" + sessionId;
         return redisson.getMap(name);
     }
-    
+
     public RTopic<AttributeMessage> getTopic() {
         return redisson.getTopic("redisson:tomcat_session_updates");
     }
-    
+
     @Override
     public Session findSession(String id) throws IOException {
         Session result = super.findSession(id);
         if (result == null && id != null) {
             Map<String, Object> attrs = getMap(id).readAllMap();
-            
+
             if (attrs.isEmpty() || !Boolean.valueOf(String.valueOf(attrs.get("session:isValid")))) {
                 log.info("Session " + id + " can't be found");
                 return null;
             }
-            
+
             RedissonSession session = (RedissonSession) createEmptySession();
             session.setId(id);
             session.load(attrs);
-            
+
             session.access();
             session.endAccess();
             return session;
@@ -153,33 +157,33 @@ public class RedissonSessionManager extends ManagerBase {
 
         result.access();
         result.endAccess();
-        
+
         return result;
     }
-    
+
     @Override
     public Session createEmptySession() {
         return new RedissonSession(this, readMode, updateMode);
     }
-    
+
     @Override
     public void remove(Session session, boolean update) {
         super.remove(session, update);
-        
+
         if (session.getIdInternal() != null) {
-            ((RedissonSession)session).delete();
+            ((RedissonSession) session).delete();
         }
     }
-    
+
     public RedissonClient getRedisson() {
         return redisson;
     }
-    
+
     @Override
     protected void startInternal() throws LifecycleException {
         super.startInternal();
         redisson = buildClient();
-        
+
         if (updateMode == UpdateMode.AFTER_REQUEST) {
             getEngine().getPipeline().addValve(new UpdateValve(this));
         }
@@ -187,30 +191,30 @@ public class RedissonSessionManager extends ManagerBase {
         if (readMode == ReadMode.MEMORY) {
             RTopic<AttributeMessage> updatesTopic = getTopic();
             updatesTopic.addListener(new MessageListener<AttributeMessage>() {
-                
+
                 @Override
                 public void onMessage(String channel, AttributeMessage msg) {
                     try {
                         // TODO make it thread-safe
                         RedissonSession session = (RedissonSession) RedissonSessionManager.super.findSession(msg.getSessionId());
-                        if (session != null) {
+                        if (session != null && !msg.getNodeId().equals(nodeId)) {
                             if (msg instanceof AttributeRemoveMessage) {
-                                session.superRemoveAttributeInternal(((AttributeRemoveMessage)msg).getName(), true);
+                                session.superRemoveAttributeInternal(((AttributeRemoveMessage) msg).getName(), true);
                             }
 
                             if (msg instanceof AttributesClearMessage) {
                                 RedissonSessionManager.super.remove(session, false);
                             }
-                            
+
                             if (msg instanceof AttributesPutAllMessage) {
                                 AttributesPutAllMessage m = (AttributesPutAllMessage) msg;
                                 for (Entry<String, Object> entry : m.getAttrs().entrySet()) {
                                     session.superSetAttribute(entry.getKey(), entry.getValue(), true);
                                 }
                             }
-                            
+
                             if (msg instanceof AttributeUpdateMessage) {
-                                AttributeUpdateMessage m = (AttributeUpdateMessage)msg;
+                                AttributeUpdateMessage m = (AttributeUpdateMessage) msg;
                                 session.superSetAttribute(m.getName(), m.getValue(), true);
                             }
                         }
@@ -220,7 +224,7 @@ public class RedissonSessionManager extends ManagerBase {
                 }
             });
         }
-        
+
         setState(LifecycleState.STARTING);
     }
 
@@ -237,13 +241,13 @@ public class RedissonSessionManager extends ManagerBase {
                 throw new LifecycleException("Can't parse yaml config " + configPath, e1);
             }
         }
-        
+
         try {
             Config c = new Config(config);
             Codec codec = c.getCodec().getClass().getConstructor(ClassLoader.class)
-                            .newInstance(Thread.currentThread().getContextClassLoader());
+                    .newInstance(Thread.currentThread().getContextClassLoader());
             config.setCodec(codec);
-            
+
             return Redisson.create(config);
         } catch (Exception e) {
             throw new LifecycleException(e);
@@ -253,9 +257,9 @@ public class RedissonSessionManager extends ManagerBase {
     @Override
     protected void stopInternal() throws LifecycleException {
         super.stopInternal();
-        
+
         setState(LifecycleState.STOPPING);
-        
+
         try {
             if (redisson != null) {
                 redisson.shutdown();
@@ -263,18 +267,18 @@ public class RedissonSessionManager extends ManagerBase {
         } catch (Exception e) {
             throw new LifecycleException(e);
         }
-        
+
     }
 
     public void store(HttpSession session) throws IOException {
         if (session == null) {
             return;
         }
-        
+
         if (updateMode == UpdateMode.AFTER_REQUEST) {
             RedissonSession sess = (RedissonSession) findSession(session.getId());
-            sess.save();            
+            sess.save();
         }
     }
-    
+
 }

--- a/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/AttributeMessage.java
+++ b/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/AttributeMessage.java
@@ -15,24 +15,35 @@
  */
 package org.redisson.tomcat;
 
+import java.io.Serializable;
+
 /**
- * 
  * @author Nikita Koksharov
- *
  */
-public class AttributeMessage {
+public class AttributeMessage implements Serializable {
 
     private String sessionId;
 
+    private String nodeId;
+
     public AttributeMessage() {
     }
-    
+
     public AttributeMessage(String sessionId) {
         this.sessionId = sessionId;
     }
-    
+
+    public AttributeMessage(String nodeId, String sessionId) {
+        this(sessionId);
+        this.nodeId = nodeId;
+    }
+
     public String getSessionId() {
         return sessionId;
     }
-    
+
+    public String getNodeId() {
+        return nodeId;
+    }
+
 }

--- a/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/AttributeRemoveMessage.java
+++ b/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/AttributeRemoveMessage.java
@@ -33,6 +33,11 @@ public class AttributeRemoveMessage extends AttributeMessage {
         this.name = name;
     }
 
+    public AttributeRemoveMessage(String nodeId,String sessionId, String name) {
+        super(nodeId,sessionId);
+        this.name = name;
+    }
+
     public String getName() {
         return name;
     }

--- a/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/AttributeUpdateMessage.java
+++ b/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/AttributeUpdateMessage.java
@@ -16,7 +16,7 @@
 package org.redisson.tomcat;
 
 /**
- * 
+ *
  * @author Nikita Koksharov
  *
  */
@@ -27,9 +27,15 @@ public class AttributeUpdateMessage extends AttributeMessage {
 
     public AttributeUpdateMessage() {
     }
-    
+
     public AttributeUpdateMessage(String sessionId, String name, Object value) {
         super(sessionId);
+        this.name = name;
+        this.value = value;
+    }
+
+    public AttributeUpdateMessage(String nodeId, String sessionId, String name, Object value) {
+        super(nodeId, sessionId);
         this.name = name;
         this.value = value;
     }
@@ -37,9 +43,9 @@ public class AttributeUpdateMessage extends AttributeMessage {
     public String getName() {
         return name;
     }
-    
+
     public Object getValue() {
         return value;
     }
-    
+
 }

--- a/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/AttributesClearMessage.java
+++ b/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/AttributesClearMessage.java
@@ -16,7 +16,7 @@
 package org.redisson.tomcat;
 
 /**
- * 
+ *
  * @author Nikita Koksharov
  *
  */
@@ -27,6 +27,10 @@ public class AttributesClearMessage extends AttributeMessage {
 
     public AttributesClearMessage(String sessionId) {
         super(sessionId);
+    }
+
+    public AttributesClearMessage(String nodeId, String sessionId) {
+        super(nodeId, sessionId);
     }
 
 }

--- a/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/AttributesPutAllMessage.java
+++ b/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/AttributesPutAllMessage.java
@@ -18,14 +18,14 @@ package org.redisson.tomcat;
 import java.util.Map;
 
 /**
- * 
+ *
  * @author Nikita Koksharov
  *
  */
 public class AttributesPutAllMessage extends AttributeMessage {
 
     private Map<String, Object> attrs;
-    
+
     public AttributesPutAllMessage() {
     }
 
@@ -33,7 +33,12 @@ public class AttributesPutAllMessage extends AttributeMessage {
         super(sessionId);
         this.attrs = attrs;
     }
-    
+
+    public AttributesPutAllMessage(String nodeId, String sessionId, Map<String, Object> attrs) {
+        super(nodeId, sessionId);
+        this.attrs = attrs;
+    }
+
     public Map<String, Object> getAttrs() {
         return attrs;
     }

--- a/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -15,13 +15,6 @@
  */
 package org.redisson.tomcat;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.Map;
-import java.util.Map.Entry;
-
-import javax.servlet.http.HttpSession;
-
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.LifecycleState;
 import org.apache.catalina.Session;
@@ -36,27 +29,38 @@ import org.redisson.api.listener.MessageListener;
 import org.redisson.client.codec.Codec;
 import org.redisson.config.Config;
 
+import javax.servlet.http.HttpSession;
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.UUID;
+
 /**
  * Redisson Session Manager for Apache Tomcat
- * 
- * @author Nikita Koksharov
  *
+ * @author Nikita Koksharov
  */
 public class RedissonSessionManager extends ManagerBase {
 
     public enum ReadMode {REDIS, MEMORY}
+
     public enum UpdateMode {DEFAULT, AFTER_REQUEST}
-    
+
     private final Log log = LogFactory.getLog(RedissonSessionManager.class);
-    
+
     private RedissonClient redisson;
     private String configPath;
-    
+
     private ReadMode readMode = ReadMode.MEMORY;
     private UpdateMode updateMode = UpdateMode.DEFAULT;
 
     private String keyPrefix = "";
-    
+
+    private final String nodeId = UUID.randomUUID().toString();
+
+    public String getNodeId() { return nodeId; }
+
     public String getUpdateMode() {
         return updateMode.toString();
     }
@@ -72,11 +76,11 @@ public class RedissonSessionManager extends ManagerBase {
     public void setReadMode(String readMode) {
         this.readMode = ReadMode.valueOf(readMode);
     }
-    
+
     public void setConfigPath(String configPath) {
         this.configPath = configPath;
     }
-    
+
     public String getConfigPath() {
         return configPath;
     }
@@ -93,7 +97,7 @@ public class RedissonSessionManager extends ManagerBase {
     public String getName() {
         return RedissonSessionManager.class.getSimpleName();
     }
-    
+
     @Override
     public void load() throws ClassNotFoundException, IOException {
     }
@@ -105,7 +109,7 @@ public class RedissonSessionManager extends ManagerBase {
     @Override
     public Session createSession(String sessionId) {
         RedissonSession session = (RedissonSession) createEmptySession();
-        
+
         session.setNew(true);
         session.setValid(true);
         session.setCreationTime(System.currentTimeMillis());
@@ -114,10 +118,10 @@ public class RedissonSessionManager extends ManagerBase {
         if (sessionId == null) {
             sessionId = generateSessionId();
         }
-        
+
         session.setId(sessionId);
         session.save();
-        
+
         return session;
     }
 
@@ -126,26 +130,26 @@ public class RedissonSessionManager extends ManagerBase {
         final String name = keyPrefix + separator + "redisson:tomcat_session:" + sessionId;
         return redisson.getMap(name);
     }
-    
+
     public RTopic<AttributeMessage> getTopic() {
         return redisson.getTopic("redisson:tomcat_session_updates");
     }
-    
+
     @Override
     public Session findSession(String id) throws IOException {
         Session result = super.findSession(id);
         if (result == null && id != null) {
             Map<String, Object> attrs = getMap(id).readAllMap();
-            
+
             if (attrs.isEmpty() || !Boolean.valueOf(String.valueOf(attrs.get("session:isValid")))) {
                 log.info("Session " + id + " can't be found");
                 return null;
             }
-            
+
             RedissonSession session = (RedissonSession) createEmptySession();
             session.setId(id);
             session.load(attrs);
-            
+
             session.access();
             session.endAccess();
             return session;
@@ -153,33 +157,33 @@ public class RedissonSessionManager extends ManagerBase {
 
         result.access();
         result.endAccess();
-        
+
         return result;
     }
-    
+
     @Override
     public Session createEmptySession() {
         return new RedissonSession(this, readMode, updateMode);
     }
-    
+
     @Override
     public void remove(Session session, boolean update) {
         super.remove(session, update);
-        
+
         if (session.getIdInternal() != null) {
-            ((RedissonSession)session).delete();
+            ((RedissonSession) session).delete();
         }
     }
-    
+
     public RedissonClient getRedisson() {
         return redisson;
     }
-    
+
     @Override
     protected void startInternal() throws LifecycleException {
         super.startInternal();
         redisson = buildClient();
-        
+
         if (updateMode == UpdateMode.AFTER_REQUEST) {
             getEngine().getPipeline().addValve(new UpdateValve(this));
         }
@@ -187,30 +191,30 @@ public class RedissonSessionManager extends ManagerBase {
         if (readMode == ReadMode.MEMORY) {
             RTopic<AttributeMessage> updatesTopic = getTopic();
             updatesTopic.addListener(new MessageListener<AttributeMessage>() {
-                
+
                 @Override
                 public void onMessage(String channel, AttributeMessage msg) {
                     try {
                         // TODO make it thread-safe
                         RedissonSession session = (RedissonSession) RedissonSessionManager.super.findSession(msg.getSessionId());
-                        if (session != null) {
+                        if (session != null && !msg.getNodeId().equals(nodeId)) {
                             if (msg instanceof AttributeRemoveMessage) {
-                                session.superRemoveAttributeInternal(((AttributeRemoveMessage)msg).getName(), true);
+                                session.superRemoveAttributeInternal(((AttributeRemoveMessage) msg).getName(), true);
                             }
 
                             if (msg instanceof AttributesClearMessage) {
                                 RedissonSessionManager.super.remove(session, false);
                             }
-                            
+
                             if (msg instanceof AttributesPutAllMessage) {
                                 AttributesPutAllMessage m = (AttributesPutAllMessage) msg;
                                 for (Entry<String, Object> entry : m.getAttrs().entrySet()) {
                                     session.superSetAttribute(entry.getKey(), entry.getValue(), true);
                                 }
                             }
-                            
+
                             if (msg instanceof AttributeUpdateMessage) {
-                                AttributeUpdateMessage m = (AttributeUpdateMessage)msg;
+                                AttributeUpdateMessage m = (AttributeUpdateMessage) msg;
                                 session.superSetAttribute(m.getName(), m.getValue(), true);
                             }
                         }
@@ -220,7 +224,7 @@ public class RedissonSessionManager extends ManagerBase {
                 }
             });
         }
-        
+
         setState(LifecycleState.STARTING);
     }
 
@@ -237,13 +241,13 @@ public class RedissonSessionManager extends ManagerBase {
                 throw new LifecycleException("Can't parse yaml config " + configPath, e1);
             }
         }
-        
+
         try {
             Config c = new Config(config);
             Codec codec = c.getCodec().getClass().getConstructor(ClassLoader.class)
-                            .newInstance(Thread.currentThread().getContextClassLoader());
+                    .newInstance(Thread.currentThread().getContextClassLoader());
             config.setCodec(codec);
-            
+
             return Redisson.create(config);
         } catch (Exception e) {
             throw new LifecycleException(e);
@@ -253,9 +257,9 @@ public class RedissonSessionManager extends ManagerBase {
     @Override
     protected void stopInternal() throws LifecycleException {
         super.stopInternal();
-        
+
         setState(LifecycleState.STOPPING);
-        
+
         try {
             if (redisson != null) {
                 redisson.shutdown();
@@ -263,18 +267,18 @@ public class RedissonSessionManager extends ManagerBase {
         } catch (Exception e) {
             throw new LifecycleException(e);
         }
-        
+
     }
 
     public void store(HttpSession session) throws IOException {
         if (session == null) {
             return;
         }
-        
+
         if (updateMode == UpdateMode.AFTER_REQUEST) {
             RedissonSession sess = (RedissonSession) findSession(session.getId());
-            sess.save();            
+            sess.save();
         }
     }
-    
+
 }


### PR DESCRIPTION
see https://github.com/redisson/redisson/issues/1414

I've found out the source of the problem in Vaadin. Actually it's a general problem for objects being serialized with transient fields.

In our case, Vaadin was creating a ReentrantLock with thread information being a transient field. So there's a piece of code that checks tries to unlock the lock. While doing this it checks the current thread to the one stored in ReentrantLock.

Now, before your fix it was working in version 3.6.5 with Memory mode due to the fact that this Lock was always fetched from the memory instead of Redis. So, it kept the this transient field as a result. But there we had the problem of sessions not being synchronized between different nodes. So in order to solve this problem you added a topic for listening to the changes, which was working really well.

But, as I noticed while debugging your new implementation was self-updating the attribute in memory after calling the HttpSession.setAttribute method. Because of this the attribute in the memory with the transient fields was overwritten and the transient fields were lost which led to the problem above.

In order to solve this problem, I added a check in RedissonSessionManager, so that whenever an AttributeMessage is captured by the topic, the changes are only applied in local memory if the changes are from a different node than the current tomcat instance. This way I was able to avoid attributes being overwritten by the topic whenever HttpSession.setAttribute is called by the same tomcat node. This seems to be working. 