### PR TITLE
Fixed - RRemoteService.getFreeWorkers api will remove the entry from remoteMap, then only get zero.

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonRemoteService.java
+++ b/redisson/src/main/java/org/redisson/RedissonRemoteService.java
@@ -136,7 +136,7 @@ public class RedissonRemoteService extends BaseRemoteService implements RRemoteS
     
     @Override
     public int getFreeWorkers(Class<?> remoteInterface) {
-        Entry entry = remoteMap.remove(remoteInterface);
+        Entry entry = remoteMap.get(remoteInterface);
         if (entry == null) {
             return 0;
         }


### PR DESCRIPTION
RRemoteService.getFreeWorkers api code issue.
it should be `Entry entry = remoteMap.get(remoteInterface)` 
#2151