### PR TITLE
Enhance PropertiesDecoder decoding performance

### DIFF
--- a/redisson-spring-data/redisson-spring-data-16/src/main/java/org/redisson/spring/data/connection/PropertiesDecoder.java
+++ b/redisson-spring-data/redisson-spring-data-16/src/main/java/org/redisson/spring/data/connection/PropertiesDecoder.java
@@ -34,11 +34,19 @@ public class PropertiesDecoder implements Decoder<Properties> {
     public Properties decode(ByteBuf buf, State state) {
         String value = buf.toString(CharsetUtil.UTF_8);
         Properties result = new Properties();
-        for (String entry : value.split("\r\n|\n")) {
-            String[] parts = entry.split(":");
-            if (parts.length == 2) {
-                result.put(parts[0], parts[1]);
+        for (String entry : value.split("\n")) {
+            if (entry.length() < 2) {
+                continue;
             }
+            String[] pair = entry.split(":");
+            if (pair.length != 2 || pair[0].length() == 0 ) {
+                continue;
+            }
+            String second = pair[1];
+            if (second.charAt(second.length() - 1) == '\r') {
+                second = second.substring(0, second.length() - 1);
+            }
+            result.put(pair[0], second);
         }
         return result;
     }

--- a/redisson-spring-data/redisson-spring-data-17/src/main/java/org/redisson/spring/data/connection/PropertiesDecoder.java
+++ b/redisson-spring-data/redisson-spring-data-17/src/main/java/org/redisson/spring/data/connection/PropertiesDecoder.java
@@ -34,11 +34,19 @@ public class PropertiesDecoder implements Decoder<Properties> {
     public Properties decode(ByteBuf buf, State state) {
         String value = buf.toString(CharsetUtil.UTF_8);
         Properties result = new Properties();
-        for (String entry : value.split("\r\n|\n")) {
-            String[] parts = entry.split(":");
-            if (parts.length == 2) {
-                result.put(parts[0], parts[1]);
+        for (String entry : value.split("\n")) {
+            if (entry.length() < 2) {
+                continue;
             }
+            String[] pair = entry.split(":");
+            if (pair.length != 2 || pair[0].length() == 0 ) {
+                continue;
+            }
+            String second = pair[1];
+            if (second.charAt(second.length() - 1) == '\r') {
+                second = second.substring(0, second.length() - 1);
+            }
+            result.put(pair[0], second);
         }
         return result;
     }

--- a/redisson-spring-data/redisson-spring-data-18/src/main/java/org/redisson/spring/data/connection/PropertiesDecoder.java
+++ b/redisson-spring-data/redisson-spring-data-18/src/main/java/org/redisson/spring/data/connection/PropertiesDecoder.java
@@ -34,11 +34,19 @@ public class PropertiesDecoder implements Decoder<Properties> {
     public Properties decode(ByteBuf buf, State state) {
         String value = buf.toString(CharsetUtil.UTF_8);
         Properties result = new Properties();
-        for (String entry : value.split("\r\n|\n")) {
-            String[] parts = entry.split(":");
-            if (parts.length == 2) {
-                result.put(parts[0], parts[1]);
+        for (String entry : value.split("\n")) {
+            if (entry.length() < 2) {
+                continue;
             }
+            String[] pair = entry.split(":");
+            if (pair.length != 2 || pair[0].length() == 0 ) {
+                continue;
+            }
+            String second = pair[1];
+            if (second.charAt(second.length() - 1) == '\r') {
+                second = second.substring(0, second.length() - 1);
+            }
+            result.put(pair[0], second);
         }
         return result;
     }

--- a/redisson-spring-data/redisson-spring-data-20/src/main/java/org/redisson/spring/data/connection/PropertiesDecoder.java
+++ b/redisson-spring-data/redisson-spring-data-20/src/main/java/org/redisson/spring/data/connection/PropertiesDecoder.java
@@ -34,11 +34,19 @@ public class PropertiesDecoder implements Decoder<Properties> {
     public Properties decode(ByteBuf buf, State state) {
         String value = buf.toString(CharsetUtil.UTF_8);
         Properties result = new Properties();
-        for (String entry : value.split("\r\n|\n")) {
-            String[] parts = entry.split(":");
-            if (parts.length == 2) {
-                result.put(parts[0], parts[1]);
+        for (String entry : value.split("\n")) {
+            if (entry.length() < 2) {
+                continue;
             }
+            String[] pair = entry.split(":");
+            if (pair.length != 2 || pair[0].length() == 0 ) {
+                continue;
+            }
+            String second = pair[1];
+            if (second.charAt(second.length() - 1) == '\r') {
+                second = second.substring(0, second.length() - 1);
+            }
+            result.put(pair[0], second);
         }
         return result;
     }

--- a/redisson-spring-data/redisson-spring-data-21/src/main/java/org/redisson/spring/data/connection/PropertiesDecoder.java
+++ b/redisson-spring-data/redisson-spring-data-21/src/main/java/org/redisson/spring/data/connection/PropertiesDecoder.java
@@ -34,11 +34,19 @@ public class PropertiesDecoder implements Decoder<Properties> {
     public Properties decode(ByteBuf buf, State state) {
         String value = buf.toString(CharsetUtil.UTF_8);
         Properties result = new Properties();
-        for (String entry : value.split("\r\n|\n")) {
-            String[] parts = entry.split(":");
-            if (parts.length == 2) {
-                result.put(parts[0], parts[1]);
+        for (String entry : value.split("\n")) {
+            if (entry.length() < 2) {
+                continue;
             }
+            String[] pair = entry.split(":");
+            if (pair.length != 2 || pair[0].length() == 0 ) {
+                continue;
+            }
+            String second = pair[1];
+            if (second.charAt(second.length() - 1) == '\r') {
+                second = second.substring(0, second.length() - 1);
+            }
+            result.put(pair[0], second);
         }
         return result;
     }

--- a/redisson-spring-data/redisson-spring-data-22/src/main/java/org/redisson/spring/data/connection/PropertiesDecoder.java
+++ b/redisson-spring-data/redisson-spring-data-22/src/main/java/org/redisson/spring/data/connection/PropertiesDecoder.java
@@ -34,11 +34,19 @@ public class PropertiesDecoder implements Decoder<Properties> {
     public Properties decode(ByteBuf buf, State state) {
         String value = buf.toString(CharsetUtil.UTF_8);
         Properties result = new Properties();
-        for (String entry : value.split("\r\n|\n")) {
-            String[] parts = entry.split(":");
-            if (parts.length == 2) {
-                result.put(parts[0], parts[1]);
+        for (String entry : value.split("\n")) {
+            if (entry.length() < 2) {
+                continue;
             }
+            String[] pair = entry.split(":");
+            if (pair.length != 2 || pair[0].length() == 0 ) {
+                continue;
+            }
+            String second = pair[1];
+            if (second.charAt(second.length() - 1) == '\r') {
+                second = second.substring(0, second.length() - 1);
+            }
+            result.put(pair[0], second);
         }
         return result;
     }

--- a/redisson-spring-data/redisson-spring-data-23/src/main/java/org/redisson/spring/data/connection/PropertiesDecoder.java
+++ b/redisson-spring-data/redisson-spring-data-23/src/main/java/org/redisson/spring/data/connection/PropertiesDecoder.java
@@ -34,11 +34,19 @@ public class PropertiesDecoder implements Decoder<Properties> {
     public Properties decode(ByteBuf buf, State state) {
         String value = buf.toString(CharsetUtil.UTF_8);
         Properties result = new Properties();
-        for (String entry : value.split("\r\n|\n")) {
-            String[] parts = entry.split(":");
-            if (parts.length == 2) {
-                result.put(parts[0], parts[1]);
+        for (String entry : value.split("\n")) {
+            if (entry.length() < 2) {
+                continue;
             }
+            String[] pair = entry.split(":");
+            if (pair.length != 2 || pair[0].length() == 0 ) {
+                continue;
+            }
+            String second = pair[1];
+            if (second.charAt(second.length() - 1) == '\r') {
+                second = second.substring(0, second.length() - 1);
+            }
+            result.put(pair[0], second);
         }
         return result;
     }

--- a/redisson-spring-data/redisson-spring-data-23/src/test/java/org/redisson/spring/data/connection/PropertiesDecoderTest.java
+++ b/redisson-spring-data/redisson-spring-data-23/src/test/java/org/redisson/spring/data/connection/PropertiesDecoderTest.java
@@ -1,0 +1,71 @@
+package org.redisson.spring.data.connection;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.util.CharsetUtil;
+import org.junit.Assert;
+import org.junit.Test;
+import org.redisson.client.handler.State;
+import org.redisson.client.protocol.Decoder;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+
+public class PropertiesDecoderTest {
+
+    private final PropertiesDecoder decoder = new PropertiesDecoder();
+
+    private final String info = "# Server\r\n" +
+            "redis_version:5.0.10\r\n" +
+            "redis_build_id:b9312d2bb5f35b93\r\n" +
+            "redis_mode:standalone\n" +
+            "executable:/data/redis-server\n" +
+            "config_file:\n" +
+            "" +
+            "# Client";
+
+    @Test
+    public void testDecode() {
+        Properties p = decoder.decode(Unpooled.copiedBuffer(info, StandardCharsets.UTF_8), null);
+        Assert.assertEquals(p.getProperty("redis_version"), "5.0.10");
+        Assert.assertEquals(p.getProperty("redis_mode"), "standalone");
+        Assert.assertNull(p.getProperty("config_file"));
+    }
+
+
+    // Codes below should be deleted before merge
+
+    private class PropertiesDecoderOld implements Decoder<Properties> {
+
+        @Override
+        public Properties decode(ByteBuf buf, State state) {
+            String value = buf.toString(CharsetUtil.UTF_8);
+            Properties result = new Properties();
+            for (String entry : value.split("\r\n|\n")) {
+                String[] parts = entry.split(":");
+                if (parts.length == 2) {
+                    result.put(parts[0], parts[1]);
+                }
+            }
+            return result;
+        }
+    }
+
+//    @Test
+    public void benchmark() {
+        PropertiesDecoderOld old = new PropertiesDecoderOld();
+        long start = System.currentTimeMillis();
+        int c = 400000;
+        while (c-- > 0) {
+            old.decode(Unpooled.copiedBuffer(info, StandardCharsets.UTF_8), null);
+        }
+        System.out.println(System.currentTimeMillis() - start);
+
+        start = System.currentTimeMillis();
+        c = 400000;
+        while (c-- > 0) {
+            testDecode();
+        }
+        System.out.println(System.currentTimeMillis() - start);
+    }
+}


### PR DESCRIPTION
I'm using Redisson with Spring Boot 2.3.5. When Spring Boot's health actuator of health is enabled and health endpoint is visited, health status of redis will be accessed through `org.redisson.spring.data.connection.RedissonReactiveServerCommands#info()`, then `PropertiesDecoder#decode` is used to decode responded string from `INFO` command.

However if no sections are provided to `INFO` command, size of responding string can be up to 3.5KB. If a low health check interval, like 2 seconds, is set, decoding the result costs significant CPU time:

![image](https://user-images.githubusercontent.com/3151930/99509253-7ea2f300-29c0-11eb-88b3-5d0c44602451.png)

To enhance the performance for decode method, splitting result with single char can be used instead of regular expression. 

Benchmark from `org.redisson.spring.data.connection.PropertiesDecoderTest#benchmark`:
Old: 2410ms
New: 960ms

