### PR TITLE
Change session id without renaming key

### DIFF
--- a/redisson/src/main/java/org/redisson/spring/session/RedissonSessionRepository.java
+++ b/redisson/src/main/java/org/redisson/spring/session/RedissonSessionRepository.java
@@ -205,8 +205,8 @@ public class RedissonSessionRepository implements FindByIndexNameSessionReposito
             RBatch batch = redisson.createBatch(BatchOptions.defaults());
             batch.getBucket(getExpiredKey(oldId)).remainTimeToLiveAsync();
             batch.getBucket(getExpiredKey(oldId)).deleteAsync();
-            batch.getMap(map.toString()).readAllMapAsync();
-            batch.getMap(map.toString()).deleteAsync();
+            batch.getMap(map.getName()).readAllMapAsync();
+            batch.getMap(map.getName()).deleteAsync();
 
             BatchResult<?> res = batch.execute();
             List<?> list = res.getResponses();


### PR DESCRIPTION
Using Redis Enterprise requires to connect as if it was a standalone
redis although it is a redis cluster. While this is great from a
technical point of view this leads to a nasty error when using spring
session because renaming keys in a redis cluster is only possible if
the hashslots of the old and new key are the same.

The resulting error is

```
org.springframework.dao.InvalidDataAccessApiUsageException:
  CROSSSLOT Keys in request don't hash to the same slot
  (command='RENAME', original slot=12273, wrong slot=10406,
  first key='spring:session:sessions:90ef42c7-xxxx-xxxx-800f-2d1a48d0aa07',
  violating key='spring:session:sessions:477ba6b1-5b8e-xxxx-xxxx-d6adeab0b580');
```

By not using the RENAME command any more changeSessionId works on all
Redis distributions.