### PR TITLE
fix bug: in RedissonNodeConfig constructor with oldConf, miss mapRedu…

### DIFF
--- a/redisson/src/main/java/org/redisson/config/RedissonNodeConfig.java
+++ b/redisson/src/main/java/org/redisson/config/RedissonNodeConfig.java
@@ -46,6 +46,7 @@ public class RedissonNodeConfig extends Config {
         super(oldConf);
         this.executorServiceWorkers = new HashMap<String, Integer>(oldConf.executorServiceWorkers);
         this.redissonNodeInitializer = oldConf.redissonNodeInitializer;
+        this.mapReduceWorkers = oldConf.mapReduceWorkers;
     }
     
     /**


### PR DESCRIPTION
bug description: In RedissonNodeConfig constructor with oldConf, miss mapReduceWorkers value set.
I want to set mapReduceWorkers to -1 using code:
```
    RedissonNodeConfig config = new RedissonNodeConfig();
    config.setMapReduceWorkers(-1);
    RedissonNode redissonNode = RedissonNode.create(config, redissonClient);
```
however, I found config instance in redissonNode still has mapReduceWorkers with 0 value. It seems forgetting to set mapReduceWorkers value.