### PR TITLE
Fix for #2528 Connection to password protected Sentinel

### DIFF
--- a/redisson/src/main/java/org/redisson/connection/SentinelConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/SentinelConnectionManager.java
@@ -206,13 +206,13 @@ public class SentinelConnectionManager extends MasterSlaveConnectionManager {
         
         for (String address : cfg.getSentinelAddresses()) {
             RedisURI addr = new RedisURI(address);
+            scheme = addr.getScheme();
             RedisClient client = createClient(NodeType.SENTINEL, addr, this.config.getConnectTimeout(), this.config.getTimeout(), null);
             try {
                 RedisConnection c = client.connect();
                 connected = true;
                 try {
                     c.sync(RedisCommands.PING);
-                    scheme = addr.getScheme();
                 } catch (RedisAuthRequiredException e) {
                     usePassword = true;
                 }

--- a/redisson/src/main/java/org/redisson/spring/cache/RedissonCacheStatisticsAutoConfiguration.java
+++ b/redisson/src/main/java/org/redisson/spring/cache/RedissonCacheStatisticsAutoConfiguration.java
@@ -35,7 +35,7 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 @AutoConfigureAfter(CacheAutoConfiguration.class)
-@ConditionalOnBean(CacheManager.class)
+@ConditionalOnBean({CacheManager.class, RedissonCache.class})
 @ConditionalOnClass(CacheMeterBinderProvider.class)
 public class RedissonCacheStatisticsAutoConfiguration {
     


### PR DESCRIPTION
Moved the extraction of scheme from sentinel address in order to always be available regardless whether a password is required.