### PR TITLE
Rate limiter update rate

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonRateLimiter.java
+++ b/redisson/src/main/java/org/redisson/RedissonRateLimiter.java
@@ -242,6 +242,21 @@ public class RedissonRateLimiter extends RedissonExpirable implements RRateLimit
               + "return redis.call('hsetnx', KEYS[1], 'type', ARGV[3]);",
                 Collections.singletonList(getName()), rate, unit.toMillis(rateInterval), type.ordinal());
     }
+
+    @Override
+    public boolean updateRate(RateType type, long rate, long rateInterval, RateIntervalUnit unit) {
+        return get(updateRateAsync(type, rate, rateInterval, unit));
+    }
+
+    @Override
+    public RFuture<Boolean> updateRateAsync(RateType type, long rate, long rateInterval, RateIntervalUnit unit) {
+        return commandExecutor.evalWriteAsync(getName(), LongCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
+                "redis.call('hset', KEYS[1], 'rate', ARGV[1]);"
+                        + "redis.call('hset', KEYS[1], 'interval', ARGV[2]);"
+                        + "redis.call('hset', KEYS[1], 'type', ARGV[3]);"
+                        + "return redis.call('del', ARGV[4], ARGV[5]);",
+                Collections.<Object>singletonList(getName()), rate, unit.toMillis(rateInterval), type.ordinal(), getValueName(), getPermitsName());
+    }
     
     private static final RedisCommand HGETALL = new RedisCommand("HGETALL", new MultiDecoder<RateLimiterConfig>() {
         @Override

--- a/redisson/src/main/java/org/redisson/RedissonRateLimiter.java
+++ b/redisson/src/main/java/org/redisson/RedissonRateLimiter.java
@@ -244,13 +244,13 @@ public class RedissonRateLimiter extends RedissonExpirable implements RRateLimit
     }
 
     @Override
-    public boolean setRate(RateType type, long rate, long rateInterval, RateIntervalUnit unit) {
-        return get(setRateAsync(type, rate, rateInterval, unit));
+    public void setRate(RateType type, long rate, long rateInterval, RateIntervalUnit unit) {
+        setRateAsync(type, rate, rateInterval, unit);
     }
 
     @Override
-    public RFuture<Boolean> setRateAsync(RateType type, long rate, long rateInterval, RateIntervalUnit unit) {
-        return commandExecutor.evalWriteAsync(getName(), LongCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
+    public RFuture<Void> setRateAsync(RateType type, long rate, long rateInterval, RateIntervalUnit unit) {
+         return commandExecutor.evalWriteAsync(getName(), LongCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
                 "redis.call('hset', KEYS[1], 'rate', ARGV[1]);"
                         + "redis.call('hset', KEYS[1], 'interval', ARGV[2]);"
                         + "redis.call('hset', KEYS[1], 'type', ARGV[3]);"

--- a/redisson/src/main/java/org/redisson/RedissonRateLimiter.java
+++ b/redisson/src/main/java/org/redisson/RedissonRateLimiter.java
@@ -254,7 +254,7 @@ public class RedissonRateLimiter extends RedissonExpirable implements RRateLimit
                 "redis.call('hset', KEYS[1], 'rate', ARGV[1]);"
                         + "redis.call('hset', KEYS[1], 'interval', ARGV[2]);"
                         + "redis.call('hset', KEYS[1], 'type', ARGV[3]);"
-                        + "return redis.call('del', KEYS[2], KEYS[3]);",
+                        + "redis.call('del', KEYS[2], KEYS[3]);",
                 Arrays.asList(getName(), getValueName(), getPermitsName()), rate, unit.toMillis(rateInterval), type.ordinal());
     }
     

--- a/redisson/src/main/java/org/redisson/api/RRateLimiter.java
+++ b/redisson/src/main/java/org/redisson/api/RRateLimiter.java
@@ -36,6 +36,18 @@ public interface RRateLimiter extends RRateLimiterAsync, RExpirable {
      *         otherwise
      */
     boolean trySetRate(RateType mode, long rate, long rateInterval, RateIntervalUnit rateIntervalUnit);
+
+    /**
+     * Updates RateLimiter's state and stores config to Redis server.
+     *
+     * @param mode - rate mode
+     * @param rate - rate
+     * @param rateInterval - rate time interval
+     * @param rateIntervalUnit - rate time interval unit
+     * @return {@code true} if rate was set and {@code false}
+     *         otherwise
+     */
+    boolean updateRate(RateType mode, long rate, long rateInterval, RateIntervalUnit rateIntervalUnit);
     
     /**
      * Acquires a permit only if one is available at the

--- a/redisson/src/main/java/org/redisson/api/RRateLimiter.java
+++ b/redisson/src/main/java/org/redisson/api/RRateLimiter.java
@@ -47,7 +47,7 @@ public interface RRateLimiter extends RRateLimiterAsync, RExpirable {
      * @return {@code true} if rate was set and {@code false}
      *         otherwise
      */
-    boolean updateRate(RateType mode, long rate, long rateInterval, RateIntervalUnit rateIntervalUnit);
+    boolean setRate(RateType mode, long rate, long rateInterval, RateIntervalUnit rateIntervalUnit);
     
     /**
      * Acquires a permit only if one is available at the

--- a/redisson/src/main/java/org/redisson/api/RRateLimiter.java
+++ b/redisson/src/main/java/org/redisson/api/RRateLimiter.java
@@ -44,10 +44,8 @@ public interface RRateLimiter extends RRateLimiterAsync, RExpirable {
      * @param rate - rate
      * @param rateInterval - rate time interval
      * @param rateIntervalUnit - rate time interval unit
-     * @return {@code true} if rate was set and {@code false}
-     *         otherwise
      */
-    boolean setRate(RateType mode, long rate, long rateInterval, RateIntervalUnit rateIntervalUnit);
+    void setRate(RateType mode, long rate, long rateInterval, RateIntervalUnit rateIntervalUnit);
     
     /**
      * Acquires a permit only if one is available at the

--- a/redisson/src/main/java/org/redisson/api/RRateLimiterAsync.java
+++ b/redisson/src/main/java/org/redisson/api/RRateLimiterAsync.java
@@ -155,7 +155,7 @@ public interface RRateLimiterAsync extends RExpirableAsync {
      * @return {@code true} if rate was set and {@code false}
      *         otherwise
      */
-    RFuture<Boolean> setRateAsync(RateType mode, long rate, long rateInterval, RateIntervalUnit rateIntervalUnit);
+    RFuture<Void> setRateAsync(RateType mode, long rate, long rateInterval, RateIntervalUnit rateIntervalUnit);
 
     /**
      * Returns current configuration of this RateLimiter object.

--- a/redisson/src/main/java/org/redisson/api/RRateLimiterAsync.java
+++ b/redisson/src/main/java/org/redisson/api/RRateLimiterAsync.java
@@ -142,7 +142,21 @@ public interface RRateLimiterAsync extends RExpirableAsync {
      *         if the waiting time elapsed before a permit was acquired
      */
     RFuture<Boolean> tryAcquireAsync(long permits, long timeout, TimeUnit unit);
-    
+
+
+    /**
+     * Updates RateLimiter's state and stores config to Redis server.
+     *
+     *
+     * @param mode - rate mode
+     * @param rate - rate
+     * @param rateInterval - rate time interval
+     * @param rateIntervalUnit - rate time interval unit
+     * @return {@code true} if rate was set and {@code false}
+     *         otherwise
+     */
+    RFuture<Boolean> updateRateAsync(RateType mode, long rate, long rateInterval, RateIntervalUnit rateIntervalUnit);
+
     /**
      * Returns current configuration of this RateLimiter object.
      * 

--- a/redisson/src/main/java/org/redisson/api/RRateLimiterAsync.java
+++ b/redisson/src/main/java/org/redisson/api/RRateLimiterAsync.java
@@ -155,7 +155,7 @@ public interface RRateLimiterAsync extends RExpirableAsync {
      * @return {@code true} if rate was set and {@code false}
      *         otherwise
      */
-    RFuture<Boolean> updateRateAsync(RateType mode, long rate, long rateInterval, RateIntervalUnit rateIntervalUnit);
+    RFuture<Boolean> setRateAsync(RateType mode, long rate, long rateInterval, RateIntervalUnit rateIntervalUnit);
 
     /**
      * Returns current configuration of this RateLimiter object.

--- a/redisson/src/main/java/org/redisson/api/RRateLimiterReactive.java
+++ b/redisson/src/main/java/org/redisson/api/RRateLimiterReactive.java
@@ -40,6 +40,18 @@ public interface RRateLimiterReactive extends RExpirableReactive {
     Mono<Boolean> trySetRate(RateType mode, long rate, long rateInterval, RateIntervalUnit rateIntervalUnit);
 
     /**
+     * Updates RateLimiter's state and stores config to Redis server.
+     *
+     * @param mode - rate mode
+     * @param rate - rate
+     * @param rateInterval - rate time interval
+     * @param rateIntervalUnit - rate time interval unit
+     * @return {@code true} if rate was set and {@code false}
+     *         otherwise
+     */
+    Mono<Boolean> setRate(RateType mode, long rate, long rateInterval, RateIntervalUnit rateIntervalUnit);
+
+    /**
      * Acquires a permit only if one is available at the
      * time of invocation.
      *

--- a/redisson/src/main/java/org/redisson/api/RRateLimiterReactive.java
+++ b/redisson/src/main/java/org/redisson/api/RRateLimiterReactive.java
@@ -46,10 +46,9 @@ public interface RRateLimiterReactive extends RExpirableReactive {
      * @param rate - rate
      * @param rateInterval - rate time interval
      * @param rateIntervalUnit - rate time interval unit
-     * @return {@code true} if rate was set and {@code false}
-     *         otherwise
+     *
      */
-    Mono<Boolean> setRate(RateType mode, long rate, long rateInterval, RateIntervalUnit rateIntervalUnit);
+    Mono<Void> setRate(RateType mode, long rate, long rateInterval, RateIntervalUnit rateIntervalUnit);
 
     /**
      * Acquires a permit only if one is available at the

--- a/redisson/src/main/java/org/redisson/api/RRateLimiterRx.java
+++ b/redisson/src/main/java/org/redisson/api/RRateLimiterRx.java
@@ -41,6 +41,18 @@ public interface RRateLimiterRx extends RExpirableRx {
     Single<Boolean> trySetRate(RateType mode, long rate, long rateInterval, RateIntervalUnit rateIntervalUnit);
 
     /**
+     * Updates RateLimiter's state and stores config to Redis server.
+     *
+     * @param mode - rate mode
+     * @param rate - rate
+     * @param rateInterval - rate time interval
+     * @param rateIntervalUnit - rate time interval unit
+     * @return {@code true} if rate was set and {@code false}
+     *         otherwise
+     */
+    Single<Boolean> setRate(RateType mode, long rate, long rateInterval, RateIntervalUnit rateIntervalUnit);
+
+    /**
      * Acquires a permit only if one is available at the
      * time of invocation.
      *

--- a/redisson/src/main/java/org/redisson/api/RRateLimiterRx.java
+++ b/redisson/src/main/java/org/redisson/api/RRateLimiterRx.java
@@ -47,10 +47,9 @@ public interface RRateLimiterRx extends RExpirableRx {
      * @param rate - rate
      * @param rateInterval - rate time interval
      * @param rateIntervalUnit - rate time interval unit
-     * @return {@code true} if rate was set and {@code false}
-     *         otherwise
+     *
      */
-    Single<Boolean> setRate(RateType mode, long rate, long rateInterval, RateIntervalUnit rateIntervalUnit);
+    Single<Void> setRate(RateType mode, long rate, long rateInterval, RateIntervalUnit rateIntervalUnit);
 
     /**
      * Acquires a permit only if one is available at the

--- a/redisson/src/test/java/org/redisson/RedissonRateLimiterTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonRateLimiterTest.java
@@ -61,7 +61,7 @@ public class RedissonRateLimiterTest extends BaseTest {
     public void testUpdateRateConfig() {
         RRateLimiter rr = redisson.getRateLimiter("acquire");
         assertThat(rr.trySetRate(RateType.OVERALL, 1, 5, RateIntervalUnit.SECONDS)).isTrue();
-        rr.updateRate(RateType.OVERALL, 2, 5, RateIntervalUnit.SECONDS);
+        rr.setRate(RateType.OVERALL, 2, 5, RateIntervalUnit.SECONDS);
 
         assertThat(rr.getConfig().getRate()).isEqualTo(2);
         assertThat(rr.getConfig().getRateInterval()).isEqualTo(5000);

--- a/redisson/src/test/java/org/redisson/RedissonRateLimiterTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonRateLimiterTest.java
@@ -56,6 +56,17 @@ public class RedissonRateLimiterTest extends BaseTest {
         assertThat(rr.getConfig().getRateInterval()).isEqualTo(5000);
         assertThat(rr.getConfig().getRateType()).isEqualTo(RateType.OVERALL);
     }
+
+    @Test
+    public void testUpdateRateConfig() {
+        RRateLimiter rr = redisson.getRateLimiter("acquire");
+        assertThat(rr.trySetRate(RateType.OVERALL, 1, 5, RateIntervalUnit.SECONDS)).isTrue();
+        assertThat(rr.updateRate(RateType.OVERALL, 2, 5, RateIntervalUnit.SECONDS)).isTrue();
+
+        assertThat(rr.getConfig().getRate()).isEqualTo(2);
+        assertThat(rr.getConfig().getRateInterval()).isEqualTo(5000);
+        assertThat(rr.getConfig().getRateType()).isEqualTo(RateType.OVERALL);
+    }
     
     @Test
     public void testPermitsExceeding() throws InterruptedException {

--- a/redisson/src/test/java/org/redisson/RedissonRateLimiterTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonRateLimiterTest.java
@@ -61,7 +61,7 @@ public class RedissonRateLimiterTest extends BaseTest {
     public void testUpdateRateConfig() {
         RRateLimiter rr = redisson.getRateLimiter("acquire");
         assertThat(rr.trySetRate(RateType.OVERALL, 1, 5, RateIntervalUnit.SECONDS)).isTrue();
-        assertThat(rr.updateRate(RateType.OVERALL, 2, 5, RateIntervalUnit.SECONDS)).isTrue();
+        rr.updateRate(RateType.OVERALL, 2, 5, RateIntervalUnit.SECONDS);
 
         assertThat(rr.getConfig().getRate()).isEqualTo(2);
         assertThat(rr.getConfig().getRateInterval()).isEqualTo(5000);


### PR DESCRIPTION
Addresses https://github.com/redisson/redisson/issues/2322. Added methods to update(overwrite) a rate. The methods 'hset'(as opposed to 'hsetnx') is used to update the rate config, and also delete the {name}:permits and {name}:value entries, which are then created during the next instance of acquire.