### PR TITLE
Fix for issue #2528 Now always extracting scheme from url for sentinel connections

### DIFF
--- a/redisson/src/main/java/org/redisson/connection/SentinelConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/SentinelConnectionManager.java
@@ -206,13 +206,13 @@ public class SentinelConnectionManager extends MasterSlaveConnectionManager {
         
         for (String address : cfg.getSentinelAddresses()) {
             RedisURI addr = new RedisURI(address);
+            scheme = addr.getScheme();
             RedisClient client = createClient(NodeType.SENTINEL, addr, this.config.getConnectTimeout(), this.config.getTimeout(), null);
             try {
                 RedisConnection c = client.connect();
                 connected = true;
                 try {
                     c.sync(RedisCommands.PING);
-                    scheme = addr.getScheme();
                 } catch (RedisAuthRequiredException e) {
                     usePassword = true;
                 }


### PR DESCRIPTION
Moved the extraction of scheme from sentinel address in order to always be available regardless whether a password is required.