### PR TITLE
fixed RedissonSessionRepository according to Spring documentation

### DIFF
--- a/redisson/src/main/java/org/redisson/spring/session/RedissonSessionRepository.java
+++ b/redisson/src/main/java/org/redisson/spring/session/RedissonSessionRepository.java
@@ -136,10 +136,9 @@ public class RedissonSessionRepository implements FindByIndexNameSessionReposito
             if (map != null) {
                 map.fastPut(attributeName, attributeValue);
                 
-                String principalSessionAttr = getSessionAttrNameKey(PRINCIPAL_NAME_INDEX_NAME);
                 String securityPrincipalSessionAttr = getSessionAttrNameKey(SPRING_SECURITY_CONTEXT);
                 
-                if (attributeName.equals(principalSessionAttr)
+                if (attributeName.equals(PRINCIPAL_NAME_INDEX_NAME)
                         || attributeName.equals(securityPrincipalSessionAttr)) {
                     // remove old
                     if (principalName != null) {


### PR DESCRIPTION
According to the [documentation](https://docs.spring.io/spring-session/docs/current/reference/html5/#api-findbyindexnamesessionrepository) setting a session attribute with the name of `FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME` should be enough to be able to find this session later with `RedissonSessionRepository.findByIndexNameAndIndexValue` but actually every time one needs to put the prefix `session-attr:` which violates the original contract