### PR TITLE
Fix in RedissonExecutorService

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonExecutorService.java
+++ b/redisson/src/main/java/org/redisson/RedissonExecutorService.java
@@ -429,6 +429,8 @@ public class RedissonExecutorService implements RScheduledExecutorService {
                 try {
                     ObjectOutput oo = new ObjectOutputStream(os);
                     oo.writeObject(task);
+                    oo.flush();
+                    oo.close();
                 } catch (Exception e) {
                     throw new IllegalArgumentException("Unable to serialize lambda", e);
                 }


### PR DESCRIPTION
When wrapping an OutputStream around a ByteArrayOutputStream, it is safer
to flush. See, for example,
 https://stackoverflow.com/questions/2984538/how-to-use-bytearrayoutputstream-and-dataoutputstream-simultaneously-java