### PR TITLE
fix import order in RedissonLiveObjectServiceTest

### DIFF
--- a/redisson/src/test/java/org/redisson/RedissonLiveObjectServiceTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonLiveObjectServiceTest.java
@@ -26,7 +26,6 @@ import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
-import org.redisson.RedissonLiveObjectServiceTest.TestEnum.MyEnum;
 import org.redisson.api.RBlockingDeque;
 import org.redisson.api.RBlockingQueue;
 import org.redisson.api.RCascadeType;
@@ -1548,15 +1547,15 @@ public class RedissonLiveObjectServiceTest extends BaseTest {
         String id = "1";
         TestEnum entry = new TestEnum();
         entry.setId(id);
-        entry.setMyEnum1(MyEnum.A);
+        entry.setMyEnum1(TestEnum.MyEnum.A);
         entry = liveObjectService.persist(entry);
 
         TestEnum liveEntry = liveObjectService.get(TestEnum.class, id);
-        assertThat(liveEntry.getMyEnum1()).isEqualTo(MyEnum.A);
+        assertThat(liveEntry.getMyEnum1()).isEqualTo(TestEnum.MyEnum.A);
         assertThat(liveEntry.getMyEnum2()).isNull();
         
-        entry.setMyEnum2(MyEnum.B);
-        assertThat(liveEntry.getMyEnum2()).isEqualTo(MyEnum.B);
+        entry.setMyEnum2(TestEnum.MyEnum.B);
+        assertThat(liveEntry.getMyEnum2()).isEqualTo(TestEnum.MyEnum.B);
     }
     
     @Test


### PR DESCRIPTION
It's a error when I run `mvn -Punit-test clean package`:

    [ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler- 
    plugin:3.7.0:testCompile (default-testCompile) on project redisson: Compilation failure
    [ERROR]
    /Users/finup/Desktop/a/github/redisson/redisson/src/test/java/org/redisson
    /RedissonLiveObjectServiceTest.java:[57,5] error: cannot find symbol
    [ERROR]   symbol:   class REntity
    [ERROR]   location: class RedissonLiveObjectServiceTest

I think it's because the file is importing its inner class `import org.redisson.RedissonLiveObjectServiceTest.TestEnum.MyEnum;
` before import the dependency of its inner class `import org.redisson.api.annotation.REntity;`

Change the order of import can solve my problem, but I suggest **not** to import inner class.

I don't know how you guys can make this package work. Please correct me if I was wrong. A stack overflow thread [here](https://stackoverflow.com/questions/51873469/java-how-import-order-matters-when-import-class-enum-inner-an-inner-class).