### PR TITLE
Fix RedissonSession to preserve attributes if Tomcat changes session id

### DIFF
--- a/redisson-tomcat/redisson-tomcat-6/src/main/java/org/redisson/tomcat/RedissonSession.java
+++ b/redisson-tomcat/redisson-tomcat-6/src/main/java/org/redisson/tomcat/RedissonSession.java
@@ -210,7 +210,7 @@ public class RedissonSession extends StandardSession {
         boolean oldValue = isNew;
         super.endAccess();
 
-        if (isNew != oldValue) {
+        if (isNew != oldValue && map != null) {
             fastPut(IS_NEW_ATTR, isNew);
         }
     }

--- a/redisson-tomcat/redisson-tomcat-6/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-6/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -132,21 +132,8 @@ public class RedissonSessionManager extends ManagerBase implements Lifecycle {
 
     @Override
     public Session createSession(String sessionId) {
-        RedissonSession session = (RedissonSession) createEmptySession();
-        
-        session.setNew(true);
-        session.setValid(true);
-        session.setCreationTime(System.currentTimeMillis());
-        session.setMaxInactiveInterval(((Context) getContainer()).getSessionTimeout() * 60);
-
-        if (sessionId == null) {
-            sessionId = generateSessionId();
-        }
-        
-        session.setManager(this);
-        session.setId(sessionId);
+    	RedissonSession session = (RedissonSession) super.createSession(sessionId);
         session.save();
-        
         return session;
     }
 
@@ -165,18 +152,18 @@ public class RedissonSessionManager extends ManagerBase implements Lifecycle {
         Session result = super.findSession(id);
         if (result == null) {
             if (id != null) {
-                Map<String, Object> attrs = new HashMap<String, Object>();
+                Map<String, Object> attrs = null;
                 try {
-                    if (readMode == ReadMode.MEMORY) {
+                if (readMode == ReadMode.MEMORY) {
                         attrs = getMap(id).readAllMap();
-                    } else {
+                } else {
                         attrs = getMap(id).getAll(RedissonSession.ATTRS);
-                    }
+                }
                 } catch (Exception e) {
                     log.error("Can't read session object by id " + id, e);
                 }
                 
-                if (attrs.isEmpty() || !Boolean.valueOf(String.valueOf(attrs.get("session:isValid")))) {
+                if (attrs == null || attrs.isEmpty() || !Boolean.valueOf(String.valueOf(attrs.get("session:isValid")))) {
                     log.info("Session " + id + " can't be found");
                     return null;
                 }

--- a/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSession.java
+++ b/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSession.java
@@ -210,7 +210,7 @@ public class RedissonSession extends StandardSession {
         boolean oldValue = isNew;
         super.endAccess();
 
-        if (isNew != oldValue) {
+        if (isNew != oldValue && map != null) {
             fastPut(IS_NEW_ATTR, isNew);
         }
     }

--- a/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -111,21 +111,8 @@ public class RedissonSessionManager extends ManagerBase {
 
     @Override
     public Session createSession(String sessionId) {
-        RedissonSession session = (RedissonSession) createEmptySession();
-        
-        session.setNew(true);
-        session.setValid(true);
-        session.setCreationTime(System.currentTimeMillis());
-        session.setMaxInactiveInterval(((Context) getContainer()).getSessionTimeout() * 60);
-
-        if (sessionId == null) {
-            sessionId = generateSessionId();
-        }
-        
-        session.setManager(this);
-        session.setId(sessionId);
+    	RedissonSession session = (RedissonSession) super.createSession(sessionId);
         session.save();
-        
         return session;
     }
 
@@ -144,18 +131,18 @@ public class RedissonSessionManager extends ManagerBase {
         Session result = super.findSession(id);
         if (result == null) {
             if (id != null) {
-                Map<String, Object> attrs = new HashMap<String, Object>();
+                Map<String, Object> attrs = null;
                 try {
-                    if (readMode == ReadMode.MEMORY) {
+                if (readMode == ReadMode.MEMORY) {
                         attrs = getMap(id).readAllMap();
-                    } else {
+                } else {
                         attrs = getMap(id).getAll(RedissonSession.ATTRS);
-                    }
+                }
                 } catch (Exception e) {
                     log.error("Can't read session object by id " + id, e);
                 }
                 
-                if (attrs.isEmpty() || !Boolean.valueOf(String.valueOf(attrs.get("session:isValid")))) {
+                if (attrs == null || attrs.isEmpty() || !Boolean.valueOf(String.valueOf(attrs.get("session:isValid")))) {
                     log.info("Session " + id + " can't be found");
                     return null;
                 }

--- a/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSession.java
+++ b/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSession.java
@@ -210,7 +210,7 @@ public class RedissonSession extends StandardSession {
         boolean oldValue = isNew;
         super.endAccess();
 
-        if (isNew != oldValue) {
+        if (isNew != oldValue && map != null) {
             fastPut(IS_NEW_ATTR, isNew);
         }
     }

--- a/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -110,21 +110,8 @@ public class RedissonSessionManager extends ManagerBase {
 
     @Override
     public Session createSession(String sessionId) {
-        RedissonSession session = (RedissonSession) createEmptySession();
-        
-        session.setNew(true);
-        session.setValid(true);
-        session.setCreationTime(System.currentTimeMillis());
-        session.setMaxInactiveInterval(getContext().getSessionTimeout() * 60);
-
-        if (sessionId == null) {
-            sessionId = generateSessionId();
-        }
-        
-        session.setManager(this);
-        session.setId(sessionId);
+    	RedissonSession session = (RedissonSession) super.createSession(sessionId);
         session.save();
-        
         return session;
     }
 
@@ -145,18 +132,18 @@ public class RedissonSessionManager extends ManagerBase {
         Session result = super.findSession(id);
         if (result == null) {
             if (id != null) {
-                Map<String, Object> attrs = new HashMap<String, Object>();
+                Map<String, Object> attrs = null;
                 try {
-                    if (readMode == ReadMode.MEMORY) {
+                if (readMode == ReadMode.MEMORY) {
                         attrs = getMap(id).readAllMap();
-                    } else {
+                } else {
                         attrs = getMap(id).getAll(RedissonSession.ATTRS);
-                    }
+                }
                 } catch (Exception e) {
                     log.error("Can't read session object by id " + id, e);
                 }
                 
-                if (attrs.isEmpty() || !Boolean.valueOf(String.valueOf(attrs.get("session:isValid")))) {
+                if (attrs == null || attrs.isEmpty() || !Boolean.valueOf(String.valueOf(attrs.get("session:isValid")))) {
                     log.info("Session " + id + " can't be found");
                     return null;
                 }

--- a/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/RedissonSession.java
+++ b/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/RedissonSession.java
@@ -210,7 +210,7 @@ public class RedissonSession extends StandardSession {
         boolean oldValue = isNew;
         super.endAccess();
 
-        if (isNew != oldValue) {
+        if (isNew != oldValue && map != null) {
             fastPut(IS_NEW_ATTR, isNew);
         }
     }

--- a/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -110,21 +110,8 @@ public class RedissonSessionManager extends ManagerBase {
 
     @Override
     public Session createSession(String sessionId) {
-        RedissonSession session = (RedissonSession) createEmptySession();
-        
-        session.setNew(true);
-        session.setValid(true);
-        session.setCreationTime(System.currentTimeMillis());
-        session.setMaxInactiveInterval(getContext().getSessionTimeout() * 60);
-
-        if (sessionId == null) {
-            sessionId = generateSessionId();
-        }
-        
-        session.setManager(this);
-        session.setId(sessionId);
+    	RedissonSession session = (RedissonSession) super.createSession(sessionId);
         session.save();
-        
         return session;
     }
 
@@ -143,18 +130,18 @@ public class RedissonSessionManager extends ManagerBase {
         Session result = super.findSession(id);
         if (result == null) {
             if (id != null) {
-                Map<String, Object> attrs = new HashMap<String, Object>();
+                Map<String, Object> attrs = null;
                 try {
-                    if (readMode == ReadMode.MEMORY) {
+                if (readMode == ReadMode.MEMORY) {
                         attrs = getMap(id).readAllMap();
-                    } else {
+                } else {
                         attrs = getMap(id).getAll(RedissonSession.ATTRS);
-                    }
+                }
                 } catch (Exception e) {
                     log.error("Can't read session object by id " + id, e);
                 }
                 
-                if (attrs.isEmpty() || !Boolean.valueOf(String.valueOf(attrs.get("session:isValid")))) {
+                if (attrs == null || attrs.isEmpty() || !Boolean.valueOf(String.valueOf(attrs.get("session:isValid")))) {
                     log.info("Session " + id + " can't be found");
                     return null;
                 }

--- a/redisson/src/main/java/org/redisson/cache/LocalCacheView.java
+++ b/redisson/src/main/java/org/redisson/cache/LocalCacheView.java
@@ -65,6 +65,11 @@ public class LocalCacheView<K, V> {
                 public K next() {
                     return (K) iter.next().getKey();
                 }
+                
+                @Override
+                public void remove() {
+                	iter.remove();
+                }
             };
         }
 
@@ -111,6 +116,11 @@ public class LocalCacheView<K, V> {
                 public V next() {
                     return (V) iter.next().getValue();
                 }
+                
+                @Override
+                public void remove() {
+                	iter.remove();
+                }
             };
         }
 
@@ -152,6 +162,11 @@ public class LocalCacheView<K, V> {
                     CacheValue e = iter.next();
                     return new AbstractMap.SimpleEntry<K, V>((K)e.getKey(), (V)e.getValue());
                 }
+                
+                @Override
+                public void remove() {
+                	iter.remove();
+                }
             };
         }
 
@@ -170,7 +185,8 @@ public class LocalCacheView<K, V> {
             if (o instanceof Map.Entry) {
                 Map.Entry<?,?> e = (Map.Entry<?,?>) o;
                 CacheKey cacheKey = toCacheKey(e.getKey());
-                return cache.remove(cacheKey, new CacheValue(e.getKey(), e.getValue()));
+                CacheValue entry = cache.remove(cacheKey);
+				return entry != null;
             }
             return false;
         }


### PR DESCRIPTION
1) fix compilation issue for sources in redisson master branch
2) Re apply http session timeout to redis when we update session attribute (set, remove) as redis is going to remove key timeout when key value is updated. Override session recycle method to nullify map and topic. Use super createSession to allow tomcat to track max session active if used. In findSession do not create extra HashMap for attrs variable as it will be initialized in if-else block anyway. Preserve session attributes in case tomcat changes the session id.

Explanation of the issue is at the end of https://github.com/redisson/redisson/pull/1618