### PR TITLE
feat: fix doc

### DIFF
--- a/redisson-spring-boot-starter/README.md
+++ b/redisson-spring-boot-starter/README.md
@@ -61,44 +61,44 @@ spring:
       master:
       nodes:
 
-  # Redisson settings
+    # Redisson settings
     
-  #path to config - redisson.yaml
-  redisson: 
-    file: classpath:redisson.yaml
-    config: |
-      clusterServersConfig:
-        idleConnectionTimeout: 10000
-        connectTimeout: 10000
-        timeout: 3000
-        retryAttempts: 3
-        retryInterval: 1500
-        failedSlaveReconnectionInterval: 3000
-        failedSlaveCheckInterval: 60000
-        password: null
-        subscriptionsPerConnection: 5
-        clientName: null
-        loadBalancer: !<org.redisson.connection.balancer.RoundRobinLoadBalancer> {}
-        subscriptionConnectionMinimumIdleSize: 1
-        subscriptionConnectionPoolSize: 50
-        slaveConnectionMinimumIdleSize: 24
-        slaveConnectionPoolSize: 64
-        masterConnectionMinimumIdleSize: 24
-        masterConnectionPoolSize: 64
-        readMode: "SLAVE"
-        subscriptionMode: "SLAVE"
-        nodeAddresses:
-        - "redis://127.0.0.1:7004"
-        - "redis://127.0.0.1:7001"
-        - "redis://127.0.0.1:7000"
-        scanInterval: 1000
-        pingConnectionInterval: 0
-        keepAlive: false
-        tcpNoDelay: false
-      threads: 16
-      nettyThreads: 32
-      codec: !<org.redisson.codec.FstCodec> {}
-      transportMode: "NIO"
+    #path to config - redisson.yaml
+    redisson: 
+      file: classpath:redisson.yaml
+      config: |
+        clusterServersConfig:
+          idleConnectionTimeout: 10000
+          connectTimeout: 10000
+          timeout: 3000
+          retryAttempts: 3
+          retryInterval: 1500
+          failedSlaveReconnectionInterval: 3000
+          failedSlaveCheckInterval: 60000
+          password: null
+          subscriptionsPerConnection: 5
+          clientName: null
+          loadBalancer: !<org.redisson.connection.balancer.RoundRobinLoadBalancer> {}
+          subscriptionConnectionMinimumIdleSize: 1
+          subscriptionConnectionPoolSize: 50
+          slaveConnectionMinimumIdleSize: 24
+          slaveConnectionPoolSize: 64
+          masterConnectionMinimumIdleSize: 24
+          masterConnectionPoolSize: 64
+          readMode: "SLAVE"
+          subscriptionMode: "SLAVE"
+          nodeAddresses:
+          - "redis://127.0.0.1:7004"
+          - "redis://127.0.0.1:7001"
+          - "redis://127.0.0.1:7000"
+          scanInterval: 1000
+          pingConnectionInterval: 0
+          keepAlive: false
+          tcpNoDelay: false
+        threads: 16
+        nettyThreads: 32
+        codec: !<org.redisson.codec.FstCodec> {}
+        transportMode: "NIO"
 
 ```
 


### PR DESCRIPTION
```java
@ConfigurationProperties(prefix = "spring.redis.redisson")
public class RedissonProperties {
... 
}
```

due to `RedissonProperties` prefix is `spring.redis.redisson`, so the `redis` level is parent of `redisson`
but in README they are in same level. 