### PR TITLE
Fix - Change the encoding of redisson.yaml from UTF-8-BOM to UTF-8.

### DIFF
--- a/redisson-spring-boot-starter/src/test/resources/redisson.yaml
+++ b/redisson-spring-boot-starter/src/test/resources/redisson.yaml
@@ -1,2 +1,2 @@
-﻿singleServerConfig:
+singleServerConfig:
   address: "redis://127.0.0.1:6379"


### PR DESCRIPTION
If you look at "Files changed" it looks like not much has changed. But actually, as described in #3208, the encoding of the files is changed.

The encoding is changed with Notepad++.

**Old version**

![image](https://user-images.githubusercontent.com/17497376/98981040-be2f9200-251d-11eb-9861-eea4e81d56dc.png)

**New version**

![image](https://user-images.githubusercontent.com/17497376/98981071-c982bd80-251d-11eb-8d99-468651bb9e40.png)

**Additional Sources**

According to the [Unicode standard](http://www.unicode.org/versions/Unicode5.0.0/ch02.pdf):

> Use of a BOM is neither required nor recommended for UTF-8, but may
be encountered in contexts where UTF-8 data is converted from other encoding forms that
use a BOM or where the BOM is used as a UTF-8 signature. 

[What's the difference between UTF-8 and UTF-8 without BOM?](https://stackoverflow.com/questions/2223882/whats-the-difference-between-utf-8-and-utf-8-without-bom#:~:text=The%20UTF%2D8%20BOM%20is,8%2C%20the%20BOM%20is%20unnecessary.)