### PR TITLE
Fix NPE of RedissonConnectionFactory

### DIFF
--- a/redisson-spring-data/redisson-spring-data-17/src/main/java/org/redisson/spring/data/connection/RedissonConnectionFactory.java
+++ b/redisson-spring-data/redisson-spring-data-17/src/main/java/org/redisson/spring/data/connection/RedissonConnectionFactory.java
@@ -24,8 +24,6 @@ import org.redisson.client.RedisClient;
 import org.redisson.client.protocol.RedisCommands;
 import org.redisson.config.Config;
 import org.redisson.connection.SentinelConnectionManager;
-import org.springframework.beans.factory.DisposableBean;
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.InvalidDataAccessResourceUsageException;
 import org.springframework.data.redis.ExceptionTranslationStrategy;
@@ -41,21 +39,22 @@ import org.springframework.data.redis.connection.RedisSentinelConnection;
  * @author Nikita Koksharov
  *
  */
-public class RedissonConnectionFactory implements RedisConnectionFactory, InitializingBean, DisposableBean {
+public class RedissonConnectionFactory implements RedisConnectionFactory, AutoCloseable {
 
     private final static Log log = LogFactory.getLog(RedissonConnectionFactory.class);
     
     public static final ExceptionTranslationStrategy EXCEPTION_TRANSLATION = 
                                 new PassThroughExceptionTranslationStrategy(new RedissonExceptionConverter());
 
-    private Config config;
-    private RedissonClient redisson;
-    
+    private final RedissonClient redisson;
+    private boolean hasOwnRedisson;
+
     /**
      * Creates factory with default Redisson configuration
      */
     public RedissonConnectionFactory() {
         this(Redisson.create());
+        hasOwnRedisson = true;
     }
     
     /**
@@ -73,8 +72,8 @@ public class RedissonConnectionFactory implements RedisConnectionFactory, Initia
      * @param config - Redisson config
      */
     public RedissonConnectionFactory(Config config) {
-        super();
-        this.config = config;
+        this(Redisson.create(config));
+        hasOwnRedisson = true;
     }
 
     @Override
@@ -83,13 +82,9 @@ public class RedissonConnectionFactory implements RedisConnectionFactory, Initia
     }
 
     @Override
-    public void destroy() throws Exception {
-    }
-
-    @Override
-    public void afterPropertiesSet() throws Exception {
-        if (config != null) {
-            redisson = Redisson.create(config);
+    public void close() {
+        if (hasOwnRedisson) {
+            redisson.shutdown();
         }
     }
 

--- a/redisson-spring-data/redisson-spring-data-18/src/main/java/org/redisson/spring/data/connection/RedissonConnectionFactory.java
+++ b/redisson-spring-data/redisson-spring-data-18/src/main/java/org/redisson/spring/data/connection/RedissonConnectionFactory.java
@@ -24,8 +24,6 @@ import org.redisson.client.RedisClient;
 import org.redisson.client.protocol.RedisCommands;
 import org.redisson.config.Config;
 import org.redisson.connection.SentinelConnectionManager;
-import org.springframework.beans.factory.DisposableBean;
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.InvalidDataAccessResourceUsageException;
 import org.springframework.data.redis.ExceptionTranslationStrategy;
@@ -42,15 +40,14 @@ import org.springframework.data.redis.connection.RedisSentinelConnection;
  *
  */
 public class RedissonConnectionFactory implements RedisConnectionFactory, 
-                    InitializingBean, DisposableBean {
+                    AutoCloseable {
 
     private final static Log log = LogFactory.getLog(RedissonConnectionFactory.class);
     
     public static final ExceptionTranslationStrategy EXCEPTION_TRANSLATION = 
                                 new PassThroughExceptionTranslationStrategy(new RedissonExceptionConverter());
 
-    private Config config;
-    private RedissonClient redisson;
+    private final RedissonClient redisson;
     private boolean hasOwnRedisson;
 
     /**
@@ -76,8 +73,7 @@ public class RedissonConnectionFactory implements RedisConnectionFactory,
      * @param config - Redisson config
      */
     public RedissonConnectionFactory(Config config) {
-        super();
-        this.config = config;
+        this(Redisson.create(config));
         hasOwnRedisson = true;
     }
 
@@ -87,16 +83,9 @@ public class RedissonConnectionFactory implements RedisConnectionFactory,
     }
 
     @Override
-    public void destroy() throws Exception {
+    public void close() {
         if (hasOwnRedisson) {
             redisson.shutdown();
-        }
-    }
-
-    @Override
-    public void afterPropertiesSet() throws Exception {
-        if (config != null) {
-            redisson = Redisson.create(config);
         }
     }
 

--- a/redisson-spring-data/redisson-spring-data-20/src/main/java/org/redisson/spring/data/connection/RedissonConnectionFactory.java
+++ b/redisson-spring-data/redisson-spring-data-20/src/main/java/org/redisson/spring/data/connection/RedissonConnectionFactory.java
@@ -25,8 +25,6 @@ import org.redisson.client.protocol.RedisCommands;
 import org.redisson.config.Config;
 import org.redisson.connection.SentinelConnectionManager;
 import org.redisson.reactive.CommandReactiveService;
-import org.springframework.beans.factory.DisposableBean;
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.InvalidDataAccessResourceUsageException;
 import org.springframework.data.redis.ExceptionTranslationStrategy;
@@ -40,15 +38,14 @@ import org.springframework.data.redis.connection.*;
  *
  */
 public class RedissonConnectionFactory implements RedisConnectionFactory, 
-                ReactiveRedisConnectionFactory, InitializingBean, DisposableBean {
+                ReactiveRedisConnectionFactory, AutoCloseable {
 
     private final static Log log = LogFactory.getLog(RedissonConnectionFactory.class);
     
     public static final ExceptionTranslationStrategy EXCEPTION_TRANSLATION = 
                                 new PassThroughExceptionTranslationStrategy(new RedissonExceptionConverter());
 
-    private Config config;
-    private RedissonClient redisson;
+    private final RedissonClient redisson;
     private boolean hasOwnRedisson;
 
     /**
@@ -74,8 +71,7 @@ public class RedissonConnectionFactory implements RedisConnectionFactory,
      * @param config - Redisson config
      */
     public RedissonConnectionFactory(Config config) {
-        super();
-        this.config = config;
+        this(Redisson.create(config));
         hasOwnRedisson = true;
     }
 
@@ -85,16 +81,9 @@ public class RedissonConnectionFactory implements RedisConnectionFactory,
     }
 
     @Override
-    public void destroy() throws Exception {
+    public void close() {
         if (hasOwnRedisson) {
             redisson.shutdown();
-        }
-    }
-
-    @Override
-    public void afterPropertiesSet() throws Exception {
-        if (config != null) {
-            redisson = Redisson.create(config);
         }
     }
 

--- a/redisson-spring-data/redisson-spring-data-21/src/main/java/org/redisson/spring/data/connection/RedissonConnectionFactory.java
+++ b/redisson-spring-data/redisson-spring-data-21/src/main/java/org/redisson/spring/data/connection/RedissonConnectionFactory.java
@@ -25,8 +25,6 @@ import org.redisson.client.protocol.RedisCommands;
 import org.redisson.config.Config;
 import org.redisson.connection.SentinelConnectionManager;
 import org.redisson.reactive.CommandReactiveService;
-import org.springframework.beans.factory.DisposableBean;
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.InvalidDataAccessResourceUsageException;
 import org.springframework.data.redis.ExceptionTranslationStrategy;
@@ -40,15 +38,14 @@ import org.springframework.data.redis.connection.*;
  *
  */
 public class RedissonConnectionFactory implements RedisConnectionFactory, 
-                ReactiveRedisConnectionFactory, InitializingBean, DisposableBean {
+                ReactiveRedisConnectionFactory, AutoCloseable {
 
     private final static Log log = LogFactory.getLog(RedissonConnectionFactory.class);
     
     public static final ExceptionTranslationStrategy EXCEPTION_TRANSLATION = 
                                 new PassThroughExceptionTranslationStrategy(new RedissonExceptionConverter());
 
-    private Config config;
-    private RedissonClient redisson;
+    private final RedissonClient redisson;
     private boolean hasOwnRedisson;
 
     /**
@@ -74,9 +71,8 @@ public class RedissonConnectionFactory implements RedisConnectionFactory,
      * @param config - Redisson config
      */
     public RedissonConnectionFactory(Config config) {
-        super();
-        this.config = config;
-        hasOwnRedisson = true;
+        this(Redisson.create(config));
+        hasOwnRedisson = true;;
     }
 
     @Override
@@ -85,16 +81,9 @@ public class RedissonConnectionFactory implements RedisConnectionFactory,
     }
 
     @Override
-    public void destroy() throws Exception {
+    public void close() {
         if (hasOwnRedisson) {
             redisson.shutdown();
-        }
-    }
-
-    @Override
-    public void afterPropertiesSet() throws Exception {
-        if (config != null) {
-            redisson = Redisson.create(config);
         }
     }
 

--- a/redisson-spring-data/redisson-spring-data-23/src/test/java/org/redisson/spring/data/connection/RedissonConnectionFactoryTest.java
+++ b/redisson-spring-data/redisson-spring-data-23/src/test/java/org/redisson/spring/data/connection/RedissonConnectionFactoryTest.java
@@ -1,0 +1,20 @@
+package org.redisson.spring.data.connection;
+
+import org.awaitility.Awaitility;
+import org.awaitility.Duration;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class RedissonConnectionFactoryTest extends BaseConnectionTest {
+
+    @Test
+    public void testFactoryConfig() {
+        RedissonConnectionFactory factory = new RedissonConnectionFactory(createConfig());
+        AtomicLong counter = new AtomicLong();
+        factory.getReactiveConnection().ping().subscribe(p -> counter.incrementAndGet());
+        Awaitility.await().atMost(Duration.ONE_SECOND)
+                .until(() -> counter.get() == 1);
+    }
+
+}


### PR DESCRIPTION
When construct a `RedissonConnectionFactory` with `Config` argument, the `Redisson` client will not create before Spring calls `afterPropertiesSet`. Which means the factory must be registered as a Spring Bean or call `afterPropertiesSet` manually. 

Registering multiple instances of same class to Spring is a bit inconvenient(`@Qualifier` everywhere) when the factory is only used by one service. Besides, `afterPropertiesSet` isn't designed to called manually so developer may forget to call it. 

Better solution is creating the client at once when constructor is called.