### PR TITLE
allows the client to use the desired TLS version for TLS handshake with the Redis Server.

### DIFF
--- a/redisson/src/main/java/org/redisson/client/RedisClientConfig.java
+++ b/redisson/src/main/java/org/redisson/client/RedisClientConfig.java
@@ -316,7 +316,7 @@ public class RedisClientConfig {
     }
 
     public enum TlsVersion {
-        TLSv0("TLSv1.0"),
+        TLSv0("TLSv1"),
         TLSv1("TLSv1.1"),
         TLSv2("TLSv1.2");
 

--- a/redisson/src/main/java/org/redisson/client/RedisClientConfig.java
+++ b/redisson/src/main/java/org/redisson/client/RedisClientConfig.java
@@ -47,6 +47,7 @@ public class RedisClientConfig {
     private int commandTimeout = 10000;
     
     private String password;
+    private String tlsVersion;
     private int database;
     private String clientName;
     private boolean readOnly;
@@ -78,6 +79,7 @@ public class RedisClientConfig {
         this.connectTimeout = config.connectTimeout;
         this.commandTimeout = config.commandTimeout;
         this.password = config.password;
+        this.tlsVersion = config.tlsVersion;
         this.database = config.database;
         this.clientName = config.clientName;
         this.readOnly = config.readOnly;
@@ -229,6 +231,15 @@ public class RedisClientConfig {
     }
     public RedisClientConfig setPassword(String password) {
         this.password = password;
+        return this;
+    }
+
+    public String getTlsVersion() {
+        return tlsVersion;
+    }
+
+    public RedisClientConfig setTlsVersion(String tlsVersion) {
+        this.tlsVersion = tlsVersion;
         return this;
     }
     

--- a/redisson/src/main/java/org/redisson/client/RedisClientConfig.java
+++ b/redisson/src/main/java/org/redisson/client/RedisClientConfig.java
@@ -47,7 +47,7 @@ public class RedisClientConfig {
     private int commandTimeout = 10000;
     
     private String password;
-    private String tlsVersion;
+    private TlsVersion tlsVersion;
     private int database;
     private String clientName;
     private boolean readOnly;
@@ -234,11 +234,11 @@ public class RedisClientConfig {
         return this;
     }
 
-    public String getTlsVersion() {
+    public TlsVersion getTlsVersion() {
         return tlsVersion;
     }
 
-    public RedisClientConfig setTlsVersion(String tlsVersion) {
+    public RedisClientConfig setTlsVersion(TlsVersion tlsVersion) {
         this.tlsVersion = tlsVersion;
         return this;
     }
@@ -314,7 +314,21 @@ public class RedisClientConfig {
         this.resolverGroup = resolverGroup;
         return this;
     }
-    
-    
+
+    public enum TlsVersion {
+        TLSv0("TLSv1.0"),
+        TLSv1("TLSv1.1"),
+        TLSv2("TLSv1.2");
+
+        private String tlsVersion;
+
+        public String getTlsVersion() {
+            return this.tlsVersion;
+        }
+
+        TlsVersion(String tlsVersion) {
+            this.tlsVersion = tlsVersion;
+        }
+    }
     
 }

--- a/redisson/src/main/java/org/redisson/client/handler/RedisChannelInitializer.java
+++ b/redisson/src/main/java/org/redisson/client/handler/RedisChannelInitializer.java
@@ -156,8 +156,8 @@ public class RedisChannelInitializer extends ChannelInitializer<Channel> {
         
         SSLParameters sslParams = new SSLParameters();
 
-        if (config.getTlsVersion() != null && !config.getTlsVersion().isEmpty()) {
-            sslParams.setProtocols(new String[]{config.getTlsVersion()});
+        if (config.getTlsVersion() != null && !config.getTlsVersion().getTlsVersion().isEmpty()) {
+            sslParams.setProtocols(new String[]{config.getTlsVersion().getTlsVersion()});
         }
 
         if (config.isSslEnableEndpointIdentification()) {

--- a/redisson/src/main/java/org/redisson/client/handler/RedisChannelInitializer.java
+++ b/redisson/src/main/java/org/redisson/client/handler/RedisChannelInitializer.java
@@ -155,6 +155,11 @@ public class RedisChannelInitializer extends ChannelInitializer<Channel> {
         }
         
         SSLParameters sslParams = new SSLParameters();
+
+        if (config.getTlsVersion() != null && !config.getTlsVersion().isEmpty()) {
+            sslParams.setProtocols(new String[]{config.getTlsVersion()});
+        }
+
         if (config.isSslEnableEndpointIdentification()) {
             // TODO remove for JDK 1.7+
             try {

--- a/redisson/src/main/java/org/redisson/config/BaseConfig.java
+++ b/redisson/src/main/java/org/redisson/config/BaseConfig.java
@@ -70,6 +70,11 @@ class BaseConfig<T extends BaseConfig<T>> {
     private String password;
 
     /**
+     * TLS version for the client to use in the TLS handshake to instances.
+     */
+    private String tlsVersion;
+
+    /**
      * Subscriptions per Redis connection limit
      */
     private int subscriptionsPerConnection = 5;
@@ -102,6 +107,7 @@ class BaseConfig<T extends BaseConfig<T>> {
     }
 
     BaseConfig(T config) {
+        setTlsVersion(config.getTlsVersion());
         setPassword(config.getPassword());
         setSubscriptionsPerConnection(config.getSubscriptionsPerConnection());
         setRetryAttempts(config.getRetryAttempts());
@@ -153,6 +159,23 @@ class BaseConfig<T extends BaseConfig<T>> {
     public String getPassword() {
         return password;
     }
+
+    /**
+     * Version for client to initiate the TLS handsake with.
+     * Default is <code>null</code>
+     *
+     * @param tlsVersion options : TLSv1, TLSv1.1, TLSv1.2
+     * @return config
+     */
+    public T setTlsVersion(String tlsVersion) {
+        this.tlsVersion = tlsVersion;
+        return (T) this;
+    }
+
+    public String getTlsVersion() {
+        return tlsVersion;
+    }
+
 
     /**
      * Error will be thrown if Redis command can't be sent to Redis server after <code>retryAttempts</code>.

--- a/redisson/src/main/java/org/redisson/config/BaseConfig.java
+++ b/redisson/src/main/java/org/redisson/config/BaseConfig.java
@@ -19,6 +19,7 @@ import java.net.URL;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.redisson.client.RedisClientConfig.TlsVersion;
 
 /**
  * 
@@ -72,7 +73,7 @@ class BaseConfig<T extends BaseConfig<T>> {
     /**
      * TLS version for the client to use in the TLS handshake to instances.
      */
-    private String tlsVersion;
+    private TlsVersion tlsVersion;
 
     /**
      * Subscriptions per Redis connection limit
@@ -167,12 +168,12 @@ class BaseConfig<T extends BaseConfig<T>> {
      * @param tlsVersion options : TLSv1, TLSv1.1, TLSv1.2
      * @return config
      */
-    public T setTlsVersion(String tlsVersion) {
+    public T setTlsVersion(TlsVersion tlsVersion) {
         this.tlsVersion = tlsVersion;
         return (T) this;
     }
 
-    public String getTlsVersion() {
+    public TlsVersion getTlsVersion() {
         return tlsVersion;
     }
 

--- a/redisson/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
@@ -399,6 +399,7 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
         c.setTimeout(cfg.getTimeout());
         c.setPingTimeout(cfg.getPingTimeout());
         c.setLoadBalancer(cfg.getLoadBalancer());
+        c.setTlsVersion(cfg.getTlsVersion());
         c.setPassword(cfg.getPassword());
         c.setClientName(cfg.getClientName());
         c.setMasterConnectionPoolSize(cfg.getMasterConnectionPoolSize());
@@ -469,8 +470,10 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
               .setPingConnectionInterval(config.getPingConnectionInterval())
               .setKeepAlive(config.isKeepAlive())
               .setTcpNoDelay(config.isTcpNoDelay())
-              .setPassword(config.getPassword());
-        
+              .setPassword(config.getPassword())
+              .setTlsVersion(config.getTlsVersion());
+
+
         if (type != NodeType.SENTINEL) {
             redisConfig.setDatabase(config.getDatabase());
         }

--- a/redisson/src/main/java/org/redisson/connection/SentinelConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/SentinelConnectionManager.java
@@ -252,6 +252,9 @@ public class SentinelConnectionManager extends MasterSlaveConnectionManager {
         if (type == NodeType.SENTINEL && !usePassword) {
             result.setPassword(null);
         }
+        if (config.getTlsVersion() != null && !config.getTlsVersion().isEmpty()) {
+            result.setTlsVersion(config.getTlsVersion());
+        }
         return result;
     }
 

--- a/redisson/src/main/java/org/redisson/connection/SentinelConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/SentinelConnectionManager.java
@@ -252,7 +252,7 @@ public class SentinelConnectionManager extends MasterSlaveConnectionManager {
         if (type == NodeType.SENTINEL && !usePassword) {
             result.setPassword(null);
         }
-        if (config.getTlsVersion() != null && !config.getTlsVersion().isEmpty()) {
+        if (config.getTlsVersion() != null && !config.getTlsVersion().getTlsVersion().isEmpty()) {
             result.setTlsVersion(config.getTlsVersion());
         }
         return result;

--- a/redisson/src/main/java/org/redisson/connection/SingleConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/SingleConnectionManager.java
@@ -50,6 +50,7 @@ public class SingleConnectionManager extends MasterSlaveConnectionManager {
         newconfig.setTimeout(cfg.getTimeout());
         newconfig.setPingTimeout(cfg.getPingTimeout());
         newconfig.setPassword(cfg.getPassword());
+        newconfig.setTlsVersion(cfg.getTlsVersion());
         newconfig.setDatabase(cfg.getDatabase());
         newconfig.setClientName(cfg.getClientName());
         newconfig.setMasterAddress(cfg.getAddress());

--- a/redisson/src/test/java/org/redisson/RedissonTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonTest.java
@@ -45,6 +45,7 @@ import org.redisson.api.RMapCache;
 import org.redisson.api.RedissonClient;
 import org.redisson.client.RedisClient;
 import org.redisson.client.RedisClientConfig;
+import org.redisson.client.RedisClientConfig.TlsVersion;
 import org.redisson.client.RedisConnection;
 import org.redisson.client.RedisConnectionException;
 import org.redisson.client.RedisOutOfMemoryException;
@@ -293,7 +294,7 @@ public class RedissonTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testTlsConfig() {
-        String tlsVersion = "TLSv1.2";
+        TlsVersion tlsVersion = RedisClientConfig.TlsVersion.TLSv2;
         Config radissonConfig = new Config();
         radissonConfig.useSingleServer()
                 .setAddress(RedisRunner.getDefaultRedisServerBindAddressAndPort())

--- a/redisson/src/test/java/org/redisson/RedissonTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonTest.java
@@ -290,7 +290,19 @@ public class RedissonTest {
         .setConnectionPoolSize(2);
         Redisson.create(redissonConfig);        
     }
-    
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testTlsConfig() {
+        String tlsVersion = "TLSv1.2";
+        Config radissonConfig = new Config();
+        radissonConfig.useSingleServer()
+                .setAddress(RedisRunner.getDefaultRedisServerBindAddressAndPort())
+                .setTlsVersion(tlsVersion);
+        Assert.assertEquals(tlsVersion, radissonConfig.useSingleServer().getTlsVersion());
+        RedissonClient r = Redisson.create(radissonConfig);
+        Assert.assertEquals(tlsVersion, r.getConfig().useSingleServer().getTlsVersion());
+    }
+
     @Test
     public void testConnectionListener() throws IOException, InterruptedException, TimeoutException {
 


### PR DESCRIPTION
The client config now holds a settings for TLS version. Older JDK libraries might use version 1.0 or 1.1 as default, this setting allows this value to be overwritten with value "TLSv1", "TLSv1.1", "TLSv1.2" for tls 1.0, 1.1 and 1.2.  

