### PR TITLE
Check if lock held by thread

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonLock.java
@@ -453,7 +453,12 @@ public class RedissonLock extends RedissonExpirable implements RLock {
 
     @Override
     public boolean isHeldByCurrentThread() {
-        RFuture<Boolean> future = commandExecutor.writeAsync(getName(), LongCodec.INSTANCE, RedisCommands.HEXISTS, getName(), getLockName(Thread.currentThread().getId()));
+        return isHeldByThread(Thread.currentThread().getId());
+    }
+
+    @Override
+    public boolean isHeldByThread(long threadId) {
+        final RFuture<Boolean> future = commandExecutor.writeAsync(getName(), LongCodec.INSTANCE, RedisCommands.HEXISTS, getName(), getLockName(threadId));
         return get(future);
     }
 

--- a/redisson/src/main/java/org/redisson/api/RLock.java
+++ b/redisson/src/main/java/org/redisson/api/RLock.java
@@ -101,6 +101,15 @@ public interface RLock extends Lock, RExpirable, RLockAsync {
     /**
      * Checks if this lock is held by the current thread
      *
+     * @param threadId Thread ID of locking thread
+     * @return <code>true</code> if held by given thread
+     * otherwise <code>false</code>
+     */
+    boolean isHeldByThread(long threadId);
+
+    /**
+     * Checks if this lock is held by the current thread
+     *
      * @return <code>true</code> if held by current thread
      * otherwise <code>false</code>
      */


### PR DESCRIPTION
Using executors or thread pools for acquiring and releasing locks, it is not trivially possible to ensure the thread acquiring the lock is the same thread releasing a lock.
We use locks with expiration and would like to ensure we still hold the lock before unlocking. This will help guarentee we had the lock all through the lock-to-unlock.
Since call to unlock returns `true` if the lock does not exist, there is no other way to find out if we still own the lock, we need this ability to pass the thread ID and check if the lock is still held by the thread. 