### PR TITLE
fixed bug when config redis password empty

### DIFF
--- a/redisson/src/main/java/org/redisson/client/handler/BaseConnectionHandler.java
+++ b/redisson/src/main/java/org/redisson/client/handler/BaseConnectionHandler.java
@@ -64,7 +64,7 @@ public abstract class BaseConnectionHandler<C extends RedisConnection> extends C
         List<RFuture<Object>> futures = new ArrayList<RFuture<Object>>();
 
         RedisClientConfig config = redisClient.getConfig();
-        if (config.getPassword() != null) {
+        if (config.getPassword() != null && !config.getPassword().equals("")) {
             RFuture<Object> future = connection.async(RedisCommands.AUTH, config.getPassword());
             futures.add(future);
         }


### PR DESCRIPTION
when the config file config the redis password empty，redisson will throw a exception