### PR TITLE
fix bug about lock exception between RedissonLock and RedissonReadWri…

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonReadLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonReadLock.java
@@ -52,7 +52,12 @@ public class RedissonReadLock extends RedissonLock implements RLock {
     String getReadWriteTimeoutNamePrefix(long threadId) {
         return suffixName(getName(), getLockName(threadId)) + ":rwlock_timeout"; 
     }
-    
+
+    @Override
+    public String getName() {
+        return super.getName()+"_rw";
+    }
+
     @Override
     <T> RFuture<T> tryLockInnerAsync(long leaseTime, TimeUnit unit, long threadId, RedisStrictCommand<T> command) {
         internalLockLeaseTime = unit.toMillis(leaseTime);

--- a/redisson/src/main/java/org/redisson/RedissonWriteLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonWriteLock.java
@@ -49,7 +49,12 @@ public class RedissonWriteLock extends RedissonLock implements RLock {
     protected String getLockName(long threadId) {
         return super.getLockName(threadId) + ":write";
     }
-    
+
+    @Override
+    public String getName() {
+        return super.getName()+"_rw";
+    }
+
     @Override
     <T> RFuture<T> tryLockInnerAsync(long leaseTime, TimeUnit unit, long threadId, RedisStrictCommand<T> command) {
         internalLockLeaseTime = unit.toMillis(leaseTime);


### PR DESCRIPTION
Hello, Nikita

This PR's target is that fix distrubuted lock issue between RedissonLock and RedissonReadWriteLock.

Firstly, issue description:

Client-1 is holding a lock with name - "lock_key" by RedissonLock.
if success:

**lock_key{
  uuid_01:thread_id_01 => 1
}**

And then client-2 is going to fetch a read/write lock  with name - "lock_key" by RedissonReadWriteLock.
successful condition:  hget lock_key mode && mode == false
so it will be also successful to hold a read/write lock.

The result:

**lock_key{
   mode => read
   uuid_01:thread_id_01 => 1
   uuid_02:thread_id_02 => 1 	
}
{lock_key}:uuid_02:thread_id_02:rwlock_timeout_1 1**

but, if right now, the client-1 is ready to release the lock, then 
Lua command will delete lock_key directly, so read/write lock is also clear.

Secondly,  How to slove this issue ?

I considered that this issue can be fixed by two way:

The first choice is that we can modify lua commod for adjusting lock condition in read/write lock scene.
The cheap cost choise that just override the function "getName() " with adding suffix-"_rw" in RedissonReadLock and RedissonWriteLock. 

This is my first time to submit PR
So I am looking forward to yr acception that is your encouragement to me，Thanks
