### PR TITLE
Configure Sentinel Password

### DIFF
--- a/redisson/src/main/java/org/redisson/config/SentinelServersConfig.java
+++ b/redisson/src/main/java/org/redisson/config/SentinelServersConfig.java
@@ -37,6 +37,8 @@ public class SentinelServersConfig extends BaseMasterSlaveServersConfig<Sentinel
 
     private String masterName;
 
+    private String sentinelPassword;
+
     /**
      * Database index used for Redis connection
      */
@@ -60,6 +62,7 @@ public class SentinelServersConfig extends BaseMasterSlaveServersConfig<Sentinel
         setScanInterval(config.getScanInterval());
         setNatMapper(config.getNatMapper());
         setCheckSentinelsList(config.isCheckSentinelsList());
+        setSentinelPassword(config.getSentinelPassword());
     }
 
     /**
@@ -75,6 +78,21 @@ public class SentinelServersConfig extends BaseMasterSlaveServersConfig<Sentinel
     public String getMasterName() {
         return masterName;
     }
+
+    /**
+     * Password required by the Redis Sentinel servers for authentication.
+     *
+     * @param sentinelPassword of Redis
+     * @return config
+     */
+    public SentinelServersConfig setSentinelPassword(String sentinelPassword) {
+        this.sentinelPassword = sentinelPassword;
+        return this;
+    }
+    public String getSentinelPassword() {
+        return sentinelPassword;
+    }
+
 
     /**
      * Add Redis Sentinel node address in host:port format. Multiple nodes at once could be added.

--- a/redisson/src/main/java/org/redisson/connection/SentinelConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/SentinelConnectionManager.java
@@ -62,9 +62,10 @@ public class SentinelConnectionManager extends MasterSlaveConnectionManager {
     private final Set<RedisURI> disconnectedSlaves = new HashSet<>();
     private ScheduledFuture<?> monitorFuture;
     private AddressResolver<InetSocketAddress> sentinelResolver;
-    
+
     private final NatMapper natMapper;
 
+    private final String sentinelPassword;
     private boolean usePassword = false;
     private String scheme;
 
@@ -79,6 +80,7 @@ public class SentinelConnectionManager extends MasterSlaveConnectionManager {
         }
 
         this.config = create(cfg);
+        this.sentinelPassword = cfg.getSentinelPassword();
         initTimer(this.config);
 
         this.natMapper = cfg.getNatMapper();
@@ -251,7 +253,13 @@ public class SentinelConnectionManager extends MasterSlaveConnectionManager {
             String sslHostname) {
         RedisClientConfig result = super.createRedisConfig(type, address, timeout, commandTimeout, sslHostname);
         if (type == NodeType.SENTINEL && !usePassword) {
+            result.setUsername(null);
             result.setPassword(null);
+        } else if (type == NodeType.SENTINEL && usePassword) {
+            result.setUsername(null);
+            if (sentinelPassword != null) {
+                result.setPassword(sentinelPassword);
+            }
         }
         return result;
     }


### PR DESCRIPTION
* Added new configuration field to allow a different password to be
  used for authenticating against sentinel nodes

In order to address https://github.com/redisson/redisson/issues/3030
where sentinel is configured with a password that is not the same as the credentials used to connect to redis.
Example: We created an ACL user entry for our application to have a reduced set of permissions (only allow access to keys matching a prefix and no dangerous commands). but we still want to use sentinel, the app needs to connect to redis as the acl user, and use the sentinel's password when talking there.