### PR TITLE
Add an auto configuration customizer

### DIFF
--- a/redisson-spring-boot-starter/src/main/java/org/redisson/spring/starter/RedissonAutoConfiguration.java
+++ b/redisson-spring-boot-starter/src/main/java/org/redisson/spring/starter/RedissonAutoConfiguration.java
@@ -47,6 +47,7 @@ import org.springframework.util.ReflectionUtils;
 /**
  * 
  * @author Nikita Koksharov
+ * @author Nikos Kakavas (https://github.com/nikakis)
  *
  */
 @Configuration
@@ -54,6 +55,9 @@ import org.springframework.util.ReflectionUtils;
 @AutoConfigureBefore(RedisAutoConfiguration.class)
 @EnableConfigurationProperties({RedissonProperties.class, RedisProperties.class})
 public class RedissonAutoConfiguration {
+
+    @Autowired(required = false)
+    private List<RedissonAutoConfigurationCustomizer> redissonAutoConfigurationCustomizers;
 
     @Autowired
     private RedissonProperties redissonProperties;
@@ -160,7 +164,11 @@ public class RedissonAutoConfiguration {
                 .setDatabase(redisProperties.getDatabase())
                 .setPassword(redisProperties.getPassword());
         }
-        
+        if (redissonAutoConfigurationCustomizers != null) {
+            for (RedissonAutoConfigurationCustomizer customizer : redissonAutoConfigurationCustomizers) {
+                customizer.customize(config);
+            }
+        }
         return Redisson.create(config);
     }
 

--- a/redisson-spring-boot-starter/src/main/java/org/redisson/spring/starter/RedissonAutoConfigurationCustomizer.java
+++ b/redisson-spring-boot-starter/src/main/java/org/redisson/spring/starter/RedissonAutoConfigurationCustomizer.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2013-2020 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.spring.starter;
+
+import org.redisson.config.Config;
+
+/**
+ * Callback interface that can be implemented by beans wishing to customize
+ * the {@link org.redisson.api.RedissonClient} auto configuration
+ *
+ * @author Nikos Kakavas (https://github.com/nikakis)
+ */
+@FunctionalInterface
+public interface RedissonAutoConfigurationCustomizer {
+
+    /**
+     * Customize the RedissonClient configuration.
+     * @param configuration the {@link Config} to customize
+     */
+    void customize(final Config configuration);
+}


### PR DESCRIPTION
Add a customizer interface that can be implemented by beans wishing to customize the RedissonClient auto configuration