### PR TITLE
bloomfilter add a `addAll` function

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonBloomFilter.java
+++ b/redisson/src/main/java/org/redisson/RedissonBloomFilter.java
@@ -31,6 +31,7 @@ package org.redisson;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -139,7 +140,7 @@ public class RedissonBloomFilter<T> extends RedissonExpirable implements RBloomF
     }
 
     @Override
-    public boolean addAll(List<T> objects) {
+    public boolean addAll(Collection<T> objects) {
         if (objects == null) {
             throw new NullPointerException();
         }

--- a/redisson/src/main/java/org/redisson/RedissonBloomFilter.java
+++ b/redisson/src/main/java/org/redisson/RedissonBloomFilter.java
@@ -29,6 +29,7 @@
 package org.redisson;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -119,6 +120,48 @@ public class RedissonBloomFilter<T> extends RedissonExpirable implements RBloomF
             RBitSetAsync bs = createBitSet(executorService);
             for (int i = 0; i < indexes.length; i++) {
                 bs.setAsync(indexes[i]);
+            }
+            try {
+                List<Boolean> result = (List<Boolean>) executorService.execute().getResponses();
+
+                for (Boolean val : result.subList(1, result.size()-1)) {
+                    if (!val) {
+                        return true;
+                    }
+                }
+                return false;
+            } catch (RedisException e) {
+                if (e.getMessage() == null || !e.getMessage().contains("Bloom filter config has been changed")) {
+                    throw e;
+                }
+            }
+        }
+    }
+
+    @Override
+    public boolean addAll(List<T> objects) {
+        List<long[]> hashesList = new ArrayList<>();
+        for (T t : objects) {
+            long[] hashes = hash(t);
+            hashesList.add(hashes);
+        }
+
+        while (true) {
+            if (size == 0) {
+                readConfig();
+            }
+
+            int hashIterations = this.hashIterations;
+            long size = this.size;
+
+            CommandBatchService executorService = new CommandBatchService(commandExecutor.getConnectionManager());
+            addConfigCheck(hashIterations, size, executorService);
+            RBitSetAsync bs = createBitSet(executorService);
+            for (long[] hashes: hashesList) {
+                long[] indexes = hash(hashes[0], hashes[1], hashIterations, size);
+                for (int i = 0; i < indexes.length; i++) {
+                    bs.setAsync(indexes[i]);
+                }
             }
             try {
                 List<Boolean> result = (List<Boolean>) executorService.execute().getResponses();

--- a/redisson/src/main/java/org/redisson/RedissonBloomFilter.java
+++ b/redisson/src/main/java/org/redisson/RedissonBloomFilter.java
@@ -140,7 +140,11 @@ public class RedissonBloomFilter<T> extends RedissonExpirable implements RBloomF
 
     @Override
     public boolean addAll(List<T> objects) {
-        List<long[]> hashesList = new ArrayList<>();
+        if (objects == null) {
+            throw new NullPointerException();
+        }
+
+        List<long[]> hashesList = new ArrayList<>(objects.size());
         for (T t : objects) {
             long[] hashes = hash(t);
             hashesList.add(hashes);

--- a/redisson/src/main/java/org/redisson/RedissonBloomFilter.java
+++ b/redisson/src/main/java/org/redisson/RedissonBloomFilter.java
@@ -29,11 +29,7 @@
 package org.redisson;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 import org.redisson.api.RBitSetAsync;
@@ -162,11 +158,15 @@ public class RedissonBloomFilter<T> extends RedissonExpirable implements RBloomF
             CommandBatchService executorService = new CommandBatchService(commandExecutor.getConnectionManager());
             addConfigCheck(hashIterations, size, executorService);
             RBitSetAsync bs = createBitSet(executorService);
+            Set<Long> indexSet = new HashSet<>();
             for (long[] hashes: hashesList) {
                 long[] indexes = hash(hashes[0], hashes[1], hashIterations, size);
                 for (int i = 0; i < indexes.length; i++) {
-                    bs.setAsync(indexes[i]);
+                    indexSet.add(indexes[i]);
                 }
+            }
+            for (Long index : indexSet) {
+                bs.setAsync(index);
             }
             try {
                 List<Boolean> result = (List<Boolean>) executorService.execute().getResponses();

--- a/redisson/src/main/java/org/redisson/api/RBloomFilter.java
+++ b/redisson/src/main/java/org/redisson/api/RBloomFilter.java
@@ -36,8 +36,9 @@ public interface RBloomFilter<T> extends RExpirable {
     boolean add(T object);
 
     /**
-     * Adds element
+     * Add elements
      *
+     * @param objects - element to add
      * @return <code>true</code> if elements has been added successfully
      *         <code>false</code> if elements is already present
      */

--- a/redisson/src/main/java/org/redisson/api/RBloomFilter.java
+++ b/redisson/src/main/java/org/redisson/api/RBloomFilter.java
@@ -15,7 +15,7 @@
  */
 package org.redisson.api;
 
-import java.util.List;
+import java.util.Collection;
 
 /**
  * Distributed implementation of Bloom filter based on Highway 128-bit hash.
@@ -42,7 +42,7 @@ public interface RBloomFilter<T> extends RExpirable {
      * @return <code>true</code> if elements has been added successfully
      *         <code>false</code> if elements is already present
      */
-    boolean addAll(List<T> objects);
+    boolean addAll(Collection<T> objects);
 
     /**
      * Check for element present

--- a/redisson/src/main/java/org/redisson/api/RBloomFilter.java
+++ b/redisson/src/main/java/org/redisson/api/RBloomFilter.java
@@ -15,6 +15,8 @@
  */
 package org.redisson.api;
 
+import java.util.List;
+
 /**
  * Distributed implementation of Bloom filter based on Highway 128-bit hash.
  *
@@ -32,6 +34,14 @@ public interface RBloomFilter<T> extends RExpirable {
      *         <code>false</code> if element is already present
      */
     boolean add(T object);
+
+    /**
+     * Adds element
+     *
+     * @return <code>true</code> if elements has been added successfully
+     *         <code>false</code> if elements is already present
+     */
+    boolean addAll(List<T> objects);
 
     /**
      * Check for element present


### PR DESCRIPTION
Sometimes we want to add a lot of object. `add` function is inefficient. So I add this function.
this close #3094 