### PR TITLE
Spring boot fails without optional actuator dependency 3.11.5

### DIFF
--- a/redisson/src/main/java/org/redisson/spring/cache/RedissonCacheStatisticsAutoConfiguration.java
+++ b/redisson/src/main/java/org/redisson/spring/cache/RedissonCacheStatisticsAutoConfiguration.java
@@ -15,6 +15,7 @@
  */
 package org.redisson.spring.cache;
 
+import org.springframework.boot.actuate.metrics.cache.CacheMeterBinderProvider;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.cache.CacheAutoConfiguration;
@@ -37,7 +38,7 @@ import io.micrometer.core.instrument.binder.MeterBinder;
 @Configuration
 @AutoConfigureAfter(CacheAutoConfiguration.class)
 @ConditionalOnBean(CacheManager.class)
-@ConditionalOnClass(MeterBinder.class)
+@ConditionalOnClass(CacheMeterBinderProvider.class)
 public class RedissonCacheStatisticsAutoConfiguration {
     
     @Bean


### PR DESCRIPTION
The conditional is related to micrometer with `MeterProvider`, whereas the actual `RedissonCacheMeterBinderProvider` requires the actuator `CacheMeterBinderProvider`.