### PR TITLE
reactivate replicas based on ip adress instead of hostname in ReplicatedConnectionManager

### DIFF
--- a/redisson/src/main/java/org/redisson/connection/ReplicatedConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/ReplicatedConnectionManager.java
@@ -15,6 +15,7 @@
  */
 package org.redisson.connection;
 
+import java.net.InetSocketAddress;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -168,7 +169,7 @@ public class ReplicatedConnectionManager extends MasterSlaveConnectionManager {
                                     });
                                 }
                             } else if (!config.checkSkipSlavesInit()) {
-                                slaveUp(addr);
+                                slaveUp(addr, connection.getRedisClient().getAddr());
                             }
                             
                             if (count.decrementAndGet() == 0) {
@@ -182,9 +183,9 @@ public class ReplicatedConnectionManager extends MasterSlaveConnectionManager {
         }, cfg.getScanInterval(), TimeUnit.MILLISECONDS);
     }
 
-    private void slaveUp(RedisURI uri) {
+    private void slaveUp(RedisURI uri, InetSocketAddress address) {
         MasterSlaveEntry entry = getEntry(singleSlotRange.getStartSlot());
-        if (entry.slaveUp(uri, FreezeReason.MANAGER)) {
+        if (entry.slaveUp(address, FreezeReason.MANAGER)) {
             log.info("slave: {} has up", uri);
         }
     }


### PR DESCRIPTION
This PR fixes a bug that I ran into when replacing a lost replica with a replacement node that had the same DNS host name as the lost one. The scenario is as follows.

There are two nodes in replicated mode:
```
node-1.redis.my.domain[127.0.0.1] (primary)
node-2.redis.my.domain[127.0.0.2] (replica)
```

The replica is lost permanently and replaced with a node having a new ip address but same host name:
```
node-1.redis.my.domain[127.0.0.1] (primary)
node-2.redis.my.domain[127.0.0.3] (replica)
```

In such a scenario, the following observation can be made:

The discovery of a new mapping from DNS host name to ip address in `DNSMonitor` leads to the addition of a new replica entry in `MasterSlaveEntry` and consequently also in `LoadBalancerManger`. 

Now that there exist two entries with the same host name but different ip addresses, we run into a problem that is caused by `ReplicationManager`: There we have a routine that continuously attempts to connect to all configured nodes. If successful and the node is a replica, the replica is declared as `up` ([here](https://github.com/redisson/redisson/blob/master/redisson/src/main/java/org/redisson/connection/ReplicatedConnectionManager.java#L171)). The problem now is, that *only the host name* is used for that. Which of the two possible connections is actually reactivated depends on the ordering of `ClientConnectionEntries` [here](https://github.com/redisson/redisson/blob/master/redisson/src/main/java/org/redisson/connection/balancer/LoadBalancerManager.java#L206). I observed cases, where the wrong connection was reactivated leading to requests being routed to an inaccessible replica. This situation can only be resolved by application restart.

This PR fixes this problem by making `ReplicationManager` use the ip address of the successfully established connection to declare a replica as `up` instead of the host name in order to remove ambiguity from client-connection selection.

I want to extend this PR by causing `DNSMonitor` to completely remove connections to the old ip address, but I'm a bit hesitant as the addition of new entries instead of replacing old with new on DNS change seems to be done deliberately. Can you share your thoughts on that @mrniko?