### PR TITLE
Return the same object in http request processing when session.getAttribute is called, add any "mutable" objects return from session.getAttribute to a tracker that will update Redis session key values at the end of the request processing #1868

### DIFF
--- a/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -257,11 +257,9 @@ public class RedissonSessionManager extends ManagerBase {
         Pipeline pipeline = getEngine().getPipeline();
         synchronized (pipeline) {
             contextInUse.add(getContext().getName());
-            if (updateMode == UpdateMode.AFTER_REQUEST) {
-                if (updateValve == null) {
-                    updateValve = new UpdateValve();
-                    pipeline.addValve(updateValve);
-                }
+            if (updateValve == null) {
+                updateValve = new UpdateValve();
+                pipeline.addValve(updateValve);
             }
         }
         


### PR DESCRIPTION
Return the same object in http request processing when session.getAttribute is called, add any "mutable" objects return from session.getAttribute to a tracker that will update Redis session key values at the end of the request processing, make sure when we update session at the end it will update only attributes touched by the request processing #1868