### PR TITLE
Migrate javadoc plugin configuration to used version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,7 +283,7 @@
          	</executions>
                 <configuration>
                     <level>public</level>
-                    <additionalparam>-Xdoclint:none</additionalparam>
+                    <doclint>none</doclint>
                     <quiet>true</quiet>
                 </configuration>
             </plugin>


### PR DESCRIPTION
The used doclint option is not valid anymore. Use the correct <doclint> configuration option.