### PR TITLE
Bug/avoid object mapper changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+Differences from official Redisson
+====
+Due to this issue: https://github.com/redisson/redisson/issues/2010, we ignore class loader changes for object mappers.
+
 Redisson: Redis Java client and In-Memory Data Grid
 ====
 [Quick start](https://github.com/redisson/redisson#quick-start) | [Documentation](https://github.com/redisson/redisson/wiki) | [Javadocs](http://www.javadoc.io/doc/org.redisson/redisson/3.10.3) | [Changelog](https://github.com/redisson/redisson/blob/master/CHANGELOG.md) | [Code examples](https://github.com/redisson/redisson-examples) | [FAQs](https://github.com/redisson/redisson/wiki/16.-FAQ) | [Report an issue](https://github.com/redisson/redisson/issues/new) | **[Redisson PRO](https://redisson.pro)**

--- a/redisson/pom.xml
+++ b/redisson/pom.xml
@@ -360,10 +360,10 @@
                 </configuration>
                 <dependencies>
                     <dependency>
-                       <groupId>com.puppycrawl.tools</groupId>
-                       <artifactId>checkstyle</artifactId>
-                       <version>[8.18,)</version>
-                  </dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>8.17</version>
+                    </dependency>
                 </dependencies>
             </plugin>
 

--- a/redisson/src/main/java/org/redisson/codec/JsonJacksonCodec.java
+++ b/redisson/src/main/java/org/redisson/codec/JsonJacksonCodec.java
@@ -41,7 +41,6 @@ import com.fasterxml.jackson.databind.ObjectMapper.DefaultTypeResolverBuilder;
 import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.jsontype.TypeResolverBuilder;
-import com.fasterxml.jackson.databind.type.TypeFactory;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
@@ -109,8 +108,9 @@ public class JsonJacksonCodec extends BaseCodec {
     }
     
     protected static ObjectMapper createObjectMapper(ClassLoader classLoader, ObjectMapper om) {
-        TypeFactory tf = TypeFactory.defaultInstance().withClassLoader(classLoader);
-        om.setTypeFactory(tf);
+        // Should not change the class loader, this changes the behavior of the ObjectMapper and cannot deserialize Optionals, for example
+//        TypeFactory tf = TypeFactory.defaultInstance().withClassLoader(classLoader);
+//        om.setTypeFactory(tf);
         return om;
     }
 


### PR DESCRIPTION
Avoid changing the object mapper class loader. This messes up the object mapper's ability to handle Optionals.

See issue: https://github.com/redisson/redisson/issues/2010