### PR TITLE
Add new option `addPrefixToSpringSessionRootKey` to separate session entities

### DIFF
--- a/redisson/src/main/java/org/redisson/spring/session/config/EnableRedissonHttpSession.java
+++ b/redisson/src/main/java/org/redisson/spring/session/config/EnableRedissonHttpSession.java
@@ -20,6 +20,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.redisson.spring.session.RedissonSessionRepository;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.session.MapSession;
@@ -55,7 +56,30 @@ import org.springframework.session.MapSession;
 public @interface EnableRedissonHttpSession {
 
     int maxInactiveIntervalInSeconds() default MapSession.DEFAULT_MAX_INACTIVE_INTERVAL_SECONDS;
-    
+
+    /**
+     * the key prefix to be add.
+     *
+     * <p>
+     * <strong>Note: the key prefix dose not add to the namespace of
+     * {@literal redisson_spring_session} by default, Set {@link #addPrefixToSpringSessionRootKey()}
+     * to {@literal true} to enable this.</strong>
+     * </p>
+     *
+     * @return the key prefix
+     */
     String keyPrefix() default "";
-    
+
+    /**
+     * weather to add {@link #keyPrefix()} to {@literal redisson_spring_session} or not.
+     *
+     * <p>
+     * This option is <strong>ignored</strong> when {@link #keyPrefix()} is blank.
+     * </p>
+     *
+     * @return weather or not
+     * @see RedissonSessionRepository.RedissonSession#RedissonSession()
+     */
+    boolean addPrefixToSpringSessionRootKey() default false;
+
 }

--- a/redisson/src/main/java/org/redisson/spring/session/config/RedissonHttpSessionConfiguration.java
+++ b/redisson/src/main/java/org/redisson/spring/session/config/RedissonHttpSessionConfiguration.java
@@ -43,6 +43,7 @@ public class RedissonHttpSessionConfiguration extends SpringHttpSessionConfigura
 
     private Integer maxInactiveIntervalInSeconds;
     private String keyPrefix;
+    private boolean addPrefixToSpringSessionRootKey;
     
     @Bean
     public RedissonSessionRepository sessionRepository(
@@ -50,6 +51,7 @@ public class RedissonHttpSessionConfiguration extends SpringHttpSessionConfigura
         RedissonSessionRepository repository = new RedissonSessionRepository(redissonClient, eventPublisher);
         if (StringUtils.hasText(keyPrefix)) {
             repository.setKeyPrefix(keyPrefix);
+            repository.setAddPrefixToSpringSessionRootKey(addPrefixToSpringSessionRootKey);
         }
         repository.setDefaultMaxInactiveInterval(maxInactiveIntervalInSeconds);
         return repository;
@@ -63,12 +65,17 @@ public class RedissonHttpSessionConfiguration extends SpringHttpSessionConfigura
         this.keyPrefix = keyPrefix;
     }
 
+    public void setAddPrefixToSpringSessionRootKey(boolean addPrefixToSpringSessionRootKey) {
+        this.addPrefixToSpringSessionRootKey = addPrefixToSpringSessionRootKey;
+    }
+
     @Override
     public void setImportMetadata(AnnotationMetadata importMetadata) {
         Map<String, Object> map = importMetadata.getAnnotationAttributes(EnableRedissonHttpSession.class.getName());
         AnnotationAttributes attrs = AnnotationAttributes.fromMap(map);
         keyPrefix = attrs.getString("keyPrefix");
         maxInactiveIntervalInSeconds = attrs.getNumber("maxInactiveIntervalInSeconds");
+        addPrefixToSpringSessionRootKey = attrs.getBoolean("addPrefixToSpringSessionRootKey");
     }
     
 }

--- a/redisson/src/test/java/org/redisson/RedisRunner.java
+++ b/redisson/src/test/java/org/redisson/RedisRunner.java
@@ -472,9 +472,8 @@ public class RedisRunner {
         this.randomDir = true;
         options.remove(REDIS_OPTIONS.DIR);
         makeRandomDefaultDir();
-        
-        
-        addConfigOption(REDIS_OPTIONS.DIR, "\"" + defaultDir + "\"");
+
+        addConfigOption(REDIS_OPTIONS.DIR, defaultDir);
         return this;
     }
 
@@ -871,7 +870,7 @@ public class RedisRunner {
             f.mkdirs();
             this.defaultDir = f.getAbsolutePath();
             if (RedissonRuntimeEnvironment.isWindows) {
-                defaultDir = defaultDir.replace("\\", "\\\\");
+                defaultDir = "\"" + defaultDir.replace("\\", "\\\\") + "\"";
             }
         }
     }

--- a/redisson/src/test/java/org/redisson/RedisRunner.java
+++ b/redisson/src/test/java/org/redisson/RedisRunner.java
@@ -473,7 +473,8 @@ public class RedisRunner {
         options.remove(REDIS_OPTIONS.DIR);
         makeRandomDefaultDir();
 
-        addConfigOption(REDIS_OPTIONS.DIR, defaultDir);
+
+        addConfigOption(REDIS_OPTIONS.DIR, "\"" + defaultDir + "\"");
         return this;
     }
 
@@ -870,7 +871,7 @@ public class RedisRunner {
             f.mkdirs();
             this.defaultDir = f.getAbsolutePath();
             if (RedissonRuntimeEnvironment.isWindows) {
-                defaultDir = "\"" + defaultDir.replace("\\", "\\\\") + "\"";
+                defaultDir = defaultDir.replace("\\", "\\\\");
             }
         }
     }


### PR DESCRIPTION
Add new option `addPrefixToSpringSessionRootKey` to separate session entities. Just like what org.redisson.tomcat.RedissonSessionManager does.

The default value is `false`, compatible with the original version.
If `keyPrefix` is blank, then the option is disabled.