### PR TITLE
Use enforcer plugin instead of prerequisites

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,10 +31,6 @@
         <tag>HEAD</tag>
     </scm>
 
-    <prerequisites>
-        <maven>3.0.5</maven>
-    </prerequisites>
-
     <licenses>
         <license>
             <name>Apache v2</name>
@@ -154,7 +150,7 @@
       <sourceDirectory>${basedir}/src/main/java</sourceDirectory>
       <testSourceDirectory>${basedir}/src/test/java</testSourceDirectory>
 
-        <plugins>	
+        <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
@@ -286,6 +282,27 @@
                     <doclint>none</doclint>
                     <quiet>true</quiet>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M3</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.0.5</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
   </build>

--- a/redisson-all/pom.xml
+++ b/redisson-all/pom.xml
@@ -29,10 +29,6 @@
         <tag>redisson-parent-0.9.0</tag>
     </scm>
 
-    <prerequisites>
-        <maven>3.0.5</maven>
-    </prerequisites>
-
     <licenses>
         <license>
             <name>Apache v2</name>


### PR DESCRIPTION
Enforcer plugin should be used in maven project and <prerequisites> in maven-plugin projects.