### PR TITLE
Fix for NPE while reading data when RLocalCachedMap is used in another RLocalCachedMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# forked to fix NPE while reading data when RLocalCachedMap is used inside another RLocalCachedMap
+
 # Redisson - Redis Java client<br/>with features of In-Memory Data Grid
 
 [Quick start](https://github.com/redisson/redisson#quick-start) | [Documentation](https://github.com/redisson/redisson/wiki) | [Javadocs](http://www.javadoc.io/doc/org.redisson/redisson/3.11.2) | [Changelog](https://github.com/redisson/redisson/blob/master/CHANGELOG.md) | [Code examples](https://github.com/redisson/redisson-examples) | [FAQs](https://github.com/redisson/redisson/wiki/16.-FAQ) | [Report an issue](https://github.com/redisson/redisson/issues/new)

--- a/redisson/src/main/java/org/redisson/Redisson.java
+++ b/redisson/src/main/java/org/redisson/Redisson.java
@@ -306,6 +306,16 @@ public class Redisson implements RedissonClient {
         return new RedissonLocalCachedMap<K, V>(codec, connectionManager.getCommandExecutor(), name, 
                 options, evictionScheduler, this, writeBehindService);
     }
+    
+    @Override
+    public <K, V> RLocalCachedMap<K, V> getLocalCachedMap(String name) {
+        return getLocalCachedMap(name, LocalCachedMapOptions.defaults());
+    }
+
+    @Override
+    public <K, V> RLocalCachedMap<K, V> getLocalCachedMap(String name, Codec codec) {
+        return getLocalCachedMap(name, codec, LocalCachedMapOptions.defaults());
+    }
 
     @Override
     public <K, V> RMap<K, V> getMap(String name) {

--- a/redisson/src/main/java/org/redisson/RedissonLocalCachedMap.java
+++ b/redisson/src/main/java/org/redisson/RedissonLocalCachedMap.java
@@ -105,6 +105,13 @@ public class RedissonLocalCachedMap<K, V> extends RedissonMap<K, V> implements R
                 CacheKey cacheKey = toCacheKey(keyBuf);
                 Object key = codec.getMapKeyDecoder().decode(keyBuf, null);
                 Object value = codec.getMapValueDecoder().decode(valueBuf, null);
+                if(value instanceof RedissonReference){
+                    try{
+                        value = commandExecutor.getObjectBuilder().fromReference((RedissonReference)value);
+                    }catch (ReflectiveOperationException roe){
+                        roe.printStackTrace();
+                    }
+                }
                 cachePut(cacheKey, key, value);
             }
             

--- a/redisson/src/main/java/org/redisson/RedissonLocalCachedMap.java
+++ b/redisson/src/main/java/org/redisson/RedissonLocalCachedMap.java
@@ -986,6 +986,16 @@ public class RedissonLocalCachedMap<K, V> extends RedissonMap<K, V> implements R
     public Set<K> cachedKeySet() {
         return localCacheView.cachedKeySet();
     }
+    
+     @Override
+    public Collection<V> values(){
+        Collection<V> data = cachedValues();
+        if(data.size() > 0){
+            return data;
+        }
+
+        return super.values();
+    }
 
     @Override
     public Collection<V> cachedValues() {

--- a/redisson/src/main/java/org/redisson/api/RedissonClient.java
+++ b/redisson/src/main/java/org/redisson/api/RedissonClient.java
@@ -326,6 +326,29 @@ public interface RedissonClient {
      * @return LocalCachedMap object
      */
     <K, V> RLocalCachedMap<K, V> getLocalCachedMap(String name, Codec codec, LocalCachedMapOptions<K, V> options);
+    /**
+     * Returns local cached map instance by name.
+     * Configured with default options-object. 
+     * 
+     * @param <K> type of key
+     * @param <V> type of value
+     * @param name - name of object
+     * @param options - local map options
+     * @return LocalCachedMap object
+     */
+    <K, V> RLocalCachedMap<K, V> getLocalCachedMap(String name);
+    /**
+     * Returns local cached map instance by name
+     * using provided codec. Configured with default options-object.
+     * 
+     * @param <K> type of key
+     * @param <V> type of value
+     * @param name - name of object
+     * @param codec - codec for keys and values
+     * @param options - local map options
+     * @return LocalCachedMap object
+     */
+    <K, V> RLocalCachedMap<K, V> getLocalCachedMap(String name, Codec codec);
     
     /**
      * Returns map instance by name.


### PR DESCRIPTION
When RLocalCachedMap is used inside another, reading data from inner map causes NPE  at RedissonObjectBuilder.java#245. This happens due to CodecMethodRef.defaultCodecMethod & CodecMethodRef.customCodecMethod are set to NULL for RLocalCachedMap as code to create CodecMethodRef ONLY checks 'get<*>' methods of RedissonClient which has one 
& two args for same method. while getLocalCachedMap method(s) has two & three args. Added two more methods to satisfy this condition and used LocalCachedMapOptions.defaults() for LocalCachedMapOptions.