### PR TITLE
scan get results in an unperdictable order on redis-cluster mode

### DIFF
--- a/redisson/src/main/java/org/redisson/client/RedisClient.java
+++ b/redisson/src/main/java/org/redisson/client/RedisClient.java
@@ -368,6 +368,11 @@ public final class RedisClient {
     }
 
     @Override
+    public int  hashCode() {
+        return uri.hashCode();
+    }
+
+    @Override
     public String toString() {
         return "[addr=" + uri + "]";
     }

--- a/redisson/src/main/java/org/redisson/client/RedisClient.java
+++ b/redisson/src/main/java/org/redisson/client/RedisClient.java
@@ -368,11 +368,6 @@ public final class RedisClient {
     }
 
     @Override
-    public int  hashCode() {
-        return uri.hashCode();
-    }
-
-    @Override
     public String toString() {
         return "[addr=" + uri + "]";
     }


### PR DESCRIPTION
# 2036 A hashcode method leads to an 'ordered' result when scanning on a redis cluster