### PR TITLE
Use correct linkXRef instead of linkXref for pmd plugin

### DIFF
--- a/redisson/pom.xml
+++ b/redisson/pom.xml
@@ -384,7 +384,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <linkXref>true</linkXref>
+                    <linkXRef>true</linkXRef>
                     <minimumTokens>100</minimumTokens>
                     <targetJdk>${source.version}</targetJdk>
                     <verbose>true</verbose>


### PR DESCRIPTION
The configuration key has an typo.