### PR TITLE
fix infinite loop in RedLock or MultiLock

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonMultiLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonMultiLock.java
@@ -82,9 +82,9 @@ public class RedissonMultiLock implements Lock {
         long waitTime = -1;
         if (leaseTime == -1) {
             waitTime = baseWaitTime;
-            unit = TimeUnit.MILLISECONDS;
         } else {
-            waitTime = unit.toMillis(leaseTime);
+            leaseTime = unit.toMillis(leaseTime);
+            waitTime = leaseTime;
             if (waitTime <= 2000) {
                 waitTime = 2000;
             } else if (waitTime <= baseWaitTime) {
@@ -92,11 +92,10 @@ public class RedissonMultiLock implements Lock {
             } else {
                 waitTime = ThreadLocalRandom.current().nextLong(baseWaitTime, waitTime);
             }
-            waitTime = unit.convert(waitTime, TimeUnit.MILLISECONDS);
         }
 
         RPromise<Void> result = new RedissonPromise<Void>();
-        tryLockAsync(leaseTime, unit, waitTime, result);
+        tryLockAsync(leaseTime, TimeUnit.MILLISECONDS, waitTime, result);
         return result;
     }
 
@@ -129,9 +128,9 @@ public class RedissonMultiLock implements Lock {
         long waitTime = -1;
         if (leaseTime == -1) {
             waitTime = baseWaitTime;
-            unit = TimeUnit.MILLISECONDS;
         } else {
-            waitTime = unit.toMillis(leaseTime);
+            leaseTime = unit.toMillis(leaseTime);
+            waitTime = leaseTime;
             if (waitTime <= 2000) {
                 waitTime = 2000;
             } else if (waitTime <= baseWaitTime) {
@@ -139,11 +138,10 @@ public class RedissonMultiLock implements Lock {
             } else {
                 waitTime = ThreadLocalRandom.current().nextLong(baseWaitTime, waitTime);
             }
-            waitTime = unit.convert(waitTime, TimeUnit.MILLISECONDS);
         }
         
         while (true) {
-            if (tryLock(waitTime, leaseTime, unit)) {
+            if (tryLock(waitTime, leaseTime, TimeUnit.MILLISECONDS)) {
                 return;
             }
         }

--- a/redisson/src/test/java/org/redisson/RedissonRedLockTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonRedLockTest.java
@@ -23,7 +23,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class RedissonRedLockTest {
 
     @Test
-    public void testLockLeasetime() throws IOException, InterruptedException {
+    public void testLockLeasetimeWithMilliSeconds() throws IOException, InterruptedException {
+        testLockLeasetime(2000, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    public void testLockLeasetimeWithSeconds() throws IOException, InterruptedException {
+        testLockLeasetime(2, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testLockLeasetimeWithMinutes() throws IOException, InterruptedException {
+        testLockLeasetime(1, TimeUnit.MINUTES);
+    }
+
+    private void testLockLeasetime(final long leaseTime, final TimeUnit unit) throws IOException, InterruptedException {
         RedisProcess redis1 = redisTestMultilockInstance();
         RedisProcess redis2 = redisTestMultilockInstance();
         
@@ -47,7 +61,7 @@ public class RedissonRedLockTest {
             executor.submit(() -> {
                 for (int j = 0; j < 5; j++) {
                     try {
-                        lock.lock(2, TimeUnit.SECONDS);
+                        lock.lock(leaseTime, unit);
                         int nextValue = counter.get() + 1;
                         Thread.sleep(1000);
                         counter.set(nextValue);


### PR DESCRIPTION
 - How to reproduce this BUG?
A: In org.redisson.RedissonRedLockTest.testLockLeasetime(),
do this change:
`lock.lock(2, TimeUnit.SECONDS);`
to
`lock.lock(1, TimeUnit.MINUTES);`

- The cause?
A: when we calculate waitTime, if leaseTime is greater than baseWaitTime(this value is locks.size() * 1500), we will get a random between baseWaitTime and leaseTime, but we may get a value less than a TimeUnit (such as MINUTE), then we get 0 as waitTime, so there will be infinite loop and 100% CPU used.