### PR TITLE
Add unit tests for org.redisson.client.ChannelName

### DIFF
--- a/redisson/src/test/java/org/redisson/client/ChannelNameTest.java
+++ b/redisson/src/test/java/org/redisson/client/ChannelNameTest.java
@@ -1,0 +1,47 @@
+package org.redisson.client;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ChannelNameTest {
+
+  @Test
+  public void testCharAt() {
+    Assert.assertEquals('\u0001', new ChannelName(new byte[]{1, 0}).charAt(0));
+  }
+
+  @Test
+  public void testEquals() {
+    final ChannelName channelName = new ChannelName(new byte[]{});
+    Assert.assertFalse(channelName.equals(null));
+    Assert.assertFalse(channelName.equals(new ChannelName((byte[])null)));
+
+    Assert.assertTrue(channelName.equals(channelName));
+    Assert.assertTrue(channelName.equals(""));
+  }
+
+  @Test
+  public void testGetname() {
+    Assert.assertNull(new ChannelName((byte[])null).getName());
+  }
+
+  @Test
+  public void testHashCode() {
+    Assert.assertEquals(131396, new ChannelName("foo").hashCode());
+  }
+
+  @Test
+  public void testLength() {
+    Assert.assertEquals(1, new ChannelName(new byte[]{0}).length());
+  }
+
+  @Test
+  public void testSubSequence() {
+    Assert.assertEquals("", new ChannelName(new byte[]{}).subSequence(0, 0));
+  }
+
+  @Test
+  public void testToString() {
+    Assert.assertEquals("\u0001\u0000", new ChannelName(new byte[]{1, 0}).toString());
+  }
+}


### PR DESCRIPTION
I've analysed your codebase and noticed that `org.redisson.client.ChannelName` is not fully tested.
I've written some tests for the methods in this class with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests will help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other classes that you consider important.