### PR TITLE
Allow checking if lock is held by a thread

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonLock.java
@@ -453,7 +453,12 @@ public class RedissonLock extends RedissonExpirable implements RLock {
 
     @Override
     public boolean isHeldByCurrentThread() {
-        RFuture<Boolean> future = commandExecutor.writeAsync(getName(), LongCodec.INSTANCE, RedisCommands.HEXISTS, getName(), getLockName(Thread.currentThread().getId()));
+        return isHeldByThread(Thread.currentThread().getId());
+    }
+
+    @Override
+    public boolean isHeldByThread(long threadId) {
+        final RFuture<Boolean> future = commandExecutor.writeAsync(getName(), LongCodec.INSTANCE, RedisCommands.HEXISTS, getName(), getLockName(threadId));
         return get(future);
     }
 

--- a/redisson/src/main/java/org/redisson/api/RLock.java
+++ b/redisson/src/main/java/org/redisson/api/RLock.java
@@ -101,6 +101,15 @@ public interface RLock extends Lock, RExpirable, RLockAsync {
     /**
      * Checks if this lock is held by the current thread
      *
+     * @param threadId Thread ID of locking thread
+     * @return <code>true</code> if held by given thread
+     * otherwise <code>false</code>
+     */
+    boolean isHeldByThread(long threadId);
+
+    /**
+     * Checks if this lock is held by the current thread
+     *
      * @return <code>true</code> if held by current thread
      * otherwise <code>false</code>
      */


### PR DESCRIPTION
…pools

* When using executors/thread pools to acquire and release locks, it is
helpful to be able to check if the lock is held by a specified thread and
not just the 'current thread'.