### PR TITLE
Add retry logic for same master connection

### DIFF
--- a/redisson/src/test/java/org/redisson/BaseReactiveTest.java
+++ b/redisson/src/test/java/org/redisson/BaseReactiveTest.java
@@ -32,7 +32,7 @@ public abstract class BaseReactiveTest {
 
     @Before
     public void before() throws IOException, InterruptedException {
-        redisson.getKeys().flushall();
+        sync(redisson.getKeys().flushall());
     }
 
     public static <V> Iterable<V> sync(RScoredSortedSetReactive<V> list) {


### PR DESCRIPTION
If there is no master change in redis sentinel mode, and the master connection is broken somehow. Eg: firewall is started and stopped. The redission need to retry and reset the master connection. 
Adding logic to resetup master connection.