### PR TITLE
Preventing sending CLUSTER NODES to the same host

### DIFF
--- a/redisson/src/main/java/org/redisson/cluster/ClusterConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/cluster/ClusterConnectionManager.java
@@ -393,6 +393,9 @@ public class ClusterConnectionManager extends MasterSlaveConnectionManager {
                         partitionSlaves.removeAll(partition.getFailedSlaveAddresses());
                         slaves.addAll(partitionSlaves);
                     }
+                    Collections.shuffle(nodes);
+                    Collections.shuffle(slaves);
+                    
                     // master nodes first
                     nodes.addAll(slaves);
 


### PR DESCRIPTION
We faced into the issue where the CLUSTER NODES command is only sent to the same node. 