### PR TITLE
Avoid redisson fair lock blocking if there are lots of registered thr…

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonFairLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonFairLock.java
@@ -212,7 +212,7 @@ public class RedissonFairLock extends RedissonLock implements RLock {
                         "if (timeout > tonumber(ARGV[4])) and (redis.call('exists', KEYS[1]) == 0) then " +
                             "redis.call('lpop', KEYS[2]);" +
                             "redis.call('zrem', KEYS[3], firstThreadId);" +
-                        "else" +
+                        "else " +
                             "break;" +
                         "end;" +
                     "end;" +

--- a/redisson/src/main/java/org/redisson/RedissonFairLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonFairLock.java
@@ -201,6 +201,22 @@ public class RedissonFairLock extends RedissonLock implements RLock {
                         "return nil;" +
                     "end;" +
 
+
+                    // check if the lock is not held, and other queues are not used
+                    "while true do " +
+                        "local firstThreadId = redis.call('lindex', KEYS[2], 0);" +
+                        "if (firstThreadId == false) or (firstThreadId == ARGV[2]) then " +
+                            "break;"+
+                        "end;" +
+                        "local timeout = tonumber(redis.call('zscore', KEYS[3], firstThreadId));" +
+                        "if (timeout > tonumber(ARGV[4])) and (redis.call('exists', KEYS[1]) == 0) then " +
+                            "redis.call('lpop', KEYS[2]);" +
+                            "redis.call('zrem', KEYS[3], firstThreadId);" +
+                        "else" +
+                            "break;" +
+                        "end;" +
+                    "end;" +
+
                     // the lock cannot be acquired
                     // check if the thread is already in the queue
                     "local timeout = redis.call('zscore', KEYS[3], ARGV[2]);" +

--- a/redisson/src/test/java/org/redisson/RedissonFairLockTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonFairLockTest.java
@@ -933,5 +933,62 @@ public class RedissonFairLockTest extends BaseConcurrentTest {
         await().atMost(30, TimeUnit.SECONDS).until(() -> lockedCounter.get() == totalThreads);
     }
 
+    @Test
+    public void testLockBlock() throws InterruptedException{
+        Config cfg = createConfig();
+        cfg.useSingleServer().setSubscriptionsPerConnection(100);
+        RedissonClient redisson = Redisson.create(cfg);
 
+        int totalExecutorCount = 5;
+        int totalThreadCount = 100;
+        int interval = 1000;
+        Lock lock = redisson.getFairLock("testLockBlock");
+        for (int count = 0; count < totalExecutorCount; count++) {
+            ExecutorService executor = Executors.newFixedThreadPool(totalThreadCount);
+            for (int i = 0; i < totalThreadCount; i++) {
+                final int finalI = i;
+                executor.submit(() -> {
+                    log.info("running " + finalI + " in thread " + Thread.currentThread().getId());
+                    try {
+                        lock.lock();
+                        log.info("Thread " + finalI + " got lock");
+                    } catch (Exception ex) {
+                        log.error("Failed to get lock");
+                    } finally {
+                        lock.unlock();
+                    }
+                });
+            }
+            executor.shutdownNow();
+        }
+        redisson.shutdown();
+
+        // In case connection closed
+        redisson = Redisson.create(cfg);
+        long timeOut = redisson.getConfig().getLockWatchdogTimeout() + interval;
+        ExecutorService lockExecutor = Executors.newFixedThreadPool(1);
+        Lock lockSecond = redisson.getFairLock("testLockBlock");
+        Future<Boolean> future = lockExecutor.submit(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                // check if this lock can be acquired in short time
+                Thread.sleep(timeOut);
+                lockSecond.lock();
+                return Boolean.TRUE;
+            }
+        });
+
+        Boolean got = Boolean.FALSE;
+        try{
+            got = future.get(timeOut + interval, TimeUnit.MILLISECONDS);
+            if (got) {
+                log.info("Got lock immediately after startup");
+            }else{
+                log.info("Failed to get lock due to blocked");
+            }
+        }catch (Exception e){
+            log.info("Failed to get lock due to blocked");
+        }
+        Assert.assertTrue(got);
+    }
 }

--- a/redisson/src/test/java/org/redisson/RedissonFairLockTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonFairLockTest.java
@@ -936,9 +936,9 @@ public class RedissonFairLockTest extends BaseConcurrentTest {
     @Test
     public void testLockBlock() throws InterruptedException{
         Config cfg = createConfig();
-        cfg.useSingleServer().setSubscriptionsPerConnection(100);
-        RedissonClient redisson = Redisson.create(cfg);
+        cfg.setLockWatchdogTimeout(30000);
 
+        RedissonClient redisson = Redisson.create(cfg);
         int totalExecutorCount = 5;
         int totalThreadCount = 100;
         int interval = 1000;


### PR DESCRIPTION
Signed-off-by:  wuqian30624@hundsun.com

If lots of thread registered in redission fair lock queue and timeout map, and all these threads got shutdown accidently. The another app which trys to reuse this fair lock will get blocked for a long time.
Add logic to clear those not used queue info.