### PR TITLE
Do not wrap in square brackets already wrapped IPv6 addresses v2

### DIFF
--- a/redisson/src/main/java/org/redisson/connection/SentinelConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/SentinelConnectionManager.java
@@ -501,7 +501,7 @@ public class SentinelConnectionManager extends MasterSlaveConnectionManager {
         if (host.contains(":")){
             String pureHost = host.replaceAll("[\\[\\]]", "");
             host = applyNatMap(pureHost);
-            if (host.contains(":")) {
+            if (host.contains(":") && !host.startsWith("[")) {
                 host = "[" + host + "]";
             }
         } else {


### PR DESCRIPTION
There was already a fix https://github.com/redisson/redisson/commit/b7df3a2d293b7cce438d1bb795289cbb4da30f37

But it was lost in https://github.com/redisson/redisson/commit/a9f7a99388c3dabdc45157af61558975e0e61fdb#diff-7d2da5068938564117bd318316bdd1ad