### PR TITLE
Expand config variables from system properties if not found as environment variables.

### DIFF
--- a/redisson/src/main/java/org/redisson/config/ConfigSupport.java
+++ b/redisson/src/main/java/org/redisson/config/ConfigSupport.java
@@ -104,11 +104,14 @@ public class ConfigSupport {
     }
     
     private String resolveEnvParams(String content) {
-        Pattern pattern = Pattern.compile("\\$\\{(\\w+(:-.+?)?)\\}");
+        Pattern pattern = Pattern.compile("\\$\\{([\\w\\.]+(:-.+?)?)\\}");
         Matcher m = pattern.matcher(content);
         while (m.find()) {
             String[] parts = m.group(1).split(":-");
             String v = System.getenv(parts[0]);
+            if (v == null) {
+                v = System.getProperty(parts[0]);
+            }
             if (v != null) {
                 content = content.replace(m.group(), v);
             } else if (parts.length == 2) {

--- a/redisson/src/test/java/org/redisson/config/ConfigSupportTest.java
+++ b/redisson/src/test/java/org/redisson/config/ConfigSupportTest.java
@@ -25,6 +25,14 @@ public class ConfigSupportTest {
         
         assertEquals("redis://1.1.1.1", config.getAddress());
     }
+
+    @Test
+    public void testParsingProperty() throws IOException {
+        mockHostProperty("1.1.1.1");
+        SingleServerConfig config = mkConfig("${REDIS_URI}");
+
+        assertEquals("redis://1.1.1.1", config.getAddress());
+    }
     
     @Test
     public void testParsingEnv2() throws IOException {
@@ -35,8 +43,17 @@ public class ConfigSupportTest {
     }
 
     @Test
+    public void testParsingProperty2() throws IOException {
+        mockHostPortProperty("1.1.1.1", "6379");
+        SingleServerConfig config = mkConfig("${REDIS_HOST}:${REDIS_PORT}");
+
+        assertEquals("redis://1.1.1.1:6379", config.getAddress());
+    }
+
+    @Test
     public void testParsingEnv_envMissing() throws IOException {
         mockHostEnv(null);
+        mockHostProperty(null);
         final SingleServerConfig config = mkConfig("${REDIS_URI}");
 
         assertEquals("redis://${REDIS_URI}", config.getAddress());
@@ -49,6 +66,14 @@ public class ConfigSupportTest {
         
         assertEquals("redis://11.0.0.1", config.getAddress());
     }
+
+    @Test
+    public void testParsingDefault_propertyPresent() throws IOException {
+        mockHostProperty("11.0.0.1");
+        SingleServerConfig config = mkConfig("${REDIS_URI:-10.0.0.1}");
+
+        assertEquals("redis://11.0.0.1", config.getAddress());
+    }
     
     @Test
     public void testParsingDefault_envPresent2() throws IOException {
@@ -57,10 +82,19 @@ public class ConfigSupportTest {
 
         assertEquals("redis://11.0.0.1:1234", config.getAddress());
     }
+
+    @Test
+    public void testParsingDefault_propertyPresent2() throws IOException {
+        mockHostPortProperty("11.0.0.1", "1234");
+        SingleServerConfig config = mkConfig("${REDIS_HOST:-127.0.0.1}:${REDIS_PORT:-6379}");
+
+        assertEquals("redis://11.0.0.1:1234", config.getAddress());
+    }
     
     @Test
     public void testParsingDefault_envMissing() throws IOException {
         mockHostEnv(null);
+        mockHostProperty(null);
         SingleServerConfig config = mkConfig("${REDIS_URI:-10.0.0.1}");
         
         assertEquals("redis://10.0.0.1", config.getAddress());
@@ -69,7 +103,24 @@ public class ConfigSupportTest {
     @Test
     public void testParsingDefault_envMissing2() throws IOException {
         mockHostPortEnv(null, null);
+        mockHostPortProperty(null, null);
         SingleServerConfig config = mkConfig("${REDIS_HOST:-127.0.0.1}:${REDIS_PORT:-6379}");
+
+        assertEquals("redis://127.0.0.1:6379", config.getAddress());
+    }
+
+    @Test
+    public void testParsingDefaultPeriod_propertyPresent2() throws IOException {
+        mockHostPortPropertyPeriod("11.0.0.1", "1234");
+        SingleServerConfig config = mkConfig("${REDIS.HOST:-127.0.0.1}:${REDIS.PORT:-6379}");
+
+        assertEquals("redis://11.0.0.1:1234", config.getAddress());
+    }
+
+    @Test
+    public void testParsingDefaultPeriod_envMissing() throws IOException {
+        mockHostPortProperty(null, null);
+        SingleServerConfig config = mkConfig("${REDIS.HOST:-127.0.0.1}:${REDIS.PORT:-6379}");
 
         assertEquals("redis://127.0.0.1:6379", config.getAddress());
     }
@@ -87,6 +138,15 @@ public class ConfigSupportTest {
             }
         };
     }
+
+    private void mockHostProperty(String value) {
+        new MockUp<System>() {
+            @Mock
+            String getProperty(String name) {
+                return value;
+            }
+        };
+    }
     
     private void mockHostPortEnv(String host, String port) {
         new MockUp<System>() {
@@ -96,6 +156,38 @@ public class ConfigSupportTest {
                     case "REDIS_HOST":
                         return host;
                     case "REDIS_PORT":
+                        return port;
+                    default:
+                        return null;
+                }
+            }
+        };
+    }
+
+    private void mockHostPortProperty(String host, String port) {
+        new MockUp<System>() {
+            @Mock
+            String getProperty(String name) {
+                switch (name) {
+                    case "REDIS_HOST":
+                        return host;
+                    case "REDIS_PORT":
+                        return port;
+                    default:
+                        return null;
+                }
+            }
+        };
+    }
+
+    private void mockHostPortPropertyPeriod(String host, String port) {
+        new MockUp<System>() {
+            @Mock
+            String getProperty(String name) {
+                switch (name) {
+                    case "REDIS.HOST":
+                        return host;
+                    case "REDIS.PORT":
                         return port;
                     default:
                         return null;


### PR DESCRIPTION
Expand config variables from system properties if not found as environment variables. From the javadoc on System.getenv " It is best to use system properties where possible." (https://docs.oracle.com/javase/8/docs/api/java/lang/System.html#getenv-java.lang.String-)

Allow '.' in config variable names: REDIS.HOST as well as REDIS_HOST. It's common to use '.' in the middle of system property names.

This is motivated by a move from using redis-session-manager (https://github.com/chexagon/redis-session-manager) to using RedissonSessionManager. We have extensive configuration using system properties across environments to configure our Redisson clients programmitically and it's much easier to modify ConfigSupport to support the same properties in yaml than it is to modify the environment configurations to use environment variables instead of system properties.