### PR TITLE
Prevent NPE when a value from Redis is null

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonBuckets.java
+++ b/redisson/src/main/java/org/redisson/RedissonBuckets.java
@@ -87,7 +87,11 @@ public class RedissonBuckets implements RBuckets {
 
             @Override
             public void onSlotResult(Map<Object, Object> result) {
-                results.putAll((Map<String, V>) (Object) result);
+                for (Map.Entry<Object, Object> entry : result.entrySet()) {
+                    if (entry.getKey() != null && entry.getValue() != null) {
+                        results.put((String) entry.getKey(), (V) entry.getValue());
+                    }
+                }
             }
 
             @Override

--- a/redisson/src/test/java/org/redisson/RedissonBucketsTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonBucketsTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -47,7 +48,9 @@ public class RedissonBucketsTest extends BaseTest {
             redisson.getBucket("test" + i).set(i);
         }
         
-        Map<String, Integer> buckets = redisson.getBuckets().get(map.keySet().toArray(new String[map.size()]));
+        Set<String> queryKeys = map.keySet();
+        queryKeys.add("test_invalid");
+        Map<String, Integer> buckets = redisson.getBuckets().get(queryKeys.toArray(new String[map.size()]));
         
         assertThat(buckets).isEqualTo(map);
         
@@ -57,10 +60,10 @@ public class RedissonBucketsTest extends BaseTest {
     
     @Test
     public void testGet() {
-        RBucket<String> bucket1 = redisson.getBucket("test1");
-        bucket1.set("someValue1");
-        RBucket<String> bucket3 = redisson.getBucket("test3");
-        bucket3.set("someValue3");
+        redisson.getBucket("test1").set("someValue1");
+        redisson.getBucket("test2").delete();
+        redisson.getBucket("test3").set("someValue3");
+        redisson.getBucket("test4").delete();
 
         Map<String, String> result = redisson.getBuckets().get("test1", "test2", "test3", "test4");
         Map<String, String> expected = new HashMap<String, String>();

--- a/redisson/src/test/java/org/redisson/RedissonBucketsTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonBucketsTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -48,7 +49,7 @@ public class RedissonBucketsTest extends BaseTest {
             redisson.getBucket("test" + i).set(i);
         }
         
-        Set<String> queryKeys = map.keySet();
+        Set<String> queryKeys = new HashSet<>(map.keySet());
         queryKeys.add("test_invalid");
         Map<String, Integer> buckets = redisson.getBuckets().get(queryKeys.toArray(new String[map.size()]));
         


### PR DESCRIPTION
I have run the unit tests related to this change and they pass.