### PR TITLE
UpdateValve should be installed only once, remove MessageListener from topic when SessionManager stopInternal is invoked #2178

### DIFF
--- a/redisson-tomcat/redisson-tomcat-6/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-6/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -382,7 +382,7 @@ public class RedissonSessionManager extends ManagerBase implements Lifecycle {
         synchronized (pipeline) {
             contextInUse.remove(((Context) getContainer()).getName());
             //remove valves when all of the RedissonSessionManagers (web apps) are not in use anymore
-            if (contextInUse.size() == 0) {
+            if (contextInUse.isEmpty()) {
                 if (updateValve != null) {
                     pipeline.removeValve(updateValve);
                     updateValve = null;

--- a/redisson-tomcat/redisson-tomcat-6/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-6/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -279,13 +279,13 @@ public class RedissonSessionManager extends ManagerBase implements Lifecycle {
         Pipeline pipeline = getEngine().getPipeline();
         synchronized (pipeline) {
             contextInUse.add(((Context) getContainer()).getName());
-	        if (updateMode == UpdateMode.AFTER_REQUEST) {
-	            if (updateValve == null) {
-		            updateValve = new UpdateValve();
-		            pipeline.addValve(updateValve);
-	            }
-	        }
-        }		
+            if (updateMode == UpdateMode.AFTER_REQUEST) {
+                if (updateValve == null) {
+                    updateValve = new UpdateValve();
+                    pipeline.addValve(updateValve);
+                }
+            }
+        }
         
         if (readMode == ReadMode.MEMORY || broadcastSessionEvents) {
             RTopic updatesTopic = getTopic();
@@ -381,18 +381,18 @@ public class RedissonSessionManager extends ManagerBase implements Lifecycle {
         Pipeline pipeline = getEngine().getPipeline();
         synchronized (pipeline) {
             contextInUse.remove(((Context) getContainer()).getName());
-	        //remove valves when all of the RedissonSessionManagers (web apps) are not in use anymore
-	        if (contextInUse.size() == 0) {
-		        if (updateValve != null) {
-		        	pipeline.removeValve(updateValve);
-		            updateValve = null;
-		        }
-	        }
+            //remove valves when all of the RedissonSessionManagers (web apps) are not in use anymore
+            if (contextInUse.size() == 0) {
+                if (updateValve != null) {
+                    pipeline.removeValve(updateValve);
+                    updateValve = null;
+                }
+            }
         }
         
         if (messageListener != null) {
-        	 RTopic updatesTopic = getTopic();
-        	 updatesTopic.removeListener(messageListener);
+             RTopic updatesTopic = getTopic();
+             updatesTopic.removeListener(messageListener);
         }
 
         codecToUse = null;

--- a/redisson-tomcat/redisson-tomcat-6/src/main/java/org/redisson/tomcat/UpdateValve.java
+++ b/redisson-tomcat/redisson-tomcat-6/src/main/java/org/redisson/tomcat/UpdateValve.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 
 import javax.servlet.ServletException;
 
+import org.apache.catalina.Manager;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
 import org.apache.catalina.valves.ValveBase;
@@ -32,11 +33,9 @@ import org.apache.catalina.valves.ValveBase;
 public class UpdateValve extends ValveBase {
 
     private static final String ALREADY_FILTERED_NOTE = UpdateValve.class.getName() + ".ALREADY_FILTERED_NOTE";
-    private final RedissonSessionManager manager;
     
-    public UpdateValve(RedissonSessionManager manager) {
+    public UpdateValve() {
         super();
-        this.manager = manager;
     }
 
     @Override
@@ -52,7 +51,10 @@ public class UpdateValve extends ValveBase {
                 try {
                     ClassLoader applicationClassLoader = request.getContext().getLoader().getClassLoader();
                     Thread.currentThread().setContextClassLoader(applicationClassLoader);
-                    manager.store(request.getSession(false));
+                    Manager manager = request.getContext().getManager();
+                    if (manager instanceof RedissonSessionManager) {
+                    	((RedissonSessionManager)manager).store(request.getSession(false));
+                    }
                 } finally {
                     Thread.currentThread().setContextClassLoader(classLoader);
                 }

--- a/redisson-tomcat/redisson-tomcat-6/src/main/java/org/redisson/tomcat/UpdateValve.java
+++ b/redisson-tomcat/redisson-tomcat-6/src/main/java/org/redisson/tomcat/UpdateValve.java
@@ -52,9 +52,7 @@ public class UpdateValve extends ValveBase {
                     ClassLoader applicationClassLoader = request.getContext().getLoader().getClassLoader();
                     Thread.currentThread().setContextClassLoader(applicationClassLoader);
                     Manager manager = request.getContext().getManager();
-                    if (manager instanceof RedissonSessionManager) {
-                    	((RedissonSessionManager)manager).store(request.getSession(false));
-                    }
+                    ((RedissonSessionManager)manager).store(request.getSession(false));
                 } finally {
                     Thread.currentThread().setContextClassLoader(classLoader);
                 }

--- a/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -259,13 +259,13 @@ public class RedissonSessionManager extends ManagerBase {
         Pipeline pipeline = getEngine().getPipeline();
         synchronized (pipeline) {
             contextInUse.add(((Context) getContainer()).getName());
-	        if (updateMode == UpdateMode.AFTER_REQUEST) {
-	            if (updateValve == null) {
-		            updateValve = new UpdateValve();
-		            pipeline.addValve(updateValve);
-	            }
-	        }
-        }		
+            if (updateMode == UpdateMode.AFTER_REQUEST) {
+                if (updateValve == null) {
+                    updateValve = new UpdateValve();
+                    pipeline.addValve(updateValve);
+                }
+            }
+        }
         
         if (readMode == ReadMode.MEMORY || broadcastSessionEvents) {
             RTopic updatesTopic = getTopic();
@@ -366,18 +366,18 @@ public class RedissonSessionManager extends ManagerBase {
         Pipeline pipeline = getEngine().getPipeline();
         synchronized (pipeline) {
             contextInUse.remove(((Context) getContainer()).getName());
-	        //remove valves when all of the RedissonSessionManagers (web apps) are not in use anymore
-	        if (contextInUse.size() == 0) {
-		        if (updateValve != null) {
-		        	pipeline.removeValve(updateValve);
-		            updateValve = null;
-		        }
-	        }
+            //remove valves when all of the RedissonSessionManagers (web apps) are not in use anymore
+            if (contextInUse.size() == 0) {
+                if (updateValve != null) {
+                    pipeline.removeValve(updateValve);
+                    updateValve = null;
+                }
+            }
         }
         
         if (messageListener != null) {
-        	 RTopic updatesTopic = getTopic();
-        	 updatesTopic.removeListener(messageListener);
+             RTopic updatesTopic = getTopic();
+             updatesTopic.removeListener(messageListener);
         }
 
         codecToUse = null;

--- a/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -17,9 +17,12 @@ package org.redisson.tomcat;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.servlet.http.HttpSession;
 
@@ -68,8 +71,12 @@ public class RedissonSessionManager extends ManagerBase {
 
     private final String nodeId = UUID.randomUUID().toString();
 
-    private UpdateValve updateValve;
+    private static UpdateValve updateValve;
 
+    private static Set<String> contextWithInstalledValves = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
+
+    private MessageListener messageListener;
+    
     private Codec codecToUse;
 
     public String getNodeId() { return nodeId; }
@@ -251,16 +258,17 @@ public class RedissonSessionManager extends ManagerBase {
         
         if (updateMode == UpdateMode.AFTER_REQUEST) {
             Pipeline pipeline = getEngine().getPipeline();
-            if (updateValve != null) { // in case startInternal is called without stopInternal cleaning the updateValve
-                pipeline.removeValve(updateValve);
+            synchronized (pipeline) {
+            	contextWithInstalledValves.add(((Context) getContainer()).getName());
+            	
+	            updateValve = new UpdateValve();
+	            pipeline.addValve(updateValve);
             }
-            updateValve = new UpdateValve(this);
-            pipeline.addValve(updateValve);			
         }
         
         if (readMode == ReadMode.MEMORY || broadcastSessionEvents) {
             RTopic updatesTopic = getTopic();
-            updatesTopic.addListener(AttributeMessage.class, new MessageListener<AttributeMessage>() {
+            messageListener = new MessageListener<AttributeMessage>() {
                 
                 @Override
                 public void onMessage(CharSequence channel, AttributeMessage msg) {
@@ -319,7 +327,9 @@ public class RedissonSessionManager extends ManagerBase {
                         log.error("Unable to handle topic message", e);
                     }
                 }
-            });
+            };
+            
+            updatesTopic.addListener(AttributeMessage.class, messageListener);
         }
         
         setState(LifecycleState.STARTING);
@@ -353,8 +363,20 @@ public class RedissonSessionManager extends ManagerBase {
         setState(LifecycleState.STOPPING);
         
         if (updateValve != null) {
-            getEngine().getPipeline().removeValve(updateValve);
-            updateValve = null;
+            Pipeline pipeline = getEngine().getPipeline();
+            synchronized (pipeline) {
+            	contextWithInstalledValves.remove(((Context) getContainer()).getName());
+            	//remove valves when all of the RedissonSessionManagers (web apps) are not in use anymore
+    	        if (contextWithInstalledValves.size() == 0) {
+	            	pipeline.removeValve(updateValve);
+		            updateValve = null;
+    	        }
+            }
+        }
+        
+        if (messageListener != null) {
+        	 RTopic updatesTopic = getTopic();
+        	 updatesTopic.removeListener(messageListener);
         }
 
         codecToUse = null;

--- a/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -73,7 +73,7 @@ public class RedissonSessionManager extends ManagerBase {
 
     private static UpdateValve updateValve;
 
-    private static Set<String> contextWithInstalledValves = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
+    private static Set<String> contextInUse = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
 
     private MessageListener messageListener;
     
@@ -256,15 +256,16 @@ public class RedissonSessionManager extends ManagerBase {
             throw new LifecycleException(e);
         }
         
-        if (updateMode == UpdateMode.AFTER_REQUEST) {
-            Pipeline pipeline = getEngine().getPipeline();
-            synchronized (pipeline) {
-            	contextWithInstalledValves.add(((Context) getContainer()).getName());
-            	
-	            updateValve = new UpdateValve();
-	            pipeline.addValve(updateValve);
-            }
-        }
+        Pipeline pipeline = getEngine().getPipeline();
+        synchronized (pipeline) {
+            contextInUse.add(((Context) getContainer()).getName());
+	        if (updateMode == UpdateMode.AFTER_REQUEST) {
+	            if (updateValve == null) {
+		            updateValve = new UpdateValve();
+		            pipeline.addValve(updateValve);
+	            }
+	        }
+        }		
         
         if (readMode == ReadMode.MEMORY || broadcastSessionEvents) {
             RTopic updatesTopic = getTopic();
@@ -362,16 +363,16 @@ public class RedissonSessionManager extends ManagerBase {
         
         setState(LifecycleState.STOPPING);
         
-        if (updateValve != null) {
-            Pipeline pipeline = getEngine().getPipeline();
-            synchronized (pipeline) {
-            	contextWithInstalledValves.remove(((Context) getContainer()).getName());
-            	//remove valves when all of the RedissonSessionManagers (web apps) are not in use anymore
-    	        if (contextWithInstalledValves.size() == 0) {
-	            	pipeline.removeValve(updateValve);
+        Pipeline pipeline = getEngine().getPipeline();
+        synchronized (pipeline) {
+            contextInUse.remove(((Context) getContainer()).getName());
+	        //remove valves when all of the RedissonSessionManagers (web apps) are not in use anymore
+	        if (contextInUse.size() == 0) {
+		        if (updateValve != null) {
+		        	pipeline.removeValve(updateValve);
 		            updateValve = null;
-    	        }
-            }
+		        }
+	        }
         }
         
         if (messageListener != null) {

--- a/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -367,7 +367,7 @@ public class RedissonSessionManager extends ManagerBase {
         synchronized (pipeline) {
             contextInUse.remove(((Context) getContainer()).getName());
             //remove valves when all of the RedissonSessionManagers (web apps) are not in use anymore
-            if (contextInUse.size() == 0) {
+            if (contextInUse.isEmpty()) {
                 if (updateValve != null) {
                     pipeline.removeValve(updateValve);
                     updateValve = null;

--- a/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/UpdateValve.java
+++ b/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/UpdateValve.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 
 import javax.servlet.ServletException;
 
+import org.apache.catalina.Manager;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
 import org.apache.catalina.valves.ValveBase;
@@ -32,11 +33,9 @@ import org.apache.catalina.valves.ValveBase;
 public class UpdateValve extends ValveBase {
 
     private static final String ALREADY_FILTERED_NOTE = UpdateValve.class.getName() + ".ALREADY_FILTERED_NOTE";
-    private final RedissonSessionManager manager;
     
-    public UpdateValve(RedissonSessionManager manager) {
+    public UpdateValve() {
         super(true);
-        this.manager = manager;
     }
 
     @Override
@@ -52,7 +51,10 @@ public class UpdateValve extends ValveBase {
                 try {
                     ClassLoader applicationClassLoader = request.getContext().getLoader().getClassLoader();
                     Thread.currentThread().setContextClassLoader(applicationClassLoader);
-                    manager.store(request.getSession(false));
+                    Manager manager = request.getContext().getManager();
+                    if (manager instanceof RedissonSessionManager) {
+                    	((RedissonSessionManager)manager).store(request.getSession(false));
+                    }
                 } finally {
                     Thread.currentThread().setContextClassLoader(classLoader);
                 }

--- a/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/UpdateValve.java
+++ b/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/UpdateValve.java
@@ -52,9 +52,7 @@ public class UpdateValve extends ValveBase {
                     ClassLoader applicationClassLoader = request.getContext().getLoader().getClassLoader();
                     Thread.currentThread().setContextClassLoader(applicationClassLoader);
                     Manager manager = request.getContext().getManager();
-                    if (manager instanceof RedissonSessionManager) {
-                    	((RedissonSessionManager)manager).store(request.getSession(false));
-                    }
+                    ((RedissonSessionManager)manager).store(request.getSession(false));
                 } finally {
                     Thread.currentThread().setContextClassLoader(classLoader);
                 }

--- a/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -17,9 +17,12 @@ package org.redisson.tomcat;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.servlet.http.HttpSession;
 
@@ -67,8 +70,12 @@ public class RedissonSessionManager extends ManagerBase {
 
     private final String nodeId = UUID.randomUUID().toString();
 
-    private UpdateValve updateValve;
+    private static UpdateValve updateValve;
 
+    private static Set<String> contextWithInstalledValves = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
+
+    private MessageListener messageListener;
+    
     private Codec codecToUse;
 
     public String getNodeId() { return nodeId; }
@@ -249,16 +256,17 @@ public class RedissonSessionManager extends ManagerBase {
         
         if (updateMode == UpdateMode.AFTER_REQUEST) {
             Pipeline pipeline = getEngine().getPipeline();
-            if (updateValve != null) { // in case startInternal is called without stopInternal cleaning the updateValve
-                pipeline.removeValve(updateValve);
+            synchronized (pipeline) {
+            	contextWithInstalledValves.add(getContext().getName());
+            	
+	            updateValve = new UpdateValve();
+	            pipeline.addValve(updateValve);
             }
-            updateValve = new UpdateValve(this);
-            pipeline.addValve(updateValve);			
         }
         
         if (readMode == ReadMode.MEMORY || broadcastSessionEvents) {
             RTopic updatesTopic = getTopic();
-            updatesTopic.addListener(AttributeMessage.class, new MessageListener<AttributeMessage>() {
+            messageListener = new MessageListener<AttributeMessage>() {
                 
                 @Override
                 public void onMessage(CharSequence channel, AttributeMessage msg) {
@@ -317,7 +325,9 @@ public class RedissonSessionManager extends ManagerBase {
                         log.error("Unable to handle topic message", e);
                     }
                 }
-            });
+            };
+            
+            updatesTopic.addListener(AttributeMessage.class, messageListener);
         }
         
         setState(LifecycleState.STARTING);
@@ -351,8 +361,20 @@ public class RedissonSessionManager extends ManagerBase {
         setState(LifecycleState.STOPPING);
         
         if (updateValve != null) {
-            getEngine().getPipeline().removeValve(updateValve);
-            updateValve = null;
+            Pipeline pipeline = getEngine().getPipeline();
+            synchronized (pipeline) {
+            	contextWithInstalledValves.remove(getContext().getName());
+            	//remove valves when all of the RedissonSessionManagers (web apps) are not in use anymore
+    	        if (contextWithInstalledValves.size() == 0) {
+	            	pipeline.removeValve(updateValve);
+		            updateValve = null;
+    	        }
+            }
+        }
+        
+        if (messageListener != null) {
+        	 RTopic updatesTopic = getTopic();
+        	 updatesTopic.removeListener(messageListener);
         }
 
         codecToUse = null;

--- a/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -257,13 +257,13 @@ public class RedissonSessionManager extends ManagerBase {
         Pipeline pipeline = getEngine().getPipeline();
         synchronized (pipeline) {
             contextInUse.add(getContext().getName());
-	        if (updateMode == UpdateMode.AFTER_REQUEST) {
-	            if (updateValve == null) {
-		            updateValve = new UpdateValve();
-		            pipeline.addValve(updateValve);
-	            }
-	        }
-        }		
+            if (updateMode == UpdateMode.AFTER_REQUEST) {
+                if (updateValve == null) {
+                    updateValve = new UpdateValve();
+                    pipeline.addValve(updateValve);
+                }
+            }
+        }
         
         if (readMode == ReadMode.MEMORY || broadcastSessionEvents) {
             RTopic updatesTopic = getTopic();
@@ -364,18 +364,18 @@ public class RedissonSessionManager extends ManagerBase {
         Pipeline pipeline = getEngine().getPipeline();
         synchronized (pipeline) {
             contextInUse.remove(getContext().getName());
-	        //remove valves when all of the RedissonSessionManagers (web apps) are not in use anymore
-	        if (contextInUse.size() == 0) {
-		        if (updateValve != null) {
-		        	pipeline.removeValve(updateValve);
-		            updateValve = null;
-		        }
-	        }
+            //remove valves when all of the RedissonSessionManagers (web apps) are not in use anymore
+            if (contextInUse.size() == 0) {
+                if (updateValve != null) {
+                    pipeline.removeValve(updateValve);
+                    updateValve = null;
+                }
+            }
         }
         
         if (messageListener != null) {
-        	 RTopic updatesTopic = getTopic();
-        	 updatesTopic.removeListener(messageListener);
+             RTopic updatesTopic = getTopic();
+             updatesTopic.removeListener(messageListener);
         }
 
         codecToUse = null;

--- a/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -365,7 +365,7 @@ public class RedissonSessionManager extends ManagerBase {
         synchronized (pipeline) {
             contextInUse.remove(getContext().getName());
             //remove valves when all of the RedissonSessionManagers (web apps) are not in use anymore
-            if (contextInUse.size() == 0) {
+            if (contextInUse.isEmpty()) {
                 if (updateValve != null) {
                     pipeline.removeValve(updateValve);
                     updateValve = null;

--- a/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/UpdateValve.java
+++ b/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/UpdateValve.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 
 import javax.servlet.ServletException;
 
+import org.apache.catalina.Manager;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
 import org.apache.catalina.valves.ValveBase;
@@ -32,11 +33,9 @@ import org.apache.catalina.valves.ValveBase;
 public class UpdateValve extends ValveBase {
 
     private static final String ALREADY_FILTERED_NOTE = UpdateValve.class.getName() + ".ALREADY_FILTERED_NOTE";
-    private final RedissonSessionManager manager;
     
-    public UpdateValve(RedissonSessionManager manager) {
+    public UpdateValve() {
         super(true);
-        this.manager = manager;
     }
 
     @Override
@@ -52,7 +51,10 @@ public class UpdateValve extends ValveBase {
                 try {
                     ClassLoader applicationClassLoader = request.getContext().getLoader().getClassLoader();
                     Thread.currentThread().setContextClassLoader(applicationClassLoader);
-                    manager.store(request.getSession(false));
+                    Manager manager = request.getContext().getManager();
+                    if (manager instanceof RedissonSessionManager) {
+                    	((RedissonSessionManager)manager).store(request.getSession(false));
+                    }
                 } finally {
                     Thread.currentThread().setContextClassLoader(classLoader);
                 }

--- a/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/UpdateValve.java
+++ b/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/UpdateValve.java
@@ -52,9 +52,7 @@ public class UpdateValve extends ValveBase {
                     ClassLoader applicationClassLoader = request.getContext().getLoader().getClassLoader();
                     Thread.currentThread().setContextClassLoader(applicationClassLoader);
                     Manager manager = request.getContext().getManager();
-                    if (manager instanceof RedissonSessionManager) {
-                    	((RedissonSessionManager)manager).store(request.getSession(false));
-                    }
+                    ((RedissonSessionManager)manager).store(request.getSession(false));
                 } finally {
                     Thread.currentThread().setContextClassLoader(classLoader);
                 }

--- a/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -17,9 +17,12 @@ package org.redisson.tomcat;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.servlet.http.HttpSession;
 
@@ -67,8 +70,12 @@ public class RedissonSessionManager extends ManagerBase {
 
     private final String nodeId = UUID.randomUUID().toString();
 
-    private UpdateValve updateValve;
+    private static UpdateValve updateValve;
 
+    private static Set<String> contextWithInstalledValves = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
+
+    private MessageListener messageListener;
+    
     private Codec codecToUse;
 
     public String getNodeId() { return nodeId; }
@@ -249,16 +256,17 @@ public class RedissonSessionManager extends ManagerBase {
         
         if (updateMode == UpdateMode.AFTER_REQUEST) {
             Pipeline pipeline = getEngine().getPipeline();
-            if (updateValve != null) { // in case startInternal is called without stopInternal cleaning the updateValve
-                pipeline.removeValve(updateValve);
+            synchronized (pipeline) {
+            	contextWithInstalledValves.add(getContext().getName());
+            	
+	            updateValve = new UpdateValve();
+	            pipeline.addValve(updateValve);
             }
-            updateValve = new UpdateValve(this);
-            pipeline.addValve(updateValve);			
         }
         
         if (readMode == ReadMode.MEMORY || broadcastSessionEvents) {
             RTopic updatesTopic = getTopic();
-            updatesTopic.addListener(AttributeMessage.class, new MessageListener<AttributeMessage>() {
+            messageListener = new MessageListener<AttributeMessage>() {
                 
                 @Override
                 public void onMessage(CharSequence channel, AttributeMessage msg) {
@@ -317,7 +325,9 @@ public class RedissonSessionManager extends ManagerBase {
                         log.error("Unable to handle topic message", e);
                     }
                 }
-            });
+            };
+            
+            updatesTopic.addListener(AttributeMessage.class, messageListener);
         }
         
         setState(LifecycleState.STARTING);
@@ -351,8 +361,20 @@ public class RedissonSessionManager extends ManagerBase {
         setState(LifecycleState.STOPPING);
         
         if (updateValve != null) {
-            getEngine().getPipeline().removeValve(updateValve);
-            updateValve = null;
+            Pipeline pipeline = getEngine().getPipeline();
+            synchronized (pipeline) {
+            	contextWithInstalledValves.remove(getContext().getName());
+            	//remove valves when all of the RedissonSessionManagers (web apps) are not in use anymore
+    	        if (contextWithInstalledValves.size() == 0) {
+	            	pipeline.removeValve(updateValve);
+		            updateValve = null;
+    	        }
+            }
+        }
+        
+        if (messageListener != null) {
+        	 RTopic updatesTopic = getTopic();
+        	 updatesTopic.removeListener(messageListener);
         }
 
         codecToUse = null;

--- a/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -257,13 +257,13 @@ public class RedissonSessionManager extends ManagerBase {
         Pipeline pipeline = getEngine().getPipeline();
         synchronized (pipeline) {
             contextInUse.add(getContext().getName());
-	        if (updateMode == UpdateMode.AFTER_REQUEST) {
-	            if (updateValve == null) {
-		            updateValve = new UpdateValve();
-		            pipeline.addValve(updateValve);
-	            }
-	        }
-        }		
+            if (updateMode == UpdateMode.AFTER_REQUEST) {
+                if (updateValve == null) {
+                    updateValve = new UpdateValve();
+                    pipeline.addValve(updateValve);
+                }
+            }
+        }
         
         if (readMode == ReadMode.MEMORY || broadcastSessionEvents) {
             RTopic updatesTopic = getTopic();
@@ -364,18 +364,18 @@ public class RedissonSessionManager extends ManagerBase {
         Pipeline pipeline = getEngine().getPipeline();
         synchronized (pipeline) {
             contextInUse.remove(getContext().getName());
-	        //remove valves when all of the RedissonSessionManagers (web apps) are not in use anymore
-	        if (contextInUse.size() == 0) {
-		        if (updateValve != null) {
-		        	pipeline.removeValve(updateValve);
-		            updateValve = null;
-		        }
-	        }
+            //remove valves when all of the RedissonSessionManagers (web apps) are not in use anymore
+            if (contextInUse.size() == 0) {
+                if (updateValve != null) {
+                    pipeline.removeValve(updateValve);
+                    updateValve = null;
+                }
+            }
         }
         
         if (messageListener != null) {
-        	 RTopic updatesTopic = getTopic();
-        	 updatesTopic.removeListener(messageListener);
+             RTopic updatesTopic = getTopic();
+             updatesTopic.removeListener(messageListener);
         }
 
         codecToUse = null;

--- a/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -365,7 +365,7 @@ public class RedissonSessionManager extends ManagerBase {
         synchronized (pipeline) {
             contextInUse.remove(getContext().getName());
             //remove valves when all of the RedissonSessionManagers (web apps) are not in use anymore
-            if (contextInUse.size() == 0) {
+            if (contextInUse.isEmpty()) {
                 if (updateValve != null) {
                     pipeline.removeValve(updateValve);
                     updateValve = null;

--- a/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/UpdateValve.java
+++ b/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/UpdateValve.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 
 import javax.servlet.ServletException;
 
+import org.apache.catalina.Manager;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
 import org.apache.catalina.valves.ValveBase;
@@ -32,11 +33,9 @@ import org.apache.catalina.valves.ValveBase;
 public class UpdateValve extends ValveBase {
 
     private static final String ALREADY_FILTERED_NOTE = UpdateValve.class.getName() + ".ALREADY_FILTERED_NOTE";
-    private final RedissonSessionManager manager;
     
-    public UpdateValve(RedissonSessionManager manager) {
+    public UpdateValve() {
         super(true);
-        this.manager = manager;
     }
 
     @Override
@@ -52,7 +51,10 @@ public class UpdateValve extends ValveBase {
                 try {
                     ClassLoader applicationClassLoader = request.getContext().getLoader().getClassLoader();
                     Thread.currentThread().setContextClassLoader(applicationClassLoader);
-                    manager.store(request.getSession(false));
+                    Manager manager = request.getContext().getManager();
+                    if (manager instanceof RedissonSessionManager) {
+                    	((RedissonSessionManager)manager).store(request.getSession(false));
+                    }
                 } finally {
                     Thread.currentThread().setContextClassLoader(classLoader);
                 }

--- a/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/UpdateValve.java
+++ b/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/UpdateValve.java
@@ -52,9 +52,7 @@ public class UpdateValve extends ValveBase {
                     ClassLoader applicationClassLoader = request.getContext().getLoader().getClassLoader();
                     Thread.currentThread().setContextClassLoader(applicationClassLoader);
                     Manager manager = request.getContext().getManager();
-                    if (manager instanceof RedissonSessionManager) {
-                    	((RedissonSessionManager)manager).store(request.getSession(false));
-                    }
+                    ((RedissonSessionManager)manager).store(request.getSession(false));
                 } finally {
                     Thread.currentThread().setContextClassLoader(classLoader);
                 }


### PR DESCRIPTION
Expected behavior
UpdateValve valve should be installed only once for tomcat pipeline but if there are multiple web application each one will instantiate a new RedissonSessionManager and each startInternal() will install it's own copy of the UpdateValve, more over the UpdateValve have back reference to RedissonSessionManager, so remove this reference in order to have only one UpdateValve installed for the tomcat pipeline and allow proper RedissonSessionManager garbage collection.

When we have Redisson client set in JNDI which is shared between web applications we need to remove MessageListener from the topic when web application is deinstalled during stopInternal method of RedissonSessionManager

Actual behavior
Each web app will create it's own RedissonSessionManager instance which will result in multiple UpdateValve instances installed into tomcat pipeline
MessageListener is not removed from redisson topic which will cause web application class loader memory leak as MessageListener have reference to codecToUse which in turn have reference to application class loader