### PR TITLE
Do not wrap in square brackets already wrapped IPv6 addresses

### DIFF
--- a/redisson/src/main/java/org/redisson/connection/SentinelConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/SentinelConnectionManager.java
@@ -437,7 +437,7 @@ public class SentinelConnectionManager extends MasterSlaveConnectionManager {
     }
 
     private String createAddress(String host, Object port) {
-        if (host.contains(":")) {
+        if (host.contains(":") && !host.startsWith("[")) {
             host = "[" + host + "]";
         }
         return "redis://" + host + ":" + port;


### PR DESCRIPTION
There is an issue in SentinelConnectionManager.slaveDown() method, that tries to convert to IPv6 format host that already was converted earlier.