### PR TITLE
Multiple tomcats issue with load balancer

### DIFF
--- a/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSession.java
+++ b/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSession.java
@@ -269,7 +269,12 @@ public class RedissonSession extends StandardSession {
         }
 
         for (Entry<String, Object> entry : attrs.entrySet()) {
-            super.setAttribute(entry.getKey(), entry.getValue(), false);
+            if(!super.isValid) {
+        		super.setValid(true);
+        		super.setAttribute(entry.getKey(), entry.getValue(), false);
+        	}
+        	else
+        		super.setAttribute(entry.getKey(), entry.getValue(), false);
         }
     }
     

--- a/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -147,7 +147,9 @@ public class RedissonSessionManager extends ManagerBase {
                 
                 if (attrs.isEmpty() || !Boolean.valueOf(String.valueOf(attrs.get("session:isValid")))) {
                     log.info("Session " + id + " can't be found");
-                    return null;
+                    attrs = getMap(id).readAllMap();
+                     if(attrs.isEmpty())
+                    	 return null;
                 }
                 
                 RedissonSession session = (RedissonSession) createEmptySession();


### PR DESCRIPTION
retrieve session from redis when not able to find through traditional method. If redis contains the session and session is still valid then populate all the session attr with values from redis.