### PR TITLE
Add RedisBusyException. In case of the watchdog logic exit during red…

### DIFF
--- a/redisson/src/main/java/org/redisson/client/RedisBusyException.java
+++ b/redisson/src/main/java/org/redisson/client/RedisBusyException.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2013-2020 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.client;
+
+/**
+ * This error occurs when Redis server is busy.
+ *
+ * @author wuqian
+ *
+ */
+public class RedisBusyException extends RedisException{
+
+    private static final long serialVersionUID = -5658453331593019251L;
+
+    public RedisBusyException(String message) {
+        super(message);
+    }
+}

--- a/redisson/src/main/java/org/redisson/client/handler/CommandDecoder.java
+++ b/redisson/src/main/java/org/redisson/client/handler/CommandDecoder.java
@@ -338,6 +338,9 @@ public class CommandDecoder extends ReplayingDecoder<State> {
             } else if (error.startsWith("CLUSTERDOWN")) {
                 data.tryFailure(new RedisClusterDownException(error
                         + ". channel: " + channel + " data: " + data));
+            } else if (error.startsWith("BUSY")) {
+                data.tryFailure(new RedisBusyException(error
+                        + ". channel: " + channel + " data: " + data));
             } else {
                 if (data != null) {
                     data.tryFailure(new RedisException(error + ". channel: " + channel + " command: " + LogHelper.toString(data)));

--- a/redisson/src/main/java/org/redisson/command/RedisExecutor.java
+++ b/redisson/src/main/java/org/redisson/command/RedisExecutor.java
@@ -424,7 +424,8 @@ public class RedisExecutor<V, R> {
             
             if (attemptFuture.cause() instanceof RedisLoadingException
                     || attemptFuture.cause() instanceof RedisTryAgainException
-                        || attemptFuture.cause() instanceof RedisClusterDownException) {
+                        || attemptFuture.cause() instanceof RedisClusterDownException
+                            || attemptFuture.cause() instanceof RedisBusyException) {
                 if (attempt < attempts) {
                     onException();
                     connectionManager.newTimeout(new TimerTask() {


### PR DESCRIPTION
Add RedisBusyException. In case of the watchdog logic exit during redis server busy.
Signed-off-by: wuqian30624 <wuqian0808@me.com>