### PR TITLE
Fix loop redirect error while "CLUSTER FAILOVER"

### DIFF
--- a/redisson/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
@@ -490,7 +490,7 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
         for (MasterSlaveEntry entry : client2entry.values()) {
             if (URIBuilder.compare(entry.getClient().getAddr(), addr)) {
                 return entry;
-    }
+            }
             if (entry.hasSlave(addr)) {
                 return entry;
             }
@@ -556,6 +556,11 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
         if (entry == null) {
             RedisNodeNotFoundException ex = new RedisNodeNotFoundException("Node: " + source + " hasn't been discovered yet");
             return RedissonPromise.newFailedFuture(ex);
+        }
+        if (source.getRedirect() != null &&
+                !URIBuilder.compare(entry.getClient().getAddr(), source.getAddr()) &&
+                entry.hasSlave(source.getAddr())) {
+            return entry.redirectedConnectionWriteOp(command, source.getAddr());
         }
         return entry.connectionWriteOp(command);
     }

--- a/redisson/src/main/java/org/redisson/connection/MasterSlaveEntry.java
+++ b/redisson/src/main/java/org/redisson/connection/MasterSlaveEntry.java
@@ -285,7 +285,7 @@ public class MasterSlaveEntry {
     public boolean hasSlave(URI addr) {
         return slaveBalancer.contains(addr);
     }
-    
+
     public int getAvailableClients() {
         return slaveBalancer.getAvailableClients();
     }
@@ -480,6 +480,10 @@ public class MasterSlaveEntry {
 
     public RFuture<RedisConnection> connectionWriteOp(RedisCommand<?> command) {
         return writeConnectionPool.get(command);
+    }
+
+    public RFuture<RedisConnection> redirectedConnectionWriteOp(RedisCommand<?> command, URI addr) {
+        return slaveBalancer.getConnection(command, addr);
     }
 
     public RFuture<RedisConnection> connectionReadOp(RedisCommand<?> command) {


### PR DESCRIPTION
This bug occurs between the time "CLUSTER FAILOVER" takes effect and the next time Redisson check "CLUSTER NODES". At that moment, Redisson try to access the old Master and get a response to redirect to the new Master, but the cluster nodes cache in Redisson indicates that the new Master should redirect to the old Master, and so the loop is formed.