### PR TITLE
Make JCacheManager constructor public

### DIFF
--- a/redisson/src/main/java/org/redisson/jcache/JCacheManager.java
+++ b/redisson/src/main/java/org/redisson/jcache/JCacheManager.java
@@ -66,7 +66,7 @@ public class JCacheManager implements CacheManager {
     
     private final Redisson redisson;
     
-    JCacheManager(Redisson redisson, ClassLoader classLoader, CachingProvider cacheProvider, Properties properties, URI uri) {
+    public JCacheManager(Redisson redisson, ClassLoader classLoader, CachingProvider cacheProvider, Properties properties, URI uri) {
         super();
         this.classLoader = classLoader;
         this.cacheProvider = cacheProvider;
@@ -354,9 +354,11 @@ public class JCacheManager implements CacheManager {
             return;
         }
 
-        synchronized (cacheProvider) {
+        synchronized (this) {
             if (!isClosed()) {
-                cacheProvider.close(uri, classLoader);
+                if (cacheProvider != null) {
+                    cacheProvider.close( uri, classLoader );
+                }
                 for (Cache<?, ?> cache : caches.values()) {
                     try {
                         cache.close();

--- a/redisson/src/main/java/org/redisson/jcache/JCacheManager.java
+++ b/redisson/src/main/java/org/redisson/jcache/JCacheManager.java
@@ -357,7 +357,7 @@ public class JCacheManager implements CacheManager {
         synchronized (this) {
             if (!isClosed()) {
                 if (cacheProvider != null) {
-                    cacheProvider.close( uri, classLoader );
+                    cacheProvider.close(uri, classLoader);
                 }
                 for (Cache<?, ?> cache : caches.values()) {
                     try {


### PR DESCRIPTION
I have a case when the underlying cache provider is being selected and configured programmatically. In particular, I need to configure a Redisson client beforehand and create an instance of JCacheManager directly without using JCachingProvider.