### PR TITLE
fix: check RedisConnection status befor RedisConnection object join f…

### DIFF
--- a/redisson/src/main/java/org/redisson/connection/ClientConnectionsEntry.java
+++ b/redisson/src/main/java/org/redisson/connection/ClientConnectionsEntry.java
@@ -151,6 +151,10 @@ public class ClientConnectionsEntry {
     }
 
     public void releaseConnection(RedisConnection connection) {
+        if (connection.isClosed()) {
+            return;
+        }
+
         if (client != connection.getRedisClient()) {
             connection.closeAsync();
             return;


### PR DESCRIPTION
fix: https://github.com/redisson/redisson/issues/2947
当网络抖动的时候,某个节点频繁的down,up,最终导致freeConnection中混入了RedisConnection.closed==true的连接,并且在后续的从ClientConnectionEntry中pollConnection的时候没有检测机制,导致已经关闭的连接被取出,sendcommand失败触发timeouter.

最终导致网络波动结束,网络恢复正常后,有部分请求还是会触发retry (attempt>0)

经确认,RedisConnection.closed=true仅通过RedisConnection.closeAsync()方法触发,一定是主动关闭,并且nettychannel经过closeAsync()后一定是关闭或将被关闭且不会重连,故在ClientConnectionsEntry.releaseConnection(RedisConnection connection)中检测,如果RedisConnection.isClosed,不将此RedisConnection加入回freeConnections中

在本地测试中有效修复问题