### PR TITLE
Avoid redisson fair lock blocking if there are lots of registered threads shutdown 

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonFairLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonFairLock.java
@@ -26,6 +26,7 @@ import org.redisson.client.codec.LongCodec;
 import org.redisson.client.protocol.RedisCommands;
 import org.redisson.client.protocol.RedisStrictCommand;
 import org.redisson.command.CommandAsyncExecutor;
+import org.redisson.executor.FairLockCache;
 import org.redisson.pubsub.LockPubSub;
 
 /**
@@ -44,9 +45,17 @@ public class RedissonFairLock extends RedissonLock implements RLock {
     private final CommandAsyncExecutor commandExecutor;
     private final String threadsQueueName;
     private final String timeoutSetName;
+    public static final String REGISTERED_CLIENT_PREFIX = "redisson_lock_clients";
+    private FairLockCache fairLockCache;
+    public static final long DEFAULT_THREAD_WAIT_TIME = 60000*5;
 
     public RedissonFairLock(CommandAsyncExecutor commandExecutor, String name) {
-        this(commandExecutor, name, 60000*5);
+        this(commandExecutor, name, DEFAULT_THREAD_WAIT_TIME);
+    }
+
+    public RedissonFairLock(CommandAsyncExecutor commandExecutor, String name, FairLockCache fairLockCache) {
+        this(commandExecutor, name, DEFAULT_THREAD_WAIT_TIME);
+        this.fairLockCache = fairLockCache;
     }
 
     public RedissonFairLock(CommandAsyncExecutor commandExecutor, String name, long threadWaitTime) {
@@ -153,84 +162,132 @@ public class RedissonFairLock extends RedissonLock implements RLock {
                     internalLockLeaseTime, getLockName(threadId), currentTime, wait);
         }
 
+        String isClientRegistered = "1";
+        String clientQueuePrefix = "";
+        String clientElementName = "";
+        long clientElementTtl = 0L;
+        if (null != fairLockCache) {
+            if (!fairLockCache.isLockRegistered(name)) {
+                isClientRegistered =  "0";
+            }
+            clientQueuePrefix = fairLockCache.getClientQueueName(name) + "*";
+            clientElementName = fairLockCache.getClientQueueElementName(name);
+            clientElementTtl = fairLockCache.getTtl();
+        }
+
         if (command == RedisCommands.EVAL_LONG) {
-            return evalWriteAsync(getName(), LongCodec.INSTANCE, command,
-                    // remove stale threads
-                    "while true do " +
-                        "local firstThreadId2 = redis.call('lindex', KEYS[2], 0);" +
-                        "if firstThreadId2 == false then " +
-                            "break;" +
-                        "end;" +
-
-                        "local timeout = tonumber(redis.call('zscore', KEYS[3], firstThreadId2));" +
-                        "if timeout <= tonumber(ARGV[4]) then " +
-                            // remove the item from the queue and timeout set
-                            // NOTE we do not alter any other timeout
-                            "redis.call('zrem', KEYS[3], firstThreadId2);" +
-                            "redis.call('lpop', KEYS[2]);" +
-                        "else " +
-                            "break;" +
-                        "end;" +
-                    "end;" +
-
-                    // check if the lock can be acquired now
-                    "if (redis.call('exists', KEYS[1]) == 0) " +
-                        "and ((redis.call('exists', KEYS[2]) == 0) " +
-                            "or (redis.call('lindex', KEYS[2], 0) == ARGV[2])) then " +
-
-                        // remove this thread from the queue and timeout set
-                        "redis.call('lpop', KEYS[2]);" +
-                        "redis.call('zrem', KEYS[3], ARGV[2]);" +
-
-                        // decrease timeouts for all waiting in the queue
-                        "local keys = redis.call('zrange', KEYS[3], 0, -1);" +
-                        "for i = 1, #keys, 1 do " +
-                            "redis.call('zincrby', KEYS[3], -tonumber(ARGV[3]), keys[i]);" +
-                        "end;" +
-
-                        // acquire the lock and set the TTL for the lease
-                        "redis.call('hset', KEYS[1], ARGV[2], 1);" +
-                        "redis.call('pexpire', KEYS[1], ARGV[1]);" +
-                        "return nil;" +
-                    "end;" +
-
-                    // check if the lock is already held, and this is a re-entry
-                    "if redis.call('hexists', KEYS[1], ARGV[2]) == 1 then " +
-                        "redis.call('hincrby', KEYS[1], ARGV[2],1);" +
-                        "redis.call('pexpire', KEYS[1], ARGV[1]);" +
-                        "return nil;" +
-                    "end;" +
-
-                    // the lock cannot be acquired
-                    // check if the thread is already in the queue
-                    "local timeout = redis.call('zscore', KEYS[3], ARGV[2]);" +
-                    "if timeout ~= false then " +
-                        // the real timeout is the timeout of the prior thread
-                        // in the queue, but this is approximately correct, and
-                        // avoids having to traverse the queue
-                        "return timeout - tonumber(ARGV[3]) - tonumber(ARGV[4]);" +
-                    "end;" +
-
-                    // add the thread to the queue at the end, and set its timeout in the timeout set to the timeout of
-                    // the prior thread in the queue (or the timeout of the lock if the queue is empty) plus the
-                    // threadWaitTime
-                    "local lastThreadId = redis.call('lindex', KEYS[2], -1);" +
-                    "local ttl;" +
-                    "if lastThreadId ~= false and lastThreadId ~= ARGV[2] then " +
-                        "ttl = tonumber(redis.call('zscore', KEYS[3], lastThreadId)) - tonumber(ARGV[4]);" +
-                    "else " +
-                        "ttl = redis.call('pttl', KEYS[1]);" +
-                    "end;" +
-                    "local timeout = ttl + tonumber(ARGV[3]) + tonumber(ARGV[4]);" +
-                    "if redis.call('zadd', KEYS[3], timeout, ARGV[2]) == 1 then " +
-                        "redis.call('rpush', KEYS[2], ARGV[2]);" +
-                    "end;" +
-                    "return ttl;",
-                    Arrays.asList(getName(), threadsQueueName, timeoutSetName),
-                    internalLockLeaseTime, getLockName(threadId), wait, currentTime);
+            return getLockTtl(threadId, command, wait, currentTime, isClientRegistered, clientQueuePrefix, clientElementName, clientElementTtl);
         }
 
         throw new IllegalArgumentException();
+    }
+
+    private <T> RFuture<T> getLockTtl(long threadId, RedisStrictCommand<T> command, long wait, long currentTime, String isClientRegistered, String clientQueuePrefix, String clientElementName, long clientElementTtl) {
+        RFuture<T> result = evalWriteAsync(getName(), LongCodec.INSTANCE, command,
+                // remove unnecessary lock queue
+                "if tonumber(ARGV[5]) == 0 then " +
+                            "local clientNo = 0;" +
+                            // only delete elements if there is no registered clients
+                            "local registeredClients = redis.call('keys', KEYS[4]);" +
+                            "if #registeredClients == 0 then " +
+                                "while true do " +
+                                    "local firstThreadId = redis.call('lindex', KEYS[2], 0);" +
+                                    "if firstThreadId == false then " +
+                                        "break;" +
+                                    "end;" +
+
+                                    "redis.call('zrem', KEYS[3], firstThreadId);" +
+                                    "redis.call('lpop', KEYS[2]);" +
+                                 "end; " +
+
+                                // register client ttl
+                                "if (redis.call('exists', KEYS[5]) == 0) then " +
+                                    "redis.call('set', KEYS[5], 1);" +
+                                    "redis.call('pexpire', KEYS[5], ARGV[6]);" +
+                                "end;" +
+                            "end;" +
+                        "end;" +
+
+                        // remove stale threads
+                        "while true do " +
+                            "local firstThreadId2 = redis.call('lindex', KEYS[2], 0);" +
+                            "if firstThreadId2 == false then " +
+                                 "break;" +
+                            "end;" +
+
+                            "local timeout = tonumber(redis.call('zscore', KEYS[3], firstThreadId2));" +
+                            "if timeout <= tonumber(ARGV[4]) then " +
+                                // remove the item from the queue and timeout set
+                                // NOTE we do not alter any other timeout
+                                "redis.call('zrem', KEYS[3], firstThreadId2);" +
+                                "redis.call('lpop', KEYS[2]);" +
+                            "else " +
+                                 "break;" +
+                            "end;" +
+                        "end;" +
+
+                        // check if the lock can be acquired now
+                        "if (redis.call('exists', KEYS[1]) == 0) " +
+                            "and ((redis.call('exists', KEYS[2]) == 0) " +
+                             "or (redis.call('lindex', KEYS[2], 0) == ARGV[2])) then " +
+
+                            // remove this thread from the queue and timeout set
+                            "redis.call('lpop', KEYS[2]);" +
+                            "redis.call('zrem', KEYS[3], ARGV[2]);" +
+
+                            // decrease timeouts for all waiting in the queue
+                            "local keys = redis.call('zrange', KEYS[3], 0, -1);" +
+                            "for i = 1, #keys, 1 do " +
+                                 "redis.call('zincrby', KEYS[3], -tonumber(ARGV[3]), keys[i]);" +
+                            "end;" +
+
+                            // acquire the lock and set the TTL for the lease
+                            "redis.call('hset', KEYS[1], ARGV[2], 1);" +
+                            "redis.call('pexpire', KEYS[1], ARGV[1]);" +
+                            "return nil;" +
+                        "end;" +
+
+                        // check if the lock is already held, and this is a re-entry
+                        "if redis.call('hexists', KEYS[1], ARGV[2]) == 1 then " +
+                            "redis.call('hincrby', KEYS[1], ARGV[2],1);" +
+                            "redis.call('pexpire', KEYS[1], ARGV[1]);" +
+                            "return nil;" +
+                        "end;" +
+
+                        // the lock cannot be acquired
+                        // check if the thread is already in the queue
+                        "local timeout = redis.call('zscore', KEYS[3], ARGV[2]);" +
+                        "if timeout ~= false then " +
+                        // the real timeout is the timeout of the prior thread
+                        // in the queue, but this is approximately correct, and
+                        // avoids having to traverse the queue
+                            "return timeout - tonumber(ARGV[3]) - tonumber(ARGV[4]);" +
+                        "end;" +
+
+                        // add the thread to the queue at the end, and set its timeout in the timeout set to the timeout of
+                        // the prior thread in the queue (or the timeout of the lock if the queue is empty) plus the
+                        // threadWaitTime
+                        "local lastThreadId = redis.call('lindex', KEYS[2], -1);" +
+                        "local ttl;" +
+                        "if lastThreadId ~= false and lastThreadId ~= ARGV[2] then " +
+                            "ttl = tonumber(redis.call('zscore', KEYS[3], lastThreadId)) - tonumber(ARGV[4]);" +
+                        "else " +
+                            "ttl = redis.call('pttl', KEYS[1]);" +
+                        "end;" +
+                        "local timeout = ttl + tonumber(ARGV[3]) + tonumber(ARGV[4]);" +
+                        "if redis.call('zadd', KEYS[3], timeout, ARGV[2]) == 1 then " +
+                            "redis.call('rpush', KEYS[2], ARGV[2]);" +
+                        "end;" +
+                        "return ttl;",
+                Arrays.asList(getName(), threadsQueueName, timeoutSetName, clientQueuePrefix, clientElementName),
+                internalLockLeaseTime, getLockName(threadId), wait, currentTime,
+                isClientRegistered, clientElementTtl);
+
+        if (null != fairLockCache) {
+            fairLockCache.registerLockIfAbsent(name);
+        }
+
+        return result;
     }
 
     @Override
@@ -341,4 +398,11 @@ public class RedissonFairLock extends RedissonLock implements RLock {
                 LockPubSub.UNLOCK_MESSAGE, System.currentTimeMillis());
     }
 
+    public FairLockCache getFairLockCache() {
+        return fairLockCache;
+    }
+
+    public void setFairLockCache(FairLockCache fairLockCache) {
+        this.fairLockCache = fairLockCache;
+    }
 }

--- a/redisson/src/main/java/org/redisson/executor/AbstractFairLockClientThread.java
+++ b/redisson/src/main/java/org/redisson/executor/AbstractFairLockClientThread.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2013-2020 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.executor;
+
+import org.redisson.RedissonLock;
+import org.redisson.command.CommandAsyncExecutor;
+
+/**
+ * @author wuqian30624
+ */
+public abstract class AbstractFairLockClientThread extends RedissonLock implements Runnable {
+    protected String threadName;
+    protected FairLockCache fairLockCache;
+
+    public AbstractFairLockClientThread(FairLockCache fairLockCache,
+                                 CommandAsyncExecutor commandExecutor, String threadName){
+        super(commandExecutor, threadName);
+        this.fairLockCache = fairLockCache;
+        this.threadName = threadName;
+    }
+
+    @Override
+    public String getName() {
+        return threadName;
+    }
+
+    @Override
+    public void run() {
+        if (null != fairLockCache && fairLockCache.getRegisteredLocks().size() > 0) {
+            for (String fairLockName:fairLockCache.getRegisteredLocks()) {
+                try {
+                    executeCommands(fairLockName);
+                }catch (Exception e){
+                    // failure during executing commands
+                }
+            }
+        }
+    }
+
+    /**
+     * Execute redis command
+     * @param fairLock
+     */
+    protected abstract void executeCommands(String fairLock);
+}

--- a/redisson/src/main/java/org/redisson/executor/FairLockCache.java
+++ b/redisson/src/main/java/org/redisson/executor/FairLockCache.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2013-2020 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.executor;
+
+import org.redisson.RedissonFairLock;
+import org.redisson.RedissonObject;
+import org.redisson.command.CommandAsyncExecutor;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Store all fairlock names and ttl
+ * @author wuqian30624
+ */
+public class FairLockCache {
+    private ScheduledExecutorService executorRefresh = Executors.newSingleThreadScheduledExecutor();
+    private ScheduledExecutorService executorClean = Executors.newSingleThreadScheduledExecutor();
+    private volatile ConcurrentHashMap<String, String> registeredLocks = new ConcurrentHashMap<String, String>();
+    private String clientId;
+    private long ttl =  RedissonFairLock.DEFAULT_THREAD_WAIT_TIME;
+    private static final String DEFAULT_LOCK_VALUE = "1";
+
+    public FairLockCache(String clientId, long ttl){
+        this.clientId = clientId;
+        this.ttl = ttl;
+    }
+
+    public boolean isLockRegistered(String name){
+        String elementName = getClientQueueElementName(name);
+        return registeredLocks.containsKey(elementName);
+    }
+
+    public void registerLockIfAbsent(String name){
+        String elementName = getClientQueueElementName(name);
+        registeredLocks.putIfAbsent(elementName, DEFAULT_LOCK_VALUE);
+    }
+
+    public Set<String> getRegisteredLocks() {
+        return registeredLocks.keySet();
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public long getTtl() {
+        return ttl;
+    }
+
+    public void startRefresh(CommandAsyncExecutor commandAsyncExecutor){
+        long interval = ttl;
+        if (ttl > 2){
+            interval = ttl / 2;
+        }
+        FairLockClientRefreshThread refreshThread = new FairLockClientRefreshThread(this, commandAsyncExecutor);
+        executorRefresh.scheduleAtFixedRate(refreshThread, 0, interval, TimeUnit.MILLISECONDS);
+    }
+
+    public void endRefresh(CommandAsyncExecutor commandAsyncExecutor){
+        try {
+            executorRefresh.shutdownNow();
+            new Thread(new FairLockClientCleanThread(this, commandAsyncExecutor)).run();
+        }catch (Exception e){
+            // Failure during shutdown. Ignore
+        }
+    }
+
+    /**
+     * Get formated queue with threadid name
+     * @param name
+     * @return
+     */
+    public String getClientQueueElementName(String name){
+        return getClientQueueName(name) + ":" + getClientId();
+    }
+
+    /**
+     * Get formated client queue name for fairlock
+     * @param name
+     * @return
+     */
+    public String getClientQueueName(String name){
+        return RedissonObject.prefixName(RedissonFairLock.REGISTERED_CLIENT_PREFIX, name);
+    }
+}

--- a/redisson/src/main/java/org/redisson/executor/FairLockClientCleanThread.java
+++ b/redisson/src/main/java/org/redisson/executor/FairLockClientCleanThread.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2013-2020 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.executor;
+
+import org.redisson.client.codec.LongCodec;
+import org.redisson.client.protocol.RedisCommands;
+import org.redisson.command.CommandAsyncExecutor;
+
+import java.util.Arrays;
+
+/**
+ * Remove all registered fairlock client info
+ * from current client
+ * @author wuqian30624
+ */
+public class FairLockClientCleanThread extends AbstractFairLockClientThread {
+    private static String threadName = "fairLock-clean";
+
+    public FairLockClientCleanThread(FairLockCache fairLockCache,
+                                     CommandAsyncExecutor commandExecutor){
+        super(fairLockCache, commandExecutor, threadName);
+    }
+
+    @Override
+    protected void executeCommands(String fairLock) {
+        evalWriteAsync(getName(), LongCodec.INSTANCE, RedisCommands.EVAL_VOID,
+                "redis.call('del', KEYS[1], 1);",
+                Arrays.<Object>asList(fairLock));
+    }
+}
+

--- a/redisson/src/main/java/org/redisson/executor/FairLockClientRefreshThread.java
+++ b/redisson/src/main/java/org/redisson/executor/FairLockClientRefreshThread.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2013-2020 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.executor;
+
+import org.redisson.client.codec.LongCodec;
+import org.redisson.client.protocol.RedisCommands;
+import org.redisson.command.CommandAsyncExecutor;
+
+import java.util.Arrays;
+
+/**
+ * @author wuqian30624
+ */
+public class FairLockClientRefreshThread extends AbstractFairLockClientThread{
+    private static String threadName = "fairLock-refresh";
+
+    public FairLockClientRefreshThread(FairLockCache fairLockCache,
+                                       CommandAsyncExecutor commandExecutor){
+        super(fairLockCache, commandExecutor, threadName);
+    }
+
+    @Override
+    protected void executeCommands(String fairLock) {
+        evalWriteAsync(getName(), LongCodec.INSTANCE, RedisCommands.EVAL_VOID,
+                "redis.call('set', KEYS[1], 1);" +
+                        "redis.call('pexpire', KEYS[1], ARGV[1]);",
+                Arrays.<Object>asList(fairLock),
+                fairLockCache.getTtl());
+    }
+
+}


### PR DESCRIPTION
Fix for concurreny test.
Origin pr: #3178

Description:
Signed-off-by: wuqian30624@hundsun.com

If lots of thread registered in redission fair lock queue and timeout map, and all these threads got shutdown accidently. The another app which trys to reuse this fair lock will get blocked for a long time.
Add logic to clear those not used queue info.