### PR TITLE
Support multiple environment variables with default

### DIFF
--- a/redisson/src/main/java/org/redisson/config/ConfigSupport.java
+++ b/redisson/src/main/java/org/redisson/config/ConfigSupport.java
@@ -101,7 +101,7 @@ public class ConfigSupport {
     }
     
     private String resolveEnvParams(String content) {
-        Pattern pattern = Pattern.compile("\\$\\{(\\w+(:-.+)?)\\}");
+        Pattern pattern = Pattern.compile("\\$\\{(\\w+(:-.+?)?)\\}");
         Matcher m = pattern.matcher(content);
         while (m.find()) {
             String[] parts = m.group(1).split(":-");

--- a/redisson/src/test/java/org/redisson/config/ConfigSupportTest.java
+++ b/redisson/src/test/java/org/redisson/config/ConfigSupportTest.java
@@ -1,12 +1,10 @@
 package org.redisson.config;
 
-import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.net.URI;
 
 import static org.junit.Assert.*;
 
@@ -17,7 +15,7 @@ public class ConfigSupportTest {
         mockHostEnv("1.1.1.1");
         SingleServerConfig config = mkConfig("127.0.0.1");
         
-        assertEquals(URI.create("redis://127.0.0.1"), config.getAddress());
+        assertEquals("redis://127.0.0.1", config.getAddress());
     }
     
     @Test
@@ -25,13 +23,15 @@ public class ConfigSupportTest {
         mockHostEnv("1.1.1.1");
         SingleServerConfig config = mkConfig("${REDIS_URI}");
         
-        assertEquals(URI.create("redis://1.1.1.1"), config.getAddress());
+        assertEquals("redis://1.1.1.1", config.getAddress());
     }
     
-    @Test(expected = InvalidFormatException.class)
+    @Test
     public void testParsingEnv_envMissing() throws IOException {
         mockHostEnv(null);
-        mkConfig("${REDIS_URI}");
+        final SingleServerConfig config = mkConfig("${REDIS_URI}");
+
+        assertEquals("redis://${REDIS_URI}", config.getAddress());
     }
     
     @Test
@@ -39,7 +39,7 @@ public class ConfigSupportTest {
         mockHostEnv("11.0.0.1");
         SingleServerConfig config = mkConfig("${REDIS_URI:-10.0.0.1}");
         
-        assertEquals(URI.create("redis://11.0.0.1"), config.getAddress());
+        assertEquals("redis://11.0.0.1", config.getAddress());
     }
     
     @Test
@@ -47,7 +47,7 @@ public class ConfigSupportTest {
         mockHostEnv(null);
         SingleServerConfig config = mkConfig("${REDIS_URI:-10.0.0.1}");
         
-        assertEquals(URI.create("redis://10.0.0.1"), config.getAddress());
+        assertEquals("redis://10.0.0.1", config.getAddress());
     }
     
     private SingleServerConfig mkConfig(String authorityValue) throws IOException {

--- a/redisson/src/test/java/org/redisson/config/ConfigSupportTest.java
+++ b/redisson/src/test/java/org/redisson/config/ConfigSupportTest.java
@@ -27,6 +27,14 @@ public class ConfigSupportTest {
     }
     
     @Test
+    public void testParsingEnv2() throws IOException {
+        mockHostPortEnv("1.1.1.1", "6379");
+        SingleServerConfig config = mkConfig("${REDIS_HOST}:${REDIS_PORT}");
+
+        assertEquals("redis://1.1.1.1:6379", config.getAddress());
+    }
+
+    @Test
     public void testParsingEnv_envMissing() throws IOException {
         mockHostEnv(null);
         final SingleServerConfig config = mkConfig("${REDIS_URI}");
@@ -43,11 +51,27 @@ public class ConfigSupportTest {
     }
     
     @Test
+    public void testParsingDefault_envPresent2() throws IOException {
+        mockHostPortEnv("11.0.0.1", "1234");
+        SingleServerConfig config = mkConfig("${REDIS_HOST:-127.0.0.1}:${REDIS_PORT:-6379}");
+
+        assertEquals("redis://11.0.0.1:1234", config.getAddress());
+    }
+    
+    @Test
     public void testParsingDefault_envMissing() throws IOException {
         mockHostEnv(null);
         SingleServerConfig config = mkConfig("${REDIS_URI:-10.0.0.1}");
         
         assertEquals("redis://10.0.0.1", config.getAddress());
+    }
+    
+    @Test
+    public void testParsingDefault_envMissing2() throws IOException {
+        mockHostPortEnv(null, null);
+        SingleServerConfig config = mkConfig("${REDIS_HOST:-127.0.0.1}:${REDIS_PORT:-6379}");
+
+        assertEquals("redis://127.0.0.1:6379", config.getAddress());
     }
     
     private SingleServerConfig mkConfig(String authorityValue) throws IOException {
@@ -64,4 +88,20 @@ public class ConfigSupportTest {
         };
     }
     
+    private void mockHostPortEnv(String host, String port) {
+        new MockUp<System>() {
+            @Mock
+            String getenv(String name) {
+                switch (name) {
+                    case "REDIS_HOST":
+                        return host;
+                    case "REDIS_PORT":
+                        return port;
+                    default:
+                        return null;
+                }
+            }
+        };
+    }
+
 }


### PR DESCRIPTION
If a config contains multiple variables (in one line) with defaults like this:

```yaml
singleServerConfig:
  address: 'redis://${REDIS_HOST:-127.0.0.1}:${REDIS_PORT:-6379}'
```

The parser failed because the regular expression threated them as one variable `REDIS_HOST:-127.0.0.1}:${REDIS_PORT` with default `6379`.