### PR TITLE
add springboot auto complete

### DIFF
--- a/redisson-spring-boot-starter/pom.xml
+++ b/redisson-spring-boot-starter/pom.xml
@@ -140,6 +140,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
When you add an integration with springboot, the redisson configuration item is automatically prompted in the configuration file