### PR TITLE
Feature - Added option to allow null values in a local cache #3221

### DIFF
--- a/redisson/src/main/java/org/redisson/api/LocalCachedMapOptions.java
+++ b/redisson/src/main/java/org/redisson/api/LocalCachedMapOptions.java
@@ -136,7 +136,7 @@ public class LocalCachedMapOptions<K, V> extends MapOptions<K, V> {
     private long maxIdleInMillis;
     private CacheProvider cacheProvider;
     private StoreMode storeMode;
-    private boolean allowNullValues;
+    private boolean storeCacheMiss;
     
     protected LocalCachedMapOptions() {
     }
@@ -150,7 +150,7 @@ public class LocalCachedMapOptions<K, V> extends MapOptions<K, V> {
         this.maxIdleInMillis = copy.maxIdleInMillis;
         this.cacheProvider = copy.cacheProvider;
         this.storeMode = copy.storeMode;
-        this.allowNullValues = copy.allowNullValues;
+        this.storeCacheMiss = copy.storeCacheMiss;
     }
     
     /**
@@ -164,7 +164,7 @@ public class LocalCachedMapOptions<K, V> extends MapOptions<K, V> {
      *      .reconnectionStrategy(ReconnectionStrategy.NONE)
      *      .cacheProvider(CacheProvider.REDISSON)
      *      .syncStrategy(SyncStrategy.INVALIDATE)
-     *      .allowNullValues(false);
+     *      .storeCacheMiss(false);
      * </pre>
      * 
      * @param <K> key type
@@ -181,7 +181,7 @@ public class LocalCachedMapOptions<K, V> extends MapOptions<K, V> {
                     .cacheProvider(CacheProvider.REDISSON)
                     .storeMode(StoreMode.LOCALCACHE_REDIS)
                     .syncStrategy(SyncStrategy.INVALIDATE)
-                    .allowNullValues(false);
+                    .storeCacheMiss(false);
     }
 
     public CacheProvider getCacheProvider() {
@@ -338,18 +338,18 @@ public class LocalCachedMapOptions<K, V> extends MapOptions<K, V> {
         return this;
     }
 
-    public boolean isAllowNullValues() {
-        return this.allowNullValues;
+    public boolean isStoreCacheMiss() {
+        return this.storeCacheMiss;
     }
 
     /**
-     * Defines whether the local cache allows null values.
+     * Defines whether to store a cache miss into the local cache.
      *
-     * @param allowNullValues - whether the local cache allows null values
+     * @param storeCacheMiss - whether to store a cache miss into the local cache
      * @return LocalCachedMapOptions instance
      */
-    public LocalCachedMapOptions<K, V> allowNullValues(boolean allowNullValues) {
-        this.allowNullValues = allowNullValues;
+    public LocalCachedMapOptions<K, V> storeCacheMiss(boolean storeCacheMiss) {
+        this.storeCacheMiss = storeCacheMiss;
         return this;
     }
 

--- a/redisson/src/main/java/org/redisson/api/LocalCachedMapOptions.java
+++ b/redisson/src/main/java/org/redisson/api/LocalCachedMapOptions.java
@@ -136,6 +136,7 @@ public class LocalCachedMapOptions<K, V> extends MapOptions<K, V> {
     private long maxIdleInMillis;
     private CacheProvider cacheProvider;
     private StoreMode storeMode;
+    private boolean allowNullValues;
     
     protected LocalCachedMapOptions() {
     }
@@ -149,6 +150,7 @@ public class LocalCachedMapOptions<K, V> extends MapOptions<K, V> {
         this.maxIdleInMillis = copy.maxIdleInMillis;
         this.cacheProvider = copy.cacheProvider;
         this.storeMode = copy.storeMode;
+        this.allowNullValues = copy.allowNullValues;
     }
     
     /**
@@ -161,7 +163,8 @@ public class LocalCachedMapOptions<K, V> extends MapOptions<K, V> {
      *      .evictionPolicy(EvictionPolicy.NONE)
      *      .reconnectionStrategy(ReconnectionStrategy.NONE)
      *      .cacheProvider(CacheProvider.REDISSON)
-     *      .syncStrategy(SyncStrategy.INVALIDATE);
+     *      .syncStrategy(SyncStrategy.INVALIDATE)
+     *      .allowNullValues(false);
      * </pre>
      * 
      * @param <K> key type
@@ -177,7 +180,8 @@ public class LocalCachedMapOptions<K, V> extends MapOptions<K, V> {
                     .reconnectionStrategy(ReconnectionStrategy.NONE)
                     .cacheProvider(CacheProvider.REDISSON)
                     .storeMode(StoreMode.LOCALCACHE_REDIS)
-                    .syncStrategy(SyncStrategy.INVALIDATE);
+                    .syncStrategy(SyncStrategy.INVALIDATE)
+                    .allowNullValues(false);
     }
 
     public CacheProvider getCacheProvider() {
@@ -331,6 +335,21 @@ public class LocalCachedMapOptions<K, V> extends MapOptions<K, V> {
      */
     public LocalCachedMapOptions<K, V> cacheProvider(CacheProvider cacheProvider) {
         this.cacheProvider = cacheProvider;
+        return this;
+    }
+
+    public boolean isAllowNullValues() {
+        return this.allowNullValues;
+    }
+
+    /**
+     * Defines whether the local cache allows null values.
+     *
+     * @param allowNullValues - whether the local cache allows null values
+     * @return LocalCachedMapOptions instance
+     */
+    public LocalCachedMapOptions<K, V> allowNullValues(boolean allowNullValues) {
+        this.allowNullValues = allowNullValues;
         return this;
     }
 

--- a/redisson/src/test/java/org/redisson/RedissonLocalCachedMapTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonLocalCachedMapTest.java
@@ -1,7 +1,6 @@
 package org.redisson;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -471,22 +470,10 @@ public class RedissonLocalCachedMapTest extends BaseMapTest {
     }
 
     @Test
-    public void testPutGetAllowingNullValues() {
-        RLocalCachedMap<String, Integer> map = redisson.getLocalCachedMap("test", LocalCachedMapOptions.<String, Integer>defaults().allowNullValues(true));
+    public void testGetStoringCacheMiss() {
+        RLocalCachedMap<String, Integer> map = redisson.getLocalCachedMap("test", LocalCachedMapOptions.<String, Integer>defaults().storeCacheMiss(true));
         Map<String, Integer> cache = map.getCachedMap();
 
-        map.put("19", null);
-        assertThat(map.get("19")).isNull();
-
-        Awaitility.await().atMost(Durations.ONE_SECOND)
-                .untilAsserted(() -> assertThat(cache.size()).isEqualTo(1));
-
-        map.remove("19");
-
-        Awaitility.await().atMost(Durations.ONE_SECOND)
-                .untilAsserted(() -> assertThat(cache.size()).isEqualTo(0));
-
-        assertThat(map.get("19")).isNull();
         assertThat(map.get("19")).isNull();
 
         Awaitility.await().atMost(Durations.ONE_SECOND)
@@ -494,19 +481,10 @@ public class RedissonLocalCachedMapTest extends BaseMapTest {
     }
 
     @Test
-    public void testPutDisallowingNullValues() {
-        RLocalCachedMap<String, Integer> map = redisson.getLocalCachedMap("test", LocalCachedMapOptions.<String, Integer>defaults().allowNullValues(false));
-
-        assertThatThrownBy(() -> map.put("19", null))
-                .isInstanceOf(NullPointerException.class);
-    }
-
-    @Test
-    public void testGetDisallowingNullValues() {
-        RLocalCachedMap<String, Integer> map = redisson.getLocalCachedMap("test", LocalCachedMapOptions.<String, Integer>defaults().allowNullValues(false));
+    public void testGetNotStoringCacheMiss() {
+        RLocalCachedMap<String, Integer> map = redisson.getLocalCachedMap("test", LocalCachedMapOptions.<String, Integer>defaults().storeCacheMiss(false));
         Map<String, Integer> cache = map.getCachedMap();
 
-        assertThat(map.get("19")).isNull();
         assertThat(map.get("19")).isNull();
 
         Awaitility.await().atMost(Durations.ONE_SECOND)


### PR DESCRIPTION
This is the first PR that I open to an open source project :)

These are the changes that I made to implement feature #3221:
- Added `allowNullValues` to `LocalCachedMapOptions` with a `false` default value.
- Modified the `RedissonLocalCachedMap.init()` method to initialize the `allowNullValues` attribute.
- Modified the `RedissonLocalCachedMap.getAsync(Object key)` method to be able to store a null value into the local cache when the value is not found in Redis and `allowNullValues` is true.
- Override the `RedissonLocalCachedMap.checkValue(Object value)` method to avoid throwing a `NullPointerException` when the value is null and `allowNullValues` is true.
- Added some tests to `RedissonLocalCachedMapTest` to check the feature. I found that this class is excluded from `maven-surefire-plugin` so I executed them manually.

By the way, as noted in the "contributing guidelines" I tried to run all the tests, but some tests failed randomly; I tried with Redis 5 and 6 versions, and two computers, but every time a different test failed. Are you able to pass all the tests?

Please, feel free to give all the feedback that you want.