### PR TITLE
Add master reconnect logic when there has connection issue

### DIFF
--- a/redisson/src/main/java/org/redisson/connection/SentinelConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/SentinelConnectionManager.java
@@ -68,6 +68,8 @@ public class SentinelConnectionManager extends MasterSlaveConnectionManager {
     private boolean usePassword = false;
     private String scheme;
 
+    private volatile AtomicBoolean hasConnectionException = new AtomicBoolean(false);
+
     public SentinelConnectionManager(SentinelServersConfig cfg, Config config, UUID id) {
         super(config, id);
         
@@ -373,23 +375,32 @@ public class SentinelConnectionManager extends MasterSlaveConnectionManager {
         };
         
         RFuture<InetSocketAddress> masterFuture = connection.async(StringCodec.INSTANCE, RedisCommands.SENTINEL_GET_MASTER_ADDR_BY_NAME, cfg.getMasterName());
-        masterFuture.onComplete((master, e) -> {
-            if (e != null) {
-                return;
-            }
-
-            RedisURI current = currentMaster.get();
-            RedisURI newMaster = toURI(master.getHostString(), String.valueOf(master.getPort()));
-            if (!newMaster.equals(current)
-                    && currentMaster.compareAndSet(current, newMaster)) {
-                RFuture<RedisClient> changeFuture = changeMaster(singleSlotRange.getStartSlot(), newMaster);
-                changeFuture.onComplete((res, ex) -> {
-                    if (ex != null) {
-                        currentMaster.compareAndSet(newMaster, current);
+        BiConsumer<InetSocketAddress, Throwable> masterListener = new BiConsumer<InetSocketAddress, Throwable>() {
+            @Override
+            public void accept(InetSocketAddress master, Throwable e) {
+                if (e != null) {
+                    if (e instanceof RedisTimeoutException) {
+                        hasConnectionException.set(true);
                     }
-                });
+                    return;
+                }
+
+                RedisURI current = currentMaster.get();
+                RedisURI newMaster = toURI(master.getHostString(), String.valueOf(master.getPort()));
+                if ((!newMaster.equals(current) || hasConnectionException.get())
+                        && currentMaster.compareAndSet(current, newMaster)) {
+                    RFuture<RedisClient> changeFuture = changeMaster(singleSlotRange.getStartSlot(), newMaster);
+                    hasConnectionException.set(false);
+                    changeFuture.onComplete((res, ex) -> {
+                        if (ex != null) {
+                            currentMaster.compareAndSet(newMaster, current);
+                        }
+                    });
+                }
             }
-        });
+        };
+
+        masterFuture.onComplete(masterListener);
         masterFuture.onComplete(commonListener);
         
         if (!config.checkSkipSlavesInit()) {


### PR DESCRIPTION
Signed-off-by: wuqian0808hundsun wuqian30624@hundsun.com

If there is no master change in redis sentinel mode, and the master connection is broken somehow. Eg: firewall is started and stopped. The redission need to retry and reset the master connection.
Adding logic to resetup master connection.