### PR TITLE
Reactive intersection, union and diff should return Integer, not Long

### DIFF
--- a/redisson/src/main/java/org/redisson/api/RSetReactive.java
+++ b/redisson/src/main/java/org/redisson/api/RSetReactive.java
@@ -146,7 +146,7 @@ public interface RSetReactive<V> extends RCollectionReactive<V>, RSortableReacti
      * @param names - name of sets
      * @return size of union
      */
-    Mono<Long> union(String... names);
+    Mono<Integer> union(String... names);
 
     /**
      * Union sets specified by name with current set.
@@ -164,7 +164,7 @@ public interface RSetReactive<V> extends RCollectionReactive<V>, RSortableReacti
      * @param names - name of sets
      * @return size of diff
      */
-    Mono<Long> diff(String... names);
+    Mono<Integer> diff(String... names);
     
     /**
      * Diff sets specified by name with current set.
@@ -182,7 +182,7 @@ public interface RSetReactive<V> extends RCollectionReactive<V>, RSortableReacti
      * @param names - name of sets
      * @return size of intersection
      */
-    Mono<Long> intersection(String... names);
+    Mono<Integer> intersection(String... names);
 
     /**
      * Intersection sets specified by name with current set.

--- a/redisson/src/main/java/org/redisson/api/RSetRx.java
+++ b/redisson/src/main/java/org/redisson/api/RSetRx.java
@@ -147,7 +147,7 @@ public interface RSetRx<V> extends RCollectionRx<V>, RSortableRx<Set<V>> {
      * @param names - name of sets
      * @return size of union
      */
-    Single<Long> union(String... names);
+    Single<Integer> union(String... names);
 
     /**
      * Union sets specified by name with current set.
@@ -165,7 +165,7 @@ public interface RSetRx<V> extends RCollectionRx<V>, RSortableRx<Set<V>> {
      * @param names - name of sets
      * @return size of diff
      */
-    Single<Long> diff(String... names);
+    Single<Integer> diff(String... names);
     
     /**
      * Diff sets specified by name with current set.
@@ -183,7 +183,7 @@ public interface RSetRx<V> extends RCollectionRx<V>, RSortableRx<Set<V>> {
      * @param names - name of sets
      * @return size of intersection
      */
-    Single<Long> intersection(String... names);
+    Single<Integer> intersection(String... names);
 
     /**
      * Intersection sets specified by name with current set.

--- a/redisson/src/test/java/org/redisson/RedissonSetReactiveTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonSetReactiveTest.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+
 import static org.assertj.core.api.Assertions.*;
 
 import org.junit.Assert;
@@ -126,7 +127,7 @@ public class RedissonSetReactiveTest extends BaseReactiveTest {
     }
 
     private void checkIterator(RSetReactive<Long> set, Set<Long> setCopy) {
-        for (Iterator<Long> iterator = toIterator(set.iterator()); iterator.hasNext();) {
+        for (Iterator<Long> iterator = toIterator(set.iterator()); iterator.hasNext(); ) {
             Long value = iterator.next();
             if (!setCopy.remove(value)) {
                 Assert.fail();
@@ -264,5 +265,31 @@ public class RedissonSetReactiveTest extends BaseReactiveTest {
 
         Assert.assertEquals(1, sync(set.size()).intValue());
         Assert.assertEquals(0, sync(otherSet.size()).intValue());
+    }
+
+    @Test
+    public void testIntersection() {
+        final String firstSetName = "firstSet";
+        RSetReactive<Integer> firstSet = redisson.getSet(firstSetName);
+
+        sync(firstSet.add(1));
+        sync(firstSet.add(2));
+        sync(firstSet.add(3));
+
+        final String secondSetName = "secondSet";
+        RSetReactive<Integer> secondSet = redisson.getSet(secondSetName);
+
+        sync(secondSet.add(3));
+        sync(secondSet.add(4));
+        sync(secondSet.add(1));
+
+        final RSetReactive<Object> tmp = redisson.getSet("tmp");
+
+        final Integer count = sync(tmp.intersection(firstSetName, secondSetName));
+
+        Assert.assertEquals(2, count.intValue());
+
+        Assert.assertTrue(sync(tmp.contains(1)));
+        Assert.assertTrue(sync(tmp.contains(3)));
     }
 }

--- a/redisson/src/test/java/org/redisson/rx/RedissonSetRxTest.java
+++ b/redisson/src/test/java/org/redisson/rx/RedissonSetRxTest.java
@@ -128,7 +128,7 @@ public class RedissonSetRxTest extends BaseRxTest {
     }
 
     private void checkIterator(RSetRx<Long> set, Set<Long> setCopy) {
-        for (Iterator<Long> iterator = toIterator(set.iterator()); iterator.hasNext();) {
+        for (Iterator<Long> iterator = toIterator(set.iterator()); iterator.hasNext(); ) {
             Long value = iterator.next();
             if (!setCopy.remove(value)) {
                 Assert.fail();
@@ -266,5 +266,31 @@ public class RedissonSetRxTest extends BaseRxTest {
 
         Assert.assertEquals(1, sync(set.size()).intValue());
         Assert.assertEquals(0, sync(otherSet.size()).intValue());
+    }
+
+    @Test
+    public void testIntersection() {
+        final String firstSetName = "firstSet";
+        RSetRx<Integer> firstSet = redisson.getSet(firstSetName);
+
+        sync(firstSet.add(1));
+        sync(firstSet.add(2));
+        sync(firstSet.add(3));
+
+        final String secondSetName = "secondSet";
+        RSetRx<Integer> secondSet = redisson.getSet(secondSetName);
+
+        sync(secondSet.add(3));
+        sync(secondSet.add(4));
+        sync(secondSet.add(1));
+
+        final RSetRx<Object> tmp = redisson.getSet("tmp");
+
+        final Integer count = sync(tmp.intersection(firstSetName, secondSetName));
+
+        Assert.assertEquals(2, count.intValue());
+
+        Assert.assertTrue(sync(tmp.contains(1)));
+        Assert.assertTrue(sync(tmp.contains(3)));
     }
 }


### PR DESCRIPTION
Fixed #2241. Set.intersection, union and diff should return a Single, or Mono, of Integer, not Long. 