### PR TITLE
Santi/test/live object service for kotlin with dco

### DIFF
--- a/redisson-kotlin-test/pom.xml
+++ b/redisson-kotlin-test/pom.xml
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>redisson-parent</artifactId>
+        <groupId>org.redisson</groupId>
+        <version>3.15.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>redisson-kotlin-test</artifactId>
+    <packaging>jar</packaging>
+    <version>${parent.version}</version>
+
+    <name>Redisson Kotlin Test for LiveObjectService</name>
+    <description>This module only holds test files to run</description>
+    <inceptionYear>2021</inceptionYear>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <kotlin.version>1.4.21</kotlin.version>
+        <kotlin.code.style>official</kotlin.code.style>
+        <redisson.version>${parent.version}</redisson.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.1.58.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>2.12.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.redisson</groupId>
+            <artifactId>redisson</artifactId>
+            <version>${redisson.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.18.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.0.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jmockit</groupId>
+            <artifactId>jmockit</artifactId>
+            <version>1.46</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jooq</groupId>
+            <artifactId>joor-java-8</artifactId>
+            <version>0.9.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>8.5.55</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-jasper</artifactId>
+            <version>8.5.51</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-jasper</artifactId>
+            <version>8.5.51</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>fluent-hc</artifactId>
+            <version>4.5.11</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <version>[4.1,)</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webflux</artifactId>
+            <version>[4.1,)</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>src/main/java</sourceDirectory>
+        <testSourceDirectory>src/test/java</testSourceDirectory>
+
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <goals> <goal>compile</goal> </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>/src/main/kotlin</sourceDir>
+                                <sourceDir>/src/main/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <goals> <goal>test-compile</goal> </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>/src/test/kotlin</sourceDir>
+                                <sourceDir>/src/test/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <jvmTarget>1.8</jvmTarget>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>java-compile</id>
+                        <phase>compile</phase>
+                        <goals> <goal>compile</goal> </goals>
+                    </execution>
+                    <execution>
+                        <id>java-test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals> <goal>testCompile</goal> </goals>
+                        <configuration>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/redisson-kotlin-test/src/main/kotlin/org/redisson/kotlin/KotlinEntities.kt
+++ b/redisson-kotlin-test/src/main/kotlin/org/redisson/kotlin/KotlinEntities.kt
@@ -1,0 +1,487 @@
+package org.redisson.kotlin
+
+import org.redisson.api.RCascadeType
+import org.redisson.api.RMap
+import org.redisson.api.annotation.RCascade
+import org.redisson.api.annotation.REntity
+import org.redisson.api.annotation.RFieldAccessor
+import org.redisson.api.annotation.RId
+import org.redisson.api.annotation.RIndex
+import org.redisson.api.annotation.RKotlinMember
+import org.redisson.liveobject.resolver.LongGenerator
+import org.redisson.liveobject.resolver.UUIDGenerator
+import java.io.Serializable
+import java.util.*
+import kotlin.collections.HashMap
+
+object KotlinEntities {
+
+    @REntity
+    open class TestEnum : Serializable {
+        enum class MyEnum { A, B }
+
+        @RId
+        open var id: String? = null
+        open var myEnum1: MyEnum? = null
+        open var myEnum2: MyEnum? = null
+    }
+
+    @REntity
+    @Suppress("LeakingThis")
+    open class TestREntity() : Comparable<TestREntity>, Serializable {
+
+        @RId
+        open var name: String = ""
+
+        open var value: String? = ""
+
+        constructor(name: String, value: String?) : this() {
+            this.name = name
+            this.value = value
+        }
+
+        override operator fun compareTo(other: TestREntity): Int {
+            val res = name.compareTo(other.name)
+            return if (res == 0) {
+                value!!.compareTo(other.value!!)
+            } else res
+        }
+    }
+
+    @REntity
+    @Suppress("LeakingThis")
+    open class TestREntityWithRMap() : Comparable<TestREntityWithRMap>, Serializable {
+
+        @RId
+        open var name: String = ""
+            protected set
+
+        open var value: RMap<*, *>? = null
+
+        constructor(name: String, value: RMap<*, *>?) : this() {
+            this.name = name
+            this.value = value
+        }
+
+        override operator fun compareTo(other: TestREntityWithRMap): Int {
+            val res = name.compareTo(other.name)
+            return if (res == 0 || value != null || other.value != null) {
+                if (value!!.name == null) {
+                    -1
+                } else value!!.name.compareTo(other.value!!.name)
+            } else res
+        }
+    }
+
+    @REntity
+    @Suppress("LeakingThis")
+    open class TestREntityWithMap() : Comparable<TestREntityWithMap>, Serializable {
+
+        @RId(generator = UUIDGenerator::class)
+        open var name: String = ""
+            protected set
+
+        open var value: Map<*, *>? = null
+
+        constructor(name: String, value: Map<*, *>?) : this() {
+            this.name = name
+            this.value = value
+        }
+
+        override operator fun compareTo(other: TestREntityWithMap): Int {
+            return name.compareTo(other.name)
+        }
+    }
+
+    @REntity
+    @Suppress("LeakingThis")
+    open class TestREntityIdNested : Comparable<TestREntityIdNested>, Serializable {
+
+        @RId
+        open var name: TestREntity
+            protected set
+
+        open var value: String = ""
+
+        constructor(name: TestREntity) {
+            this.name = name
+        }
+
+        constructor(name: TestREntity, value: String) : this(name) {
+            this.value = value
+        }
+
+        override operator fun compareTo(other: TestREntityIdNested): Int {
+            val res = name.compareTo(other.name)
+            return if (res == 0) {
+                value.compareTo(other.value)
+            } else res
+        }
+    }
+
+    @REntity
+    @Suppress("LeakingThis")
+    open class TestREntityValueNested() : Comparable<TestREntityValueNested>, Serializable {
+        @RId
+        open var name: String = ""
+            protected set
+
+        open var value: TestREntityWithRMap? = null
+
+        constructor(name: String) : this() {
+            this.name = name
+        }
+
+        constructor(name: String, value: TestREntityWithRMap?) : this(name) {
+            this.value = value
+        }
+
+        override operator fun compareTo(other: TestREntityValueNested): Int {
+            val res = name.compareTo(other.name)
+            return if (res == 0 || value != null || other.value != null) {
+                value!!.compareTo(other.value!!)
+            } else res
+        }
+    }
+
+    @REntity
+    @Suppress("LeakingThis")
+    open class TestIndexed() : Serializable {
+
+        @RId
+        open var id: String? = null
+            protected set
+
+        @RIndex
+        open var name1: String? = null
+
+        @RIndex
+        open var name2: String? = null
+
+        @RIndex
+        open var num1: Int? = null
+
+        @RIndex
+        open var bool1: Boolean? = null
+
+        @RIndex
+        open var obj: TestIndexed? = null
+
+        @RIndex
+        open var num2 = 0
+
+        constructor(id: String?) : this() {
+            this.id = id
+        }
+    }
+
+    @REntity
+    @Suppress("LeakingThis")
+    open class TestClass() {
+
+        @RId(generator = UUIDGenerator::class)
+        open var id: Serializable? = null
+            protected set
+
+        open var value: String? = null
+        open var code: String? = null
+
+        @RCascade(RCascadeType.ALL)
+        open var content: Any? = null
+
+        open var values: MutableMap<String, String> = HashMap()
+
+        constructor(id: Serializable?) : this() {
+            this.id = id
+        }
+
+        @RFieldAccessor
+        open fun <T> set(field: String?, value: T) {
+        }
+
+        @RFieldAccessor
+        open fun <T> get(field: String?): T? {
+            return null
+        }
+
+        fun addEntry(key: String, value: String) {
+            values[key] = value
+        }
+
+        override fun equals(obj: Any?): Boolean {
+            if (obj == null || obj !is TestClass || this.javaClass != obj.javaClass) {
+                return false
+            }
+            val o = obj
+            return (id == o.id
+                && code == o.code
+                && value == o.value
+                && content == o.content)
+        }
+
+        override fun hashCode(): Int {
+            var hash = 3
+            hash = 23 * hash + Objects.hashCode(value)
+            hash = 23 * hash + Objects.hashCode(code)
+            hash = 23 * hash + Objects.hashCode(id)
+            hash = 23 * hash + Objects.hashCode(content)
+            return hash
+        }
+    }
+
+    open class ObjectId() : Serializable {
+        var id = 0
+
+        constructor(id: Int) : this() {
+            this.id = id
+        }
+
+        override fun equals(obj: Any?): Boolean {
+            return if (obj !is ObjectId) {
+                false
+            } else id == obj.id
+        }
+
+        override fun hashCode(): Int {
+            var hash = 3
+            hash = 11 * hash + id
+            return hash
+        }
+
+        override fun toString(): String {
+            return "" + id
+        }
+    }
+
+    @REntity
+    @Suppress("LeakingThis")
+    open class TestClassID1() {
+
+        @RId(generator = LongGenerator::class)
+        open var name: Long? = null
+            protected set
+
+        constructor(name: Long?) : this() {
+            this.name = name
+        }
+    }
+
+    @REntity
+    @Suppress("LeakingThis")
+    open class TestClassID2() {
+
+        @RId(generator = LongGenerator::class)
+        open var name: Long? = null
+            protected set
+
+        constructor(name: Long?) : this() {
+            this.name = name
+        }
+    }
+
+    @REntity
+    open class TestIndexed1 : Serializable {
+
+        @RId
+        open var id: String? = null
+
+        open var keywords: List<String> = ArrayList()
+    }
+
+    @REntity(fieldTransformation = REntity.TransformationMode.IMPLEMENTATION_BASED)
+    @Suppress("LeakingThis")
+    open class TestClassNoTransformation() {
+
+        @RId(generator = UUIDGenerator::class)
+        open var id: Serializable? = null
+            protected set
+
+        open var value: String? = null
+        open var code: String? = null
+        open var content: Any? = null
+
+        constructor(id: Serializable?) : this() {
+            this.id = id
+        }
+
+        override fun equals(obj: Any?): Boolean {
+            if (obj == null || obj !is TestClass || this.javaClass != obj.javaClass) {
+                return false
+            }
+            val o = obj
+            return (id == o.id
+                && code == o.code
+                && value == o.value
+                && content == o.content)
+        }
+
+        override fun hashCode(): Int {
+            var hash = 3
+            hash = 33 * hash + Objects.hashCode(value)
+            hash = 33 * hash + Objects.hashCode(code)
+            hash = 33 * hash + Objects.hashCode(id)
+            hash = 33 * hash + Objects.hashCode(content)
+            return hash
+        }
+    }
+
+    @REntity
+    @Suppress("LeakingThis")
+    open class MyObject() : Serializable {
+
+        @RId(generator = LongGenerator::class)
+        open var id: Long? = null
+            protected set
+
+        open var myId: Long? = null
+            protected set
+
+        open var name: String? = null
+
+        constructor(myId: Long?) : this() {
+            this.myId = myId
+        }
+    }
+
+    @REntity
+    @Suppress("LeakingThis")
+    open class SimpleObject() {
+
+        @RId(generator = UUIDGenerator::class)
+        open var id: String? = null
+            protected set
+
+        open var value: Long? = null
+    }
+
+    @REntity
+    @Suppress("LeakingThis")
+    open class ObjectWithList() {
+
+        @RId(generator = UUIDGenerator::class)
+        open var id: String? = null
+            protected set
+
+        open var objects: List<SimpleObject>? = null
+        open var so: SimpleObject? = null
+    }
+
+    @REntity
+    @Suppress("LeakingThis")
+    open class Customer() {
+
+        @RId
+        open var id: String? = null
+            protected set
+
+        @RCascade(RCascadeType.ALL)
+        open var orders: MutableList<Order> = mutableListOf()
+
+        constructor(id: String?) : this() {
+            this.id = id
+        }
+
+        fun addOrder(order: Order) {
+            orders.add(order)
+        }
+    }
+
+    @REntity
+    @Suppress("LeakingThis")
+    open class Order() {
+
+        @RId(generator = LongGenerator::class)
+        open var id: Long? = null
+            protected set
+
+        @RCascade(RCascadeType.PERSIST, RCascadeType.DETACH)
+        open var customer: Customer? = null
+
+        constructor(customer: Customer?) : this() {
+            this.customer = customer
+        }
+    }
+
+    @REntity
+    @Suppress("LeakingThis")
+    open class SetterEncapsulation() {
+
+        @RId(generator = LongGenerator::class)
+        open var id: Long? = null
+            protected set
+
+        protected open var map: MutableMap<String, Int>? = null
+
+        fun getItem(name: String): Int? {
+            return map!![name]
+        }
+
+        fun addItem(name: String, amount: Int) {
+            map!![name] = amount
+        }
+    }
+
+    @REntity
+    @Suppress("LeakingThis")
+    open class ClassWithoutIdSetterGetter() {
+
+        @RId(generator = LongGenerator::class)
+        protected open var id: Long? = null
+
+        open var name: String? = null
+            protected set
+
+        constructor(name: String?) : this() {
+            this.name = name
+        }
+    }
+
+    @REntity
+    @Suppress("LeakingThis")
+    open class Animal() {
+
+        @RId(generator = LongGenerator::class)
+        protected open var id: Long? = null
+
+        open var name: String? = null
+            protected set
+
+        constructor(name: String?) : this() {
+            this.name = name
+        }
+    }
+
+    open class Dog : Animal {
+        open var breed: String? = null
+
+        constructor() : super() {}
+        constructor(name: String?) : super(name) {}
+    }
+
+    open class MyCustomer : Customer {
+
+        @RCascade(RCascadeType.ALL)
+        open var specialOrders: MutableList<Order> = ArrayList()
+
+        constructor() : super() {}
+        constructor(id: String?) : super(id) {}
+
+        fun addSpecialOrder(order: Order) {
+            specialOrders.add(order)
+        }
+    }
+
+    open class MyObjectWithList() : ObjectWithList() {
+        open var name: String? = null
+    }
+
+    @REntity
+    open class HasIsAccessor {
+
+        @RId(generator = LongGenerator::class)
+        protected open var id: Long? = null
+
+        open var good = false
+    }
+
+}

--- a/redisson-kotlin-test/src/main/kotlin/org/redisson/kotlin/KotlinEntities.kt
+++ b/redisson-kotlin-test/src/main/kotlin/org/redisson/kotlin/KotlinEntities.kt
@@ -7,7 +7,6 @@ import org.redisson.api.annotation.REntity
 import org.redisson.api.annotation.RFieldAccessor
 import org.redisson.api.annotation.RId
 import org.redisson.api.annotation.RIndex
-import org.redisson.api.annotation.RKotlinMember
 import org.redisson.liveobject.resolver.LongGenerator
 import org.redisson.liveobject.resolver.UUIDGenerator
 import java.io.Serializable

--- a/redisson-kotlin-test/src/test/java/org/redisson/BaseTest.java
+++ b/redisson-kotlin-test/src/test/java/org/redisson/BaseTest.java
@@ -1,0 +1,61 @@
+package org.redisson;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+
+import java.io.IOException;
+
+public abstract class BaseTest {
+
+	protected static RedissonClient redisson;
+
+	@BeforeClass
+	public static void beforeClass() throws IOException, InterruptedException {
+		RedisRunner.startDefaultRedisServerInstance();
+		redisson = createInstance();
+	}
+
+	@AfterClass
+	public static void afterClass() throws InterruptedException {
+		redisson.shutdown();
+		RedisRunner.shutDownDefaultRedisServerInstance();
+	}
+
+	@Before
+	public void before() throws IOException, InterruptedException {
+		if (flushBetweenTests()) {
+			redisson.getKeys().flushall();
+		}
+	}
+
+	public static Config createConfig() {
+//        String redisAddress = System.getProperty("redisAddress");
+//        if (redisAddress == null) {
+//            redisAddress = "127.0.0.1:6379";
+//        }
+		Config config = new Config();
+//        config.setCodec(new MsgPackJacksonCodec());
+//        config.useSentinelServers().setMasterName("mymaster").addSentinelAddress("127.0.0.1:26379", "127.0.0.1:26389");
+//        config.useClusterServers().addNodeAddress("127.0.0.1:7004", "127.0.0.1:7001", "127.0.0.1:7000");
+		config.useSingleServer()
+				.setAddress(RedisRunner.getDefaultRedisServerBindAddressAndPort());
+//        .setPassword("mypass1");
+//        config.useMasterSlaveConnection()
+//        .setMasterAddress("127.0.0.1:6379")
+//        .addSlaveAddress("127.0.0.1:6399")
+//        .addSlaveAddress("127.0.0.1:6389");
+		return config;
+	}
+
+	public static RedissonClient createInstance() {
+		Config config = createConfig();
+		return Redisson.create(config);
+	}
+
+	protected boolean flushBetweenTests() {
+		return true;
+	}
+}

--- a/redisson-kotlin-test/src/test/java/org/redisson/ClusterRunner.java
+++ b/redisson-kotlin-test/src/test/java/org/redisson/ClusterRunner.java
@@ -1,0 +1,168 @@
+package org.redisson;
+
+import org.redisson.misc.BiHashMap;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.math.BigInteger;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ *
+ * @author Rui Gu (https://github.com/jackygurui)
+ */
+public class ClusterRunner {
+
+	private final LinkedHashMap<RedisRunner, String> nodes = new LinkedHashMap<>();
+	private final LinkedHashMap<String, String> slaveMasters = new LinkedHashMap<>();
+
+	public ClusterRunner addNode(RedisRunner runner) {
+		nodes.putIfAbsent(runner, getRandomId());
+		if (!runner.hasOption(RedisRunner.REDIS_OPTIONS.CLUSTER_ENABLED)) {
+			runner.clusterEnabled(true);
+		}
+		if (!runner.hasOption(RedisRunner.REDIS_OPTIONS.CLUSTER_NODE_TIMEOUT)) {
+			runner.clusterNodeTimeout(5000);
+		}
+		if (!runner.hasOption(RedisRunner.REDIS_OPTIONS.PORT)) {
+			runner.randomPort(1);
+			runner.port(RedisRunner.findFreePort());
+		}
+		if (!runner.hasOption(RedisRunner.REDIS_OPTIONS.BIND)) {
+			runner.bind("127.0.0.1");
+		}
+		return this;
+	}
+
+	public ClusterRunner addNode(RedisRunner master, RedisRunner... slaves) {
+		addNode(master);
+		for (RedisRunner slave : slaves) {
+			addNode(slave);
+			slaveMasters.put(nodes.get(slave), nodes.get(master));
+		}
+		return this;
+	}
+
+	public synchronized ClusterProcesses run() throws IOException, InterruptedException, RedisRunner.FailedToStartRedisException {
+		BiHashMap<String, RedisRunner.RedisProcess> processes = new BiHashMap<>();
+		for (RedisRunner runner : nodes.keySet()) {
+			List<String> options = getClusterConfig(runner);
+			String confFile = runner.dir() + File.separator + nodes.get(runner) + ".conf";
+			System.out.println("WRITING CONFIG: for " + nodes.get(runner));
+			try (PrintWriter printer = new PrintWriter(new FileWriter(confFile))) {
+				options.stream().forEach((line) -> {
+					printer.println(line);
+					System.out.println(line);
+				});
+			}
+			processes.put(nodes.get(runner), runner.clusterConfigFile(confFile).run());
+		}
+
+		boolean allAlive = true;
+		for (int i = 0; i < 15; i++) {
+			for (RedisRunner.RedisProcess process : processes.valueSet()) {
+				allAlive &= process.isAlive();
+			}
+			if (allAlive) {
+				break;
+			}
+			allAlive = true;
+			Thread.sleep(100);
+		}
+		if (!allAlive) {
+			throw new RedisRunner.FailedToStartRedisException();
+		}
+		Thread.sleep(1000);
+
+		return new ClusterProcesses(processes);
+	}
+
+	private List<String> getClusterConfig(RedisRunner runner) {
+		String me = runner.getInitialBindAddr() + ":" + runner.getPort();
+		List<String> nodeConfig = new ArrayList<>();
+		int c = 0;
+		for (RedisRunner node : nodes.keySet()) {
+			String nodeId = nodes.get(node);
+			StringBuilder sb = new StringBuilder();
+			String nodeAddr = node.getInitialBindAddr() + ":" + node.getPort();
+			sb.append(nodeId).append(" ");
+			sb.append(nodeAddr).append(" ");
+			sb.append(me.equals(nodeAddr)
+					? "myself,"
+					: "");
+			boolean isMaster = !slaveMasters.containsKey(nodeId);
+			if (isMaster) {
+				sb.append("master -");
+			} else {
+				sb.append("slave ").append(slaveMasters.get(nodeId));
+			}
+			sb.append(" ");
+			sb.append("0").append(" ");
+			sb.append(me.equals(nodeAddr)
+					? "0"
+					: "1").append(" ");
+			sb.append(c + 1).append(" ");
+			sb.append("connected ");
+			if (isMaster) {
+				sb.append(getSlots(c, nodes.size() - slaveMasters.size()));
+				c++;
+			}
+			nodeConfig.add(sb.toString());
+		}
+		nodeConfig.add("vars currentEpoch 0 lastVoteEpoch 0");
+		return nodeConfig;
+	}
+
+	private static String getSlots(int index, int groupNum) {
+		final double t = 16383;
+		int start = index == 0 ? 0 : (int) (t / groupNum * index);
+		int end = index == groupNum - 1 ? (int) t : (int) (t / groupNum * (index + 1)) - 1;
+		return start + "-" + end;
+	}
+
+	private static String getRandomId() {
+		final SecureRandom r = new SecureRandom();
+		return new BigInteger(160, r).toString(16);
+	}
+
+	public static class ClusterProcesses {
+		private final BiHashMap<String, RedisRunner.RedisProcess> processes;
+
+		private ClusterProcesses(BiHashMap<String, RedisRunner.RedisProcess> processes) {
+			this.processes = processes;
+		}
+
+		public RedisRunner.RedisProcess getProcess(String nodeId) {
+			return processes.get(nodeId);
+		}
+
+		public String getNodeId(RedisRunner.RedisProcess process) {
+			return processes.reverseGet(process);
+		}
+
+		public Set<RedisRunner.RedisProcess> getNodes() {
+			return processes.valueSet();
+		}
+
+		public Set<String> getNodeIds() {
+			return processes.keySet();
+		}
+
+		public synchronized Map<String, Integer> shutdown() {
+			return processes
+					.entrySet()
+					.stream()
+					.collect(Collectors.toMap(
+							e -> e.getKey(),
+							e -> e.getValue().stop()));
+		}
+	}
+}

--- a/redisson-kotlin-test/src/test/java/org/redisson/RedisRunner.java
+++ b/redisson-kotlin-test/src/test/java/org/redisson/RedisRunner.java
@@ -1,0 +1,1108 @@
+package org.redisson;
+
+import org.redisson.client.RedisClient;
+import org.redisson.client.RedisClientConfig;
+import org.redisson.client.RedisConnection;
+import org.redisson.client.protocol.RedisCommands;
+import org.redisson.client.protocol.RedisStrictCommand;
+import org.redisson.client.protocol.convertor.VoidReplayConvertor;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.net.Inet4Address;
+import java.net.ServerSocket;
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/**
+ *
+ * @author Rui Gu (https://github.com/jackygurui)
+ */
+public class RedisRunner {
+
+	public enum REDIS_OPTIONS {
+
+		BINARY_PATH,
+		DAEMONIZE,
+		PIDFILE,
+		PORT,
+		TCP_BACKLOG,
+		BIND(true),
+		UNIXSOCKET,
+		UNIXSOCKETPERM,
+		TIMEOUT,
+		TCP_KEEPALIVE,
+		LOGLEVEL,
+		LOGFILE,
+		SYSLOG_ENABLED,
+		SYSLOG_IDENT,
+		SYSLOG_FACILITY,
+		DATABASES,
+		SAVE(true),
+		STOP_WRITES_ON_BGSAVE_ERROR,
+		RDBCOMPRESSION,
+		RDBCHECKSUM,
+		DBFILENAME,
+		DIR,
+		SLAVEOF,
+		MASTERAUTH,
+		SLAVE_SERVE_STALE_DATA,
+		SLAVE_READ_ONLY,
+		REPL_DISKLESS_SYNC,
+		REPL_DISKLESS_SYNC_DELAY,
+		REPL_PING_SLAVE_PERIOD,
+		REPL_TIMEOUT,
+		REPL_DISABLE_TCP_NODELAY,
+		REPL_BACKLOG_SIZE,
+		REPL_BACKLOG_TTL,
+		SLAVE_PRIORITY,
+		MIN_SLAVES_TO_WRITE,
+		MIN_SLAVES_MAX_LAG,
+		REQUIREPASS,
+		RENAME_COMMAND(true),
+		MAXCLIENTS,
+		MAXMEMORY,
+		MAXMEMORY_POLICY,
+		MAXMEMORY_SAMPLE,
+		APPENDONLY,
+		APPENDFILENAME,
+		APPENDFSYNC,
+		NO_APPENDFSYNC_ON_REWRITE,
+		AUTO_AOF_REWRITE_PERCENTAGE,
+		AUTO_AOF_REWRITE_MIN_SIZE,
+		AOF_LOAD_TRUNCATED,
+		LUA_TIME_LIMIT,
+		CLUSTER_ENABLED,
+		CLUSTER_CONFIG_FILE,
+		CLUSTER_NODE_TIMEOUT,
+		CLUSTER_SLAVE_VALIDITY_FACTOR,
+		CLUSTER_MIGRATION_BARRIER,
+		CLUSTER_REQUIRE_FULL_COVERAGE,
+		SLOWLOG_LOG_SLOWER_THAN,
+		SLOWLOG_MAX_LEN,
+		LATENCY_MONITOR_THRESHOLD,
+		NOTIFY_KEYSPACE_EVENTS,
+		HASH_MAX_ZIPLIST_ENTRIES,
+		HASH_MAX_ZIPLIST_VALUE,
+		LIST_MAX_ZIPLIST_ENTRIES,
+		LIST_MAX_ZIPLIST_VALUE,
+		SET_MAX_INTSET_ENTRIES,
+		ZSET_MAX_ZIPLIST_ENTRIES,
+		ZSET_MAX_ZIPLIST_VALUE,
+		HLL_SPARSE_MAX_BYTES,
+		ACTIVEREHASHING,
+		CLIENT_OUTPUT_BUFFER_LIMIT$NORMAL,
+		CLIENT_OUTPUT_BUFFER_LIMIT$SLAVE,
+		CLIENT_OUTPUT_BUFFER_LIMIT$PUBSUB,
+		HZ,
+		AOF_REWRITE_INCREMENTAL_FSYNC,
+		PROTECTED_MODE,
+		SENTINEL,
+		SENTINEL$ANNOUNCE_IP,
+		SENTINEL$ANNOUNCE_PORT,
+		SENTINEL$MONITOR(true),
+		SENTINEL$AUTH_PASS(true),
+		SENTINEL$DOWN_AFTER_MILLISECONDS(true),
+		SENTINEL$PARALLEL_SYNCS(true),
+		SENTINEL$FAILOVER_TIMEOUT(true),
+		SENTINEL$NOTIFICATION_SCRIPT(true),
+		SENTINEL$CLIENT_RECONFIG_SCRIPT(true)
+		;
+
+		private final boolean allowMutiple;
+
+		private REDIS_OPTIONS() {
+			this.allowMutiple = false;
+		}
+
+		private REDIS_OPTIONS(boolean allowMutiple) {
+			this.allowMutiple = allowMutiple;
+		}
+
+		public boolean isAllowMultiple() {
+			return allowMutiple;
+		}
+	}
+
+	public enum LOGLEVEL_OPTIONS {
+
+		DEBUG,
+		VERBOSE,
+		NOTICE,
+		WARNING
+	}
+
+	public enum SYSLOG_FACILITY_OPTIONS {
+
+		USER,
+		LOCAL0,
+		LOCAL1,
+		LOCAL2,
+		LOCAL3,
+		LOCAL4,
+		LOCAL5,
+		LOCAL6,
+		LOCAL7
+	}
+
+	public enum MAX_MEMORY_POLICY_OPTIONS {
+
+		VOLATILE_LRU,
+		ALLKEYS_LRU,
+		VOLATILE_RANDOM,
+		ALLKEYS_RANDOM,
+		VOLATILE_TTL,
+		NOEVICTION
+	}
+
+	public enum APPEND_FSYNC_MODE_OPTIONS {
+
+		ALWAYS,
+		EVERYSEC,
+		NO
+	}
+
+	public enum KEYSPACE_EVENTS_OPTIONS {
+
+		K,
+		E,
+		g,
+		$,
+		l,
+		s,
+		h,
+		z,
+		x,
+		e,
+		A
+	}
+
+	private final LinkedHashMap<REDIS_OPTIONS, String> options = new LinkedHashMap<>();
+	protected static RedisRunner.RedisProcess defaultRedisInstance;
+	private static int defaultRedisInstanceExitCode;
+
+	private String path = "";
+	private String defaultDir = Paths.get("").toString();
+	private boolean nosave = false;
+	private boolean randomDir = false;
+	private ArrayList<String> bindAddr = new ArrayList<>();
+	private int port = 6379;
+	private int retryCount = Integer.MAX_VALUE;
+	private boolean randomPort = false;
+	private String sentinelFile;
+	private String clusterFile;
+
+	{
+		this.options.put(REDIS_OPTIONS.BINARY_PATH, RedissonRuntimeEnvironment.redisBinaryPath);
+		if (!RedissonRuntimeEnvironment.redisPort.isEmpty()) this.options.put(REDIS_OPTIONS.PORT, RedissonRuntimeEnvironment.redisPort);
+	}
+
+	/**
+	 * To change the <b>redisBinary</b> system property for running the test,
+	 * use <i>argLine</i> option from surefire plugin:
+	 *
+	 * $ mvn -DargLine="-DredisBinary=`which redis-server`" -Punit-test clean \
+	 * verify
+	 *
+	 * @param configPath
+	 * @return Process running redis instance
+	 * @throws IOException
+	 * @throws InterruptedException
+	 * @see
+	 * <a href="http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#argLine">
+	 * http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#argLine</a>
+	 */
+	public static RedisProcess runRedisWithConfigFile(String configPath) throws IOException, InterruptedException {
+		URL resource = RedisRunner.class.getResource(configPath);
+		return runWithOptions(new RedisRunner(), RedissonRuntimeEnvironment.redisBinaryPath, resource.getFile());
+	}
+
+	private static RedisProcess runWithOptions(RedisRunner runner, String... options) throws IOException, InterruptedException {
+		List<String> launchOptions = Arrays.stream(options)
+				.map(x -> Arrays.asList(x.split(" "))).flatMap(x -> x.stream())
+				.collect(Collectors.toList());
+		System.out.println("REDIS LAUNCH OPTIONS: " + Arrays.toString(launchOptions.toArray()));
+		ProcessBuilder master = new ProcessBuilder(launchOptions)
+				.redirectErrorStream(true)
+				.directory(new File(RedissonRuntimeEnvironment.tempDir));
+		Process p = master.start();
+		new Thread(() -> {
+			BufferedReader reader = new BufferedReader(new InputStreamReader(p.getInputStream()));
+			String line;
+			try {
+				while (p.isAlive() && (line = reader.readLine()) != null && !RedissonRuntimeEnvironment.isTravis) {
+//                    System.out.println("REDIS PROCESS: " + line);
+				}
+			} catch (IOException ex) {
+				System.out.println("Exception: " + ex.getLocalizedMessage());
+			}
+		}).start();
+		Thread.sleep(1500);
+		return new RedisProcess(p, runner);
+	}
+
+	public RedisProcess run() throws IOException, InterruptedException, FailedToStartRedisException {
+		if (!options.containsKey(REDIS_OPTIONS.DIR)) {
+			addConfigOption(REDIS_OPTIONS.DIR, defaultDir);
+		}
+		if (randomPort) {
+			for (int i = 0; i < retryCount; i++) {
+				this.port = findFreePort();
+				addConfigOption(REDIS_OPTIONS.PORT, this.port);
+				try {
+					return runAndCheck();
+				} catch (FailedToStartRedisException e) {
+				}
+			}
+			throw new FailedToStartRedisException();
+		} else {
+			return runAndCheck();
+		}
+	}
+
+	public RedisProcess runAndCheck() throws IOException, InterruptedException, FailedToStartRedisException {
+		List<String> args = new ArrayList(options.values());
+		if (sentinelFile != null && sentinelFile.length() > 0) {
+			String confFile = defaultDir + File.separator + sentinelFile;
+			try (PrintWriter printer = new PrintWriter(new FileWriter(confFile))) {
+				args.stream().forEach((arg) -> {
+					if (arg.contains("--")) {
+						printer.println(arg.replace("--", ""));
+					}
+				});
+			}
+			args = args.subList(0, 1);
+			args.add(confFile);
+			args.add("--sentinel");
+		}
+		RedisProcess rp = runWithOptions(this, args.toArray(new String[0]));
+		if (!isCluster()
+				&& rp.redisProcess.waitFor(1000, TimeUnit.MILLISECONDS)) {
+			throw new FailedToStartRedisException();
+		}
+		Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+			rp.stop();
+		}));
+		return rp;
+	}
+
+	public boolean hasOption(REDIS_OPTIONS option) {
+		return options.containsKey(option);
+	}
+
+	private void addConfigOption(REDIS_OPTIONS option, Object... args) {
+		StringBuilder sb = new StringBuilder("--")
+				.append(option.toString()
+						.replaceAll("_", "-")
+						.replaceAll("\\$", " ")
+						.toLowerCase())
+				.append(" ")
+				.append(Arrays.stream(args).map(Object::toString)
+						.collect(Collectors.joining(" ")));
+		this.options.put(option,
+				option.isAllowMultiple()
+						? sb.insert(0, this.options.getOrDefault(option, "")).toString()
+						: sb.toString());
+	}
+
+	private String convertBoolean(boolean b) {
+		return b ? "yes" : "no";
+	}
+
+	public RedisRunner daemonize(boolean daemonize) {
+		addConfigOption(REDIS_OPTIONS.DAEMONIZE, convertBoolean(daemonize));
+		return this;
+	}
+
+	public RedisRunner pidfile(String pidfile) {
+		addConfigOption(REDIS_OPTIONS.PIDFILE, pidfile);
+		return this;
+	}
+
+	public RedisRunner port(int port) {
+		this.port = port;
+		this.randomPort = false;
+		addConfigOption(REDIS_OPTIONS.PORT, port);
+		return this;
+	}
+
+	public RedisRunner randomPort() {
+		return randomPort(Integer.MAX_VALUE);
+	}
+
+	public RedisRunner randomPort(int retryCount) {
+		this.randomPort = true;
+		this.retryCount = retryCount;
+		options.remove(REDIS_OPTIONS.PORT);
+		return this;
+	}
+
+	public int getPort() {
+		return this.port;
+	}
+
+	public RedisRunner tcpBacklog(long tcpBacklog) {
+		addConfigOption(REDIS_OPTIONS.TCP_BACKLOG, tcpBacklog);
+		return this;
+	}
+
+	public RedisRunner bind(String bind) {
+		this.bindAddr.add(bind);
+		addConfigOption(REDIS_OPTIONS.BIND, bind);
+		return this;
+	}
+
+	public ArrayList<String> getBindAddr() {
+		return this.bindAddr;
+	}
+
+	public RedisRunner unixsocket(String unixsocket) {
+		addConfigOption(REDIS_OPTIONS.UNIXSOCKET, unixsocket);
+		return this;
+	}
+
+	public RedisRunner unixsocketperm(int unixsocketperm) {
+		addConfigOption(REDIS_OPTIONS.UNIXSOCKETPERM, unixsocketperm);
+		return this;
+	}
+
+	public RedisRunner timeout(long timeout) {
+		addConfigOption(REDIS_OPTIONS.TIMEOUT, timeout);
+		return this;
+	}
+
+	public RedisRunner tcpKeepalive(long tcpKeepalive) {
+		addConfigOption(REDIS_OPTIONS.TCP_KEEPALIVE, tcpKeepalive);
+		return this;
+	}
+
+	public RedisRunner loglevel(LOGLEVEL_OPTIONS loglevel) {
+		addConfigOption(REDIS_OPTIONS.LOGLEVEL, loglevel.toString());
+		return this;
+	}
+
+	public RedisRunner logfile(String logfile) {
+		addConfigOption(REDIS_OPTIONS.LOGLEVEL, logfile);
+		return this;
+	}
+
+	public RedisRunner syslogEnabled(boolean syslogEnabled) {
+		addConfigOption(REDIS_OPTIONS.SYSLOG_ENABLED, convertBoolean(syslogEnabled));
+		return this;
+	}
+
+	public RedisRunner syslogIdent(String syslogIdent) {
+		addConfigOption(REDIS_OPTIONS.SYSLOG_IDENT, syslogIdent);
+		return this;
+	}
+
+	public RedisRunner syslogFacility(SYSLOG_FACILITY_OPTIONS syslogFacility) {
+		addConfigOption(REDIS_OPTIONS.SYSLOG_IDENT, syslogFacility.toString());
+		return this;
+	}
+
+	public RedisRunner databases(int databases) {
+		addConfigOption(REDIS_OPTIONS.DATABASES, databases);
+		return this;
+	}
+
+	public RedisRunner save(long seconds, long changes) {
+		if (!nosave) {
+			addConfigOption(REDIS_OPTIONS.SAVE, seconds, changes);
+		}
+		return this;
+	}
+
+	/**
+	 * Phantom option
+	 *
+	 * @return RedisRunner
+	 */
+	public RedisRunner nosave() {
+		this.nosave = true;
+		options.remove(REDIS_OPTIONS.SAVE);
+//        addConfigOption(REDIS_OPTIONS.SAVE, "''");
+		return this;
+	}
+
+	public RedisRunner stopWritesOnBgsaveError(boolean stopWritesOnBgsaveError) {
+		addConfigOption(REDIS_OPTIONS.STOP_WRITES_ON_BGSAVE_ERROR, convertBoolean(stopWritesOnBgsaveError));
+		return this;
+	}
+
+	public RedisRunner rdbcompression(boolean rdbcompression) {
+		addConfigOption(REDIS_OPTIONS.RDBCOMPRESSION, convertBoolean(rdbcompression));
+		return this;
+	}
+
+	public RedisRunner rdbchecksum(boolean rdbchecksum) {
+		addConfigOption(REDIS_OPTIONS.RDBCHECKSUM, convertBoolean(rdbchecksum));
+		return this;
+	}
+
+	public RedisRunner dbfilename(String dbfilename) {
+		addConfigOption(REDIS_OPTIONS.DBFILENAME, dbfilename);
+		return this;
+	}
+
+	public RedisRunner dir(String dir) {
+		if (!randomDir) {
+			addConfigOption(REDIS_OPTIONS.DIR, dir);
+			this.path = dir;
+		}
+		return this;
+	}
+
+	/**
+	 * Phantom option
+	 *
+	 * @return RedisRunner
+	 */
+	public RedisRunner randomDir() {
+		this.randomDir = true;
+		options.remove(REDIS_OPTIONS.DIR);
+		makeRandomDefaultDir();
+
+
+		addConfigOption(REDIS_OPTIONS.DIR, defaultDir);
+		return this;
+	}
+
+	public RedisRunner slaveof(Inet4Address masterip, int port) {
+		addConfigOption(REDIS_OPTIONS.SLAVEOF, masterip.getHostAddress(), port);
+		return this;
+	}
+
+	public RedisRunner slaveof(String masterip, int port) {
+		addConfigOption(REDIS_OPTIONS.SLAVEOF, masterip, port);
+		return this;
+	}
+
+	public RedisRunner masterauth(String masterauth) {
+		addConfigOption(REDIS_OPTIONS.MASTERAUTH, masterauth);
+		return this;
+	}
+
+	public RedisRunner slaveServeStaleData(boolean slaveServeStaleData) {
+		addConfigOption(REDIS_OPTIONS.SLAVE_SERVE_STALE_DATA, convertBoolean(slaveServeStaleData));
+		return this;
+	}
+
+	public RedisRunner slaveReadOnly(boolean slaveReadOnly) {
+		addConfigOption(REDIS_OPTIONS.SLAVE_READ_ONLY, convertBoolean(slaveReadOnly));
+		return this;
+	}
+
+	public RedisRunner replDisklessSync(boolean replDisklessSync) {
+		addConfigOption(REDIS_OPTIONS.REPL_DISKLESS_SYNC, convertBoolean(replDisklessSync));
+		return this;
+	}
+
+	public RedisRunner replDisklessSyncDelay(long replDisklessSyncDelay) {
+		addConfigOption(REDIS_OPTIONS.REPL_DISKLESS_SYNC_DELAY, replDisklessSyncDelay);
+		return this;
+	}
+
+	public RedisRunner replPingSlavePeriod(long replPingSlavePeriod) {
+		addConfigOption(REDIS_OPTIONS.REPL_PING_SLAVE_PERIOD, replPingSlavePeriod);
+		return this;
+	}
+
+	public RedisRunner replTimeout(long replTimeout) {
+		addConfigOption(REDIS_OPTIONS.REPL_TIMEOUT, replTimeout);
+		return this;
+	}
+
+	public RedisRunner replDisableTcpNodelay(boolean replDisableTcpNodelay) {
+		addConfigOption(REDIS_OPTIONS.REPL_DISABLE_TCP_NODELAY, convertBoolean(replDisableTcpNodelay));
+		return this;
+	}
+
+	public RedisRunner replBacklogSize(String replBacklogSize) {
+		addConfigOption(REDIS_OPTIONS.REPL_BACKLOG_SIZE, replBacklogSize);
+		return this;
+	}
+
+	public RedisRunner replBacklogTtl(long replBacklogTtl) {
+		addConfigOption(REDIS_OPTIONS.REPL_BACKLOG_TTL, replBacklogTtl);
+		return this;
+	}
+
+	public RedisRunner slavePriority(long slavePriority) {
+		addConfigOption(REDIS_OPTIONS.SLAVE_PRIORITY, slavePriority);
+		return this;
+	}
+
+	public RedisRunner minSlaveToWrite(long minSlaveToWrite) {
+		addConfigOption(REDIS_OPTIONS.MIN_SLAVES_TO_WRITE, minSlaveToWrite);
+		return this;
+	}
+
+	public RedisRunner minSlaveMaxLag(long minSlaveMaxLag) {
+		addConfigOption(REDIS_OPTIONS.MIN_SLAVES_MAX_LAG, minSlaveMaxLag);
+		return this;
+	}
+
+	public RedisRunner requirepass(String requirepass) {
+		addConfigOption(REDIS_OPTIONS.REQUIREPASS, requirepass);
+		return this;
+	}
+
+	public RedisRunner renameCommand(String renameCommand) {
+		addConfigOption(REDIS_OPTIONS.RENAME_COMMAND, renameCommand);
+		return this;
+	}
+
+	public RedisRunner maxclients(long maxclients) {
+		addConfigOption(REDIS_OPTIONS.MAXCLIENTS, maxclients);
+		return this;
+	}
+
+	public RedisRunner maxmemory(String maxmemory) {
+		addConfigOption(REDIS_OPTIONS.MAXMEMORY, maxmemory);
+		return this;
+	}
+
+	public RedisRunner maxmemoryPolicy(MAX_MEMORY_POLICY_OPTIONS maxmemoryPolicy) {
+		addConfigOption(REDIS_OPTIONS.MAXMEMORY, maxmemoryPolicy.toString());
+		return this;
+	}
+
+	public RedisRunner maxmemorySamples(long maxmemorySamples) {
+		addConfigOption(REDIS_OPTIONS.MAXMEMORY, maxmemorySamples);
+		return this;
+	}
+
+	public RedisRunner appendonly(boolean appendonly) {
+		addConfigOption(REDIS_OPTIONS.APPENDONLY, convertBoolean(appendonly));
+		return this;
+	}
+
+	public RedisRunner appendfilename(String appendfilename) {
+		addConfigOption(REDIS_OPTIONS.APPENDFILENAME, appendfilename);
+		return this;
+	}
+
+	public RedisRunner appendfsync(APPEND_FSYNC_MODE_OPTIONS appendfsync) {
+		addConfigOption(REDIS_OPTIONS.APPENDFSYNC, appendfsync.toString());
+		return this;
+	}
+
+	public RedisRunner noAppendfsyncOnRewrite(boolean noAppendfsyncOnRewrite) {
+		addConfigOption(REDIS_OPTIONS.NO_APPENDFSYNC_ON_REWRITE, convertBoolean(noAppendfsyncOnRewrite));
+		return this;
+	}
+
+	public RedisRunner autoAofRewritePercentage(int autoAofRewritePercentage) {
+		addConfigOption(REDIS_OPTIONS.AUTO_AOF_REWRITE_PERCENTAGE, autoAofRewritePercentage);
+		return this;
+	}
+
+	public RedisRunner autoAofRewriteMinSize(String autoAofRewriteMinSize) {
+		addConfigOption(REDIS_OPTIONS.AUTO_AOF_REWRITE_MIN_SIZE, autoAofRewriteMinSize);
+		return this;
+	}
+
+	public RedisRunner aofLoadTruncated(boolean aofLoadTruncated) {
+		addConfigOption(REDIS_OPTIONS.AOF_LOAD_TRUNCATED, convertBoolean(aofLoadTruncated));
+		return this;
+	}
+
+	public RedisRunner luaTimeLimit(long luaTimeLimit) {
+		addConfigOption(REDIS_OPTIONS.AOF_LOAD_TRUNCATED, luaTimeLimit);
+		return this;
+	}
+
+	public RedisRunner clusterEnabled(boolean clusterEnabled) {
+		addConfigOption(REDIS_OPTIONS.CLUSTER_ENABLED, convertBoolean(clusterEnabled));
+		return this;
+	}
+
+	public RedisRunner clusterConfigFile(String clusterConfigFile) {
+		addConfigOption(REDIS_OPTIONS.CLUSTER_CONFIG_FILE, clusterConfigFile);
+		this.clusterFile = clusterConfigFile;
+		return this;
+	}
+
+	public RedisRunner clusterNodeTimeout(long clusterNodeTimeout) {
+		addConfigOption(REDIS_OPTIONS.CLUSTER_NODE_TIMEOUT, clusterNodeTimeout);
+		return this;
+	}
+
+	public RedisRunner clusterSlaveValidityFactor(long clusterSlaveValidityFactor) {
+		addConfigOption(REDIS_OPTIONS.CLUSTER_SLAVE_VALIDITY_FACTOR, clusterSlaveValidityFactor);
+		return this;
+	}
+
+	public RedisRunner clusterMigrationBarrier(long clusterMigrationBarrier) {
+		addConfigOption(REDIS_OPTIONS.CLUSTER_MIGRATION_BARRIER, clusterMigrationBarrier);
+		return this;
+	}
+
+	public RedisRunner clusterRequireFullCoverage(boolean clusterRequireFullCoverage) {
+		addConfigOption(REDIS_OPTIONS.CLUSTER_REQUIRE_FULL_COVERAGE, convertBoolean(clusterRequireFullCoverage));
+		return this;
+	}
+
+	public RedisRunner slowlogLogSlowerThan(long slowlogLogSlowerThan) {
+		addConfigOption(REDIS_OPTIONS.SLOWLOG_LOG_SLOWER_THAN, slowlogLogSlowerThan);
+		return this;
+	}
+
+	public RedisRunner slowlogMaxLen(long slowlogMaxLen) {
+		addConfigOption(REDIS_OPTIONS.SLOWLOG_MAX_LEN, slowlogMaxLen);
+		return this;
+	}
+
+	public RedisRunner latencyMonitorThreshold(long latencyMonitorThreshold) {
+		addConfigOption(REDIS_OPTIONS.LATENCY_MONITOR_THRESHOLD, latencyMonitorThreshold);
+		return this;
+	}
+
+	public RedisRunner notifyKeyspaceEvents(KEYSPACE_EVENTS_OPTIONS... notifyKeyspaceEvents) {
+		String existing = this.options.getOrDefault(REDIS_OPTIONS.NOTIFY_KEYSPACE_EVENTS, "");
+
+		String events = Arrays.stream(notifyKeyspaceEvents)
+				.collect(StringBuilder::new, StringBuilder::append, StringBuilder::append).toString();
+
+		addConfigOption(REDIS_OPTIONS.NOTIFY_KEYSPACE_EVENTS,
+				existing.contains(events)
+						? existing
+						: (existing + events));
+		return this;
+	}
+
+	public RedisRunner hashMaxZiplistEntries(long hashMaxZiplistEntries) {
+		addConfigOption(REDIS_OPTIONS.HASH_MAX_ZIPLIST_ENTRIES, hashMaxZiplistEntries);
+		return this;
+	}
+
+	public RedisRunner hashMaxZiplistValue(long hashMaxZiplistValue) {
+		addConfigOption(REDIS_OPTIONS.HASH_MAX_ZIPLIST_VALUE, hashMaxZiplistValue);
+		return this;
+	}
+
+	public RedisRunner listMaxZiplistEntries(long listMaxZiplistEntries) {
+		addConfigOption(REDIS_OPTIONS.LIST_MAX_ZIPLIST_ENTRIES, listMaxZiplistEntries);
+		return this;
+	}
+
+	public RedisRunner listMaxZiplistValue(long listMaxZiplistValue) {
+		addConfigOption(REDIS_OPTIONS.LIST_MAX_ZIPLIST_VALUE, listMaxZiplistValue);
+		return this;
+	}
+
+	public RedisRunner setMaxIntsetEntries(long setMaxIntsetEntries) {
+		addConfigOption(REDIS_OPTIONS.SET_MAX_INTSET_ENTRIES, setMaxIntsetEntries);
+		return this;
+	}
+
+	public RedisRunner zsetMaxZiplistEntries(long zsetMaxZiplistEntries) {
+		addConfigOption(REDIS_OPTIONS.ZSET_MAX_ZIPLIST_ENTRIES, zsetMaxZiplistEntries);
+		return this;
+	}
+
+	public RedisRunner zsetMaxZiplistValue(long zsetMaxZiplistValue) {
+		addConfigOption(REDIS_OPTIONS.ZSET_MAX_ZIPLIST_VALUE, zsetMaxZiplistValue);
+		return this;
+	}
+
+	public RedisRunner hllSparseMaxBytes(long hllSparseMaxBytes) {
+		addConfigOption(REDIS_OPTIONS.HLL_SPARSE_MAX_BYTES, hllSparseMaxBytes);
+		return this;
+	}
+
+	public RedisRunner activerehashing(boolean activerehashing) {
+		addConfigOption(REDIS_OPTIONS.ACTIVEREHASHING, convertBoolean(activerehashing));
+		return this;
+	}
+
+	public RedisRunner clientOutputBufferLimit$Normal(String hardLimit, String softLimit, long softSeconds) {
+		addConfigOption(REDIS_OPTIONS.CLIENT_OUTPUT_BUFFER_LIMIT$NORMAL, hardLimit, softLimit, softSeconds);
+		return this;
+	}
+
+	public RedisRunner clientOutputBufferLimit$Slave(String hardLimit, String softLimit, long softSeconds) {
+		addConfigOption(REDIS_OPTIONS.CLIENT_OUTPUT_BUFFER_LIMIT$SLAVE, hardLimit, softLimit, softSeconds);
+		return this;
+	}
+
+	public RedisRunner clientOutputBufferLimit$Pubsub(String hardLimit, String softLimit, long softSeconds) {
+		addConfigOption(REDIS_OPTIONS.CLIENT_OUTPUT_BUFFER_LIMIT$PUBSUB, hardLimit, softLimit, softSeconds);
+		return this;
+	}
+
+	public RedisRunner hz(int hz) {
+		addConfigOption(REDIS_OPTIONS.HZ, hz);
+		return this;
+	}
+
+	public RedisRunner aofRewriteIncrementalFsync(boolean aofRewriteIncrementalFsync) {
+		addConfigOption(REDIS_OPTIONS.AOF_REWRITE_INCREMENTAL_FSYNC, convertBoolean(aofRewriteIncrementalFsync));
+		return this;
+	}
+
+	public RedisRunner protectedMode(boolean protectedMode) {
+		addConfigOption(REDIS_OPTIONS.PROTECTED_MODE, convertBoolean(protectedMode));
+		return this;
+	}
+
+	public RedisRunner sentinel() {
+		sentinelFile = "sentinel_conf_" + UUID.randomUUID() + ".conf";
+		return this;
+	}
+
+	public RedisRunner sentinelAnnounceIP(String sentinelAnnounceIP) {
+		addConfigOption(REDIS_OPTIONS.SENTINEL$ANNOUNCE_IP, sentinelAnnounceIP);
+		return this;
+	}
+
+	public RedisRunner sentinelAnnouncePort(int sentinelAnnouncePort) {
+		addConfigOption(REDIS_OPTIONS.SENTINEL$ANNOUNCE_PORT, sentinelAnnouncePort);
+		return this;
+	}
+
+	public RedisRunner sentinelMonitor(String masterName, String ip, int port, int quorum) {
+		addConfigOption(REDIS_OPTIONS.SENTINEL$MONITOR, masterName, ip, port, quorum);
+		return this;
+	}
+
+	public RedisRunner sentinelAuthPass(String masterName, String password) {
+		addConfigOption(REDIS_OPTIONS.SENTINEL$AUTH_PASS, masterName, password);
+		return this;
+	}
+
+	public RedisRunner sentinelDownAfterMilliseconds(String masterName, long downAfterMilliseconds) {
+		addConfigOption(REDIS_OPTIONS.SENTINEL$DOWN_AFTER_MILLISECONDS, masterName, downAfterMilliseconds);
+		return this;
+	}
+
+	public RedisRunner sentinelParallelSyncs(String masterName, int numSlaves) {
+		addConfigOption(REDIS_OPTIONS.SENTINEL$PARALLEL_SYNCS, masterName, numSlaves);
+		return this;
+	}
+
+	public RedisRunner sentinelFailoverTimeout(String masterName, long failoverTimeout) {
+		addConfigOption(REDIS_OPTIONS.SENTINEL$FAILOVER_TIMEOUT, masterName, failoverTimeout);
+		return this;
+	}
+
+	public RedisRunner sentinelNotificationScript(String masterName, String scriptPath) {
+		addConfigOption(REDIS_OPTIONS.SENTINEL$NOTIFICATION_SCRIPT, masterName, scriptPath);
+		return this;
+	}
+
+	public RedisRunner sentinelClientReconfigScript(String masterName, String scriptPath) {
+		addConfigOption(REDIS_OPTIONS.SENTINEL$CLIENT_RECONFIG_SCRIPT, masterName, scriptPath);
+		return this;
+	}
+
+	public boolean isSentinel() {
+		return this.sentinelFile != null;
+	}
+
+	public boolean isCluster() {
+		return this.clusterFile != null;
+	}
+
+	public boolean isRandomDir() {
+		return this.randomDir;
+	}
+
+	public boolean isNosave() {
+		return this.nosave;
+	}
+
+	public String defaultDir() {
+		return this.defaultDir;
+	}
+
+	public String dir() {
+		return isRandomDir() ? defaultDir() : this.path;
+	}
+
+	public String getInitialBindAddr() {
+		return bindAddr.size() > 0 ? bindAddr.get(0) : "localhost";
+	}
+
+	public boolean deleteDBfileDir() {
+		File f = new File(defaultDir);
+		if (f.exists()) {
+			System.out.println("REDIS RUNNER: Deleting directory " + f.getAbsolutePath());
+			return f.delete();
+		}
+		return false;
+	}
+
+	public boolean deleteSentinelFile() {
+		File f = new File(defaultDir + File.separator + sentinelFile);
+		if (f.exists()) {
+			System.out.println("REDIS RUNNER: Deleting sentinel config file " + f.getAbsolutePath());
+			return f.delete();
+		}
+		return false;
+	}
+
+	public boolean deleteClusterFile() {
+		File f = new File(clusterFile);
+		if (f.exists() && isRandomDir()) {
+			System.out.println("REDIS RUNNER: Deleting cluster config file " + f.getAbsolutePath());
+			return f.delete();
+		}
+		return false;
+	}
+
+	private void makeRandomDefaultDir() {
+		File f = new File(RedissonRuntimeEnvironment.tempDir + File.separator + UUID.randomUUID());
+		if (f.exists()) {
+			makeRandomDefaultDir();
+		} else {
+			System.out.println("REDIS RUNNER: Making directory " + f.getAbsolutePath());
+			f.mkdirs();
+			this.defaultDir = f.getAbsolutePath();
+			if (RedissonRuntimeEnvironment.isWindows) {
+				defaultDir = defaultDir.replace("\\", "\\\\");
+			}
+		}
+	}
+
+	public static final class RedisProcess {
+
+		private Process redisProcess;
+		private final RedisRunner runner;
+		private RedisVersion redisVersion;
+
+		private RedisProcess(Process redisProcess, RedisRunner runner) {
+			this.redisProcess = redisProcess;
+			this.runner = runner;
+		}
+
+		public void restart(int startTimeout) {
+			if (runner.isNosave() && !runner.isRandomDir()) {
+				RedisClient c = createDefaultRedisClientInstance();
+				RedisConnection connection = c.connect();
+				try {
+					connection.async(new RedisStrictCommand<Void>("SHUTDOWN", "NOSAVE", new VoidReplayConvertor()))
+							.await(3, TimeUnit.SECONDS);
+				} catch (InterruptedException interruptedException) {
+					//shutdown via command failed, lets wait and kill it later.
+				}
+				c.shutdown();
+				connection.closeAsync().syncUninterruptibly();
+			}
+			Process p = redisProcess;
+			p.destroy();
+			boolean normalTermination = false;
+			try {
+				normalTermination = p.waitFor(5, TimeUnit.SECONDS);
+			} catch (InterruptedException ex) {
+				//OK lets hurry up by force kill;
+			}
+			if (!normalTermination) {
+				p = p.destroyForcibly();
+			}
+
+			Executors.newScheduledThreadPool(1).schedule(() -> {
+				try {
+					redisProcess = runner.run().redisProcess;
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+			}, startTimeout, TimeUnit.SECONDS);
+		}
+
+		public int stop() {
+			if (runner.isNosave() && !runner.isRandomDir()) {
+				RedisClient c = createDefaultRedisClientInstance();
+				RedisConnection connection = c.connect();
+				try {
+					connection.async(new RedisStrictCommand<Void>("SHUTDOWN", "NOSAVE", new VoidReplayConvertor()))
+							.await(3, TimeUnit.SECONDS);
+				} catch (InterruptedException interruptedException) {
+					//shutdown via command failed, lets wait and kill it later.
+				}
+				c.shutdown();
+				connection.closeAsync().syncUninterruptibly();
+			}
+			Process p = redisProcess;
+			p.destroy();
+			boolean normalTermination = false;
+			try {
+				normalTermination = p.waitFor(5, TimeUnit.SECONDS);
+			} catch (InterruptedException ex) {
+				//OK lets hurry up by force kill;
+			}
+			if (!normalTermination) {
+				p = p.destroyForcibly();
+			}
+			cleanup();
+			int exitCode = p.exitValue();
+			return exitCode == 1 && RedissonRuntimeEnvironment.isWindows ? 0 : exitCode;
+		}
+
+		private void cleanup() {
+			if (runner.isSentinel()) {
+				runner.deleteSentinelFile();
+			}
+			if (runner.isCluster()) {
+				runner.deleteClusterFile();
+			}
+			if (runner.isRandomDir()) {
+				runner.deleteDBfileDir();
+			}
+		}
+
+		public String getDefaultDir() {
+			return runner.getDefaultDir();
+		}
+
+		public Process getRedisProcess() {
+			return redisProcess;
+		}
+
+		public RedisClient createRedisClientInstance() {
+			if (redisProcess.isAlive()) {
+				RedisClientConfig config = new RedisClientConfig();
+				config.setAddress(runner.getInitialBindAddr(), runner.getPort());
+				return RedisClient.create(config);
+			}
+			throw new IllegalStateException("Redis server instance is not running.");
+		}
+
+		public RedisVersion getRedisVersion() {
+			if (redisVersion == null) {
+				RedisConnection c = createRedisClientInstance().connect();
+				Map<String, String> serverMap = c.sync(RedisCommands.INFO_SERVER);
+				redisVersion = new RedisVersion(serverMap.get("redis_version"));
+				c.closeAsync();
+			}
+			return redisVersion;
+		}
+
+		public int getRedisServerPort() {
+			return runner.getPort();
+		}
+
+		public String getRedisServerBindAddress() {
+			return runner.getInitialBindAddr();
+		}
+
+		public String getRedisServerAddressAndPort() {
+			return "redis://" + getRedisServerBindAddress() + ":" + getRedisServerPort();
+		}
+
+		public boolean isAlive() {
+			return redisProcess.isAlive();
+		}
+	}
+
+	public static RedisRunner.RedisProcess startDefaultRedisServerInstance() throws IOException, InterruptedException, FailedToStartRedisException {
+		if (defaultRedisInstance == null) {
+			System.out.println("REDIS RUNNER: Starting up default instance...");
+            RedisRunner runner = new RedisRunner();
+			if (runner.options.getOrDefault(REDIS_OPTIONS.PORT, "").isEmpty()) {
+    			defaultRedisInstance = runner.nosave().randomDir().randomPort().run();
+            } else {
+                defaultRedisInstance = runner.nosave().randomDir().port(runner.port).run();
+            }
+		}
+		return defaultRedisInstance;
+	}
+
+	public static int shutDownDefaultRedisServerInstance() throws InterruptedException {
+		if (defaultRedisInstance != null) {
+			System.out.println("REDIS RUNNER: Shutting down default instance...");
+			try {
+				defaultRedisInstanceExitCode = defaultRedisInstance.stop();
+			} finally {
+				defaultRedisInstance = null;
+			}
+		} else {
+			System.out.println("REDIS RUNNER: Default instance is already down with an exit code " + defaultRedisInstanceExitCode);
+		}
+		return defaultRedisInstanceExitCode;
+	}
+
+	public static boolean isDefaultRedisServerInstanceRunning() {
+		return defaultRedisInstance != null && defaultRedisInstance.redisProcess.isAlive();
+	}
+
+	public static RedisClient createDefaultRedisClientInstance() {
+		return defaultRedisInstance.createRedisClientInstance();
+	}
+
+	public String getDefaultDir() {
+		return defaultDir;
+	}
+
+	public static RedisRunner.RedisProcess getDefaultRedisServerInstance() {
+		return defaultRedisInstance;
+	}
+
+	public static String getDefaultRedisServerBindAddressAndPort() {
+		return "redis://" + defaultRedisInstance.getRedisServerBindAddress()
+				+ ":"
+				+ defaultRedisInstance.getRedisServerPort();
+	}
+
+	public static int findFreePort() {
+		ServerSocket socket = null;
+		try {
+			socket = new ServerSocket(0);
+			socket.setReuseAddress(true);
+			int port = socket.getLocalPort();
+			if (port > 55535 && isFreePort(port - 10000)) {
+				return port - 10000;
+			} else {
+				return port;
+			}
+		} catch (IOException e) {
+		} finally {
+			if (socket != null) {
+				try {
+					socket.close();
+				} catch (IOException e) {
+				}
+			}
+		}
+		throw new IllegalStateException("Could not find a free TCP/IP port.");
+	}
+
+	public static boolean isFreePort(int port) {
+		ServerSocket socket = null;
+		try {
+			socket = new ServerSocket(port);
+			socket.setReuseAddress(true);
+			return true;
+		} catch (IOException e) {
+		} finally {
+			if (socket != null) {
+				try {
+					socket.close();
+				} catch (IOException e) {
+				}
+			}
+		}
+		return false;
+	}
+
+	public static class FailedToStartRedisException extends RuntimeException {
+
+		public FailedToStartRedisException() {
+		}
+	}
+
+}

--- a/redisson-kotlin-test/src/test/java/org/redisson/RedisVersion.java
+++ b/redisson-kotlin-test/src/test/java/org/redisson/RedisVersion.java
@@ -1,0 +1,58 @@
+package org.redisson;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ *
+ * @author Rui Gu (https://github.com/jackygurui)
+ */
+public class RedisVersion implements Comparable<RedisVersion>{
+
+	private final String fullVersion;
+	private final Integer majorVersion;
+	private final Integer minorVersion;
+	private final Integer patchVersion;
+
+	public RedisVersion(String fullVersion) {
+		this.fullVersion = fullVersion;
+		Matcher matcher = Pattern.compile("^([\\d]+)\\.([\\d]+)\\.([\\d]+)").matcher(fullVersion);
+		matcher.find();
+		majorVersion = Integer.parseInt(matcher.group(1));
+		minorVersion = Integer.parseInt(matcher.group(2));
+		patchVersion = Integer.parseInt(matcher.group(3));
+	}
+
+	public String getFullVersion() {
+		return fullVersion;
+	}
+
+	public int getMajorVersion() {
+		return majorVersion;
+	}
+
+	public int getMinorVersion() {
+		return minorVersion;
+	}
+
+	public int getPatchVersion() {
+		return patchVersion;
+	}
+
+	@Override
+	public int compareTo(RedisVersion o) {
+		int ma = this.majorVersion.compareTo(o.majorVersion);
+		int mi = this.minorVersion.compareTo(o.minorVersion);
+		int pa = this.patchVersion.compareTo(o.patchVersion);
+		return ma != 0 ? ma : mi != 0 ? mi : pa;
+	}
+
+	public int compareTo(String redisVersion) {
+		return this.compareTo(new RedisVersion(redisVersion));
+	}
+
+	public static int compareTo(String redisVersion1, String redisVersion2) {
+		return new RedisVersion(redisVersion1).compareTo(redisVersion2);
+	}
+
+}

--- a/redisson-kotlin-test/src/test/java/org/redisson/RedissonLiveObjectServiceForKotlinTest.java
+++ b/redisson-kotlin-test/src/test/java/org/redisson/RedissonLiveObjectServiceForKotlinTest.java
@@ -1,0 +1,1433 @@
+package org.redisson;
+
+import org.junit.Test;
+import org.redisson.api.RBlockingDeque;
+import org.redisson.api.RBlockingQueue;
+import org.redisson.api.RDeque;
+import org.redisson.api.RList;
+import org.redisson.api.RLiveObject;
+import org.redisson.api.RLiveObjectService;
+import org.redisson.api.RMap;
+import org.redisson.api.RObject;
+import org.redisson.api.RQueue;
+import org.redisson.api.RSet;
+import org.redisson.api.RSortedSet;
+import org.redisson.api.RedissonClient;
+import org.redisson.api.condition.Conditions;
+import org.redisson.config.Config;
+import org.redisson.liveobject.resolver.DefaultNamingScheme;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeSet;
+import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.redisson.kotlin.KotlinEntities.ClassWithoutIdSetterGetter;
+import static org.redisson.kotlin.KotlinEntities.Customer;
+import static org.redisson.kotlin.KotlinEntities.Dog;
+import static org.redisson.kotlin.KotlinEntities.HasIsAccessor;
+import static org.redisson.kotlin.KotlinEntities.MyCustomer;
+import static org.redisson.kotlin.KotlinEntities.MyObject;
+import static org.redisson.kotlin.KotlinEntities.MyObjectWithList;
+import static org.redisson.kotlin.KotlinEntities.ObjectId;
+import static org.redisson.kotlin.KotlinEntities.ObjectWithList;
+import static org.redisson.kotlin.KotlinEntities.Order;
+import static org.redisson.kotlin.KotlinEntities.SetterEncapsulation;
+import static org.redisson.kotlin.KotlinEntities.SimpleObject;
+import static org.redisson.kotlin.KotlinEntities.TestClass;
+import static org.redisson.kotlin.KotlinEntities.TestClassID1;
+import static org.redisson.kotlin.KotlinEntities.TestClassID2;
+import static org.redisson.kotlin.KotlinEntities.TestClassNoTransformation;
+import static org.redisson.kotlin.KotlinEntities.TestIndexed;
+import static org.redisson.kotlin.KotlinEntities.TestIndexed1;
+import static org.redisson.kotlin.KotlinEntities.TestREntity;
+import static org.redisson.kotlin.KotlinEntities.TestREntityIdNested;
+import static org.redisson.kotlin.KotlinEntities.TestREntityValueNested;
+import static org.redisson.kotlin.KotlinEntities.TestREntityWithMap;
+import static org.redisson.kotlin.KotlinEntities.TestREntityWithRMap;
+import static org.redisson.kotlin.KotlinEntities.TestEnum;
+
+public class RedissonLiveObjectServiceForKotlinTest extends BaseTest {
+
+	@Test
+	public void testFindEq2() {
+		RLiveObjectService s = redisson.getLiveObjectService();
+		TestIndexed t1 = new TestIndexed("1");
+		t1.setNum1(1);
+		t1.setName1("common");
+		t1.setName2(";asdlkfj");
+		t1 = s.persist(t1);
+
+		TestIndexed t2 = new TestIndexed("2");
+		t2.setNum1(1);
+		t2.setName1("common");
+		t2.setName2("893123");
+		t2 = s.persist(t2);
+
+		TestIndexed t3 = new TestIndexed("3");
+		t3.setNum1(1);
+		t3.setName1("common");
+		t3.setName2("hkf;glhsdfg");
+		t3 = s.persist(t3);
+
+		Collection<TestIndexed> objects2 = s.find(TestIndexed.class, Conditions.and(
+				Conditions.eq("num1", 1),
+				Conditions.eq("name1", "jkflasdf"),
+				Conditions.eq("name2", "fdfdf")));
+		assertThat(objects2).isEmpty();
+
+		Collection<TestIndexed> objects1 = s.find(TestIndexed.class, Conditions.and(
+				Conditions.eq("num1", 1),
+				Conditions.eq("name1", "common"),
+				Conditions.eq("name2", "hkf;glhsdfg")));
+		assertThat(objects1).hasSize(1);
+	}
+
+	@Test
+	public void testFindLe() {
+		RLiveObjectService s = redisson.getLiveObjectService();
+		TestIndexed t1 = new TestIndexed("1");
+		t1.setNum1(12);
+		t1 = s.persist(t1);
+
+		TestIndexed t2 = new TestIndexed("2");
+		t2.setNum1(10);
+		t2 = s.persist(t2);
+
+		Collection<TestIndexed> objects2 = s.find(TestIndexed.class, Conditions.le("num1", 9));
+		assertThat(objects2).isEmpty();
+
+		Collection<TestIndexed> objects0 = s.find(TestIndexed.class, Conditions.le("num1", 12));
+		assertThat(objects0).hasSize(2);
+		Iterator<TestIndexed> iter = objects0.iterator();
+		TestIndexed obj1 = iter.next();
+		assertThat(obj1.getId()).isEqualTo(t1.getId());
+		TestIndexed obj2 = iter.next();
+		assertThat(obj2.getId()).isEqualTo(t2.getId());
+
+		s.delete(t1);
+		s.delete(t2);
+
+		Collection<TestIndexed> objects3 = s.find(TestIndexed.class, Conditions.le("num1", 12));
+		assertThat(objects3).isEmpty();
+
+		TestIndexed t3 = new TestIndexed("3");
+		t3.setName1("test31");
+		t3.setNum1(32);
+		t3.setBool1(false);
+		t3 = s.persist(t3);
+
+		TestIndexed t4 = new TestIndexed("4");
+		t4 = s.persist(t4);
+		t4.setName1("test41");
+		t4.setNum1(42);
+		t4.setBool1(true);
+
+		Collection<TestIndexed> objects4 = s.find(TestIndexed.class, Conditions.or(Conditions.le("num1", 30), Conditions.le("num1", 32)));
+		assertThat(objects4).hasSize(1);
+
+		Collection<TestIndexed> objects41 = s.find(TestIndexed.class, Conditions.or(Conditions.le("num1", 31), Conditions.lt("num1", -1)));
+		assertThat(objects41).hasSize(0);
+
+		Collection<TestIndexed> objects5 = s.find(TestIndexed.class, Conditions.or(Conditions.and(Conditions.eq("name1", "test31"), Conditions.le("num1", 32)),
+				Conditions.and(Conditions.eq("name1", "test41"), Conditions.le("num1", 42))));
+		assertThat(objects5).hasSize(2);
+
+		Collection<TestIndexed> objects6 = s.find(TestIndexed.class, Conditions.or(Conditions.eq("name1", "test34"),
+				Conditions.and(Conditions.eq("name1", "test41"), Conditions.le("num1", 42))));
+		assertThat(objects6.iterator().next().getId()).isEqualTo("4");
+	}
+
+	@Test
+	public void testFindLt() {
+		RLiveObjectService s = redisson.getLiveObjectService();
+		TestIndexed t1 = new TestIndexed("1");
+		t1.setNum1(12);
+		t1 = s.persist(t1);
+
+		TestIndexed t2 = new TestIndexed("2");
+		t2.setNum1(10);
+		t2 = s.persist(t2);
+
+		Collection<TestIndexed> objects2 = s.find(TestIndexed.class, Conditions.lt("num1", 9));
+		assertThat(objects2).isEmpty();
+
+		Collection<TestIndexed> objects0 = s.find(TestIndexed.class, Conditions.lt("num1", 13));
+		assertThat(objects0).hasSize(2);
+		Iterator<TestIndexed> iter = objects0.iterator();
+		TestIndexed obj1 = iter.next();
+		assertThat(obj1.getId()).isEqualTo(t1.getId());
+		TestIndexed obj2 = iter.next();
+		assertThat(obj2.getId()).isEqualTo(t2.getId());
+
+		s.delete(t1);
+		s.delete(t2);
+
+		Collection<TestIndexed> objects3 = s.find(TestIndexed.class, Conditions.lt("num1", 13));
+		assertThat(objects3).isEmpty();
+
+		TestIndexed t3 = new TestIndexed("3");
+		t3.setName1("test31");
+		t3.setNum1(32);
+		t3.setBool1(false);
+		t3 = s.persist(t3);
+
+		TestIndexed t4 = new TestIndexed("4");
+		t4 = s.persist(t4);
+		t4.setName1("test41");
+		t4.setNum1(42);
+		t4.setBool1(true);
+
+		Collection<TestIndexed> objects4 = s.find(TestIndexed.class, Conditions.or(Conditions.lt("num1", 30), Conditions.lt("num1", 33)));
+		assertThat(objects4).hasSize(1);
+
+		Collection<TestIndexed> objects41 = s.find(TestIndexed.class, Conditions.or(Conditions.lt("num1", 32), Conditions.lt("num1", -1)));
+		assertThat(objects41).hasSize(0);
+
+		Collection<TestIndexed> objects5 = s.find(TestIndexed.class, Conditions.or(Conditions.and(Conditions.eq("name1", "test31"), Conditions.lt("num1", 33)),
+				Conditions.and(Conditions.eq("name1", "test41"), Conditions.lt("num1", 43))));
+		assertThat(objects5).hasSize(2);
+
+		Collection<TestIndexed> objects6 = s.find(TestIndexed.class, Conditions.or(Conditions.eq("name1", "test34"),
+				Conditions.and(Conditions.eq("name1", "test41"), Conditions.lt("num1", 43))));
+		assertThat(objects6.iterator().next().getId()).isEqualTo("4");
+	}
+
+	@Test
+	public void testFindGe() {
+		RLiveObjectService s = redisson.getLiveObjectService();
+		TestIndexed t1 = new TestIndexed("1");
+		t1.setNum1(12);
+		t1 = s.persist(t1);
+
+		TestIndexed t2 = new TestIndexed("2");
+		t2.setNum1(10);
+		t2 = s.persist(t2);
+
+		Collection<TestIndexed> objects0 = s.find(TestIndexed.class, Conditions.ge("num1", 10));
+		assertThat(objects0).hasSize(2);
+		Iterator<TestIndexed> iter = objects0.iterator();
+		TestIndexed obj1 = iter.next();
+		assertThat(obj1.getId()).isEqualTo(t1.getId());
+		TestIndexed obj2 = iter.next();
+		assertThat(obj2.getId()).isEqualTo(t2.getId());
+
+		s.delete(t1);
+		s.delete(t2);
+
+		Collection<TestIndexed> objects3 = s.find(TestIndexed.class, Conditions.ge("num1", 10));
+		assertThat(objects3).isEmpty();
+
+		TestIndexed t3 = new TestIndexed("3");
+		t3.setName1("test31");
+		t3.setNum1(32);
+		t3.setBool1(false);
+		t3 = s.persist(t3);
+
+		TestIndexed t4 = new TestIndexed("4");
+		t4 = s.persist(t4);
+		t4.setName1("test41");
+		t4.setNum1(42);
+		t4.setBool1(true);
+
+		Collection<TestIndexed> objects4 = s.find(TestIndexed.class, Conditions.or(Conditions.ge("num1", 42), Conditions.ge("num1", 43)));
+		assertThat(objects4).hasSize(1);
+
+		Collection<TestIndexed> objects41 = s.find(TestIndexed.class, Conditions.or(Conditions.ge("num1", 43), Conditions.ge("num1", 45)));
+		assertThat(objects41).hasSize(0);
+
+		Collection<TestIndexed> objects5 = s.find(TestIndexed.class, Conditions.or(Conditions.and(Conditions.eq("name1", "test31"), Conditions.ge("num1", 32)),
+				Conditions.and(Conditions.eq("name1", "test41"), Conditions.ge("num1", 42))));
+		assertThat(objects5).hasSize(2);
+
+		Collection<TestIndexed> objects6 = s.find(TestIndexed.class, Conditions.or(Conditions.eq("name1", "test34"),
+				Conditions.and(Conditions.eq("name1", "test41"), Conditions.ge("num1", 42))));
+		assertThat(objects6.iterator().next().getId()).isEqualTo("4");
+	}
+
+	@Test
+	public void testFindGt() {
+		RLiveObjectService s = redisson.getLiveObjectService();
+		TestIndexed t1 = new TestIndexed("1");
+		t1.setNum1(12);
+		t1 = s.persist(t1);
+
+		TestIndexed t2 = new TestIndexed("2");
+		t2.setNum1(10);
+		t2 = s.persist(t2);
+
+		Collection<TestIndexed> objects0 = s.find(TestIndexed.class, Conditions.gt("num1", 9));
+		assertThat(objects0).hasSize(2);
+		Iterator<TestIndexed> iter = objects0.iterator();
+		TestIndexed obj1 = iter.next();
+		assertThat(obj1.getId()).isEqualTo(t1.getId());
+		TestIndexed obj2 = iter.next();
+		assertThat(obj2.getId()).isEqualTo(t2.getId());
+
+		s.delete(t1);
+		s.delete(t2);
+
+		Collection<TestIndexed> objects3 = s.find(TestIndexed.class, Conditions.gt("num1", 9));
+		assertThat(objects3).isEmpty();
+
+		TestIndexed t3 = new TestIndexed("3");
+		t3.setName1("test31");
+		t3.setNum1(32);
+		t3.setBool1(false);
+		t3 = s.persist(t3);
+
+		TestIndexed t4 = new TestIndexed("4");
+		t4 = s.persist(t4);
+		t4.setName1("test41");
+		t4.setNum1(42);
+		t4.setBool1(true);
+
+		Collection<TestIndexed> objects4 = s.find(TestIndexed.class, Conditions.or(Conditions.gt("num1", 40), Conditions.gt("num1", 42)));
+		assertThat(objects4).hasSize(1);
+
+		Collection<TestIndexed> objects41 = s.find(TestIndexed.class, Conditions.or(Conditions.gt("num1", 42), Conditions.gt("num1", 45)));
+		assertThat(objects41).hasSize(0);
+
+		Collection<TestIndexed> objects5 = s.find(TestIndexed.class, Conditions.or(Conditions.and(Conditions.eq("name1", "test31"), Conditions.gt("num1", 30)),
+				Conditions.and(Conditions.eq("name1", "test41"), Conditions.gt("num1", 40))));
+		assertThat(objects5).hasSize(2);
+
+		Collection<TestIndexed> objects6 = s.find(TestIndexed.class, Conditions.or(Conditions.eq("name1", "test34"),
+				Conditions.and(Conditions.eq("name1", "test41"), Conditions.gt("num1", 41))));
+		assertThat(objects6.iterator().next().getId()).isEqualTo("4");
+	}
+
+	@Test
+	public void testCountEq() {
+		RLiveObjectService s = redisson.getLiveObjectService();
+		TestIndexed t1 = new TestIndexed("1");
+		t1.setName1("test1");
+		t1.setNum1(100);
+		t1 = s.persist(t1);
+
+		TestIndexed t2 = new TestIndexed("2");
+		t2 = s.persist(t2);
+		t2.setName1("test1");
+		t2.setObj(t1);
+		t2.setNum1(100);
+
+		long ids = s.count(TestIndexed.class, Conditions.eq("name1", "test1"));
+		assertThat(ids).isEqualTo(2);
+
+		long ids2 = s.count(TestIndexed.class, Conditions.eq("name1", "test2"));
+		assertThat(ids2).isZero();
+
+		long ids3 = s.count(TestIndexed.class, Conditions.eq("num1", 100));
+		assertThat(ids3).isEqualTo(2);
+	}
+
+	@Test
+	public void testIndexUpdateCluster() throws IOException, InterruptedException {
+		RedisRunner master1 = new RedisRunner().randomPort().randomDir().nosave();
+		RedisRunner master2 = new RedisRunner().randomPort().randomDir().nosave();
+		RedisRunner master3 = new RedisRunner().randomPort().randomDir().nosave();
+		RedisRunner slot1 = new RedisRunner().randomPort().randomDir().nosave();
+		RedisRunner slot2 = new RedisRunner().randomPort().randomDir().nosave();
+		RedisRunner slot3 = new RedisRunner().randomPort().randomDir().nosave();
+
+		ClusterRunner clusterRunner = new ClusterRunner()
+				.addNode(master1, slot1)
+				.addNode(master2, slot2)
+				.addNode(master3, slot3);
+		ClusterRunner.ClusterProcesses process = clusterRunner.run();
+
+		Config config = new Config();
+		config.useClusterServers()
+				.addNodeAddress(process.getNodes().stream().findAny().get().getRedisServerAddressAndPort());
+		RedissonClient redisson = Redisson.create(config);
+
+		RLiveObjectService s = redisson.getLiveObjectService();
+		TestIndexed t1 = new TestIndexed("1");
+		t1.setName1("test1");
+		t1 = s.persist(t1);
+
+		Collection<TestIndexed> objects0 = s.find(TestIndexed.class, Conditions.eq("name1", "test1"));
+		assertThat(objects0.iterator().next().getId()).isEqualTo(t1.getId());
+
+		redisson.shutdown();
+		process.shutdown();
+	}
+
+	@Test
+	public void testIndexUpdate() {
+		RLiveObjectService s = redisson.getLiveObjectService();
+		TestIndexed t1 = new TestIndexed("1");
+		t1.setName1("test1");
+		t1 = s.persist(t1);
+
+		Collection<TestIndexed> objects0 = s.find(TestIndexed.class, Conditions.eq("name1", "test1"));
+		assertThat(objects0.iterator().next().getId()).isEqualTo(t1.getId());
+
+		t1.setName1("test2");
+
+		Collection<TestIndexed> objects2 = s.find(TestIndexed.class, Conditions.eq("name1", "test1"));
+		assertThat(objects2.isEmpty()).isTrue();
+		Collection<TestIndexed> objects3 = s.find(TestIndexed.class, Conditions.eq("name1", "test2"));
+		assertThat(objects3.iterator().next().getId()).isEqualTo(t1.getId());
+	}
+
+	@Test
+	public void testIndexUpdatePrimitive() {
+		RLiveObjectService s = redisson.getLiveObjectService();
+		TestIndexed t1 = new TestIndexed("1");
+		t1.setNum2(11);
+		t1 = s.persist(t1);
+
+		Collection<TestIndexed> objects0 = s.find(TestIndexed.class, Conditions.eq("num2", 11));
+		assertThat(objects0.iterator().next().getId()).isEqualTo(t1.getId());
+
+		t1.setNum2(12);
+
+		Collection<TestIndexed> objects01 = s.find(TestIndexed.class, Conditions.eq("num2", 11));
+		assertThat(objects01).isEmpty();
+		Collection<TestIndexed> objects1 = s.find(TestIndexed.class, Conditions.eq("num2", 12));
+		assertThat(objects1.iterator().next().getId()).isEqualTo(t1.getId());
+	}
+
+	@Test
+	public void testIndexUpdate2() {
+		RLiveObjectService s = redisson.getLiveObjectService();
+		TestIndexed t1 = new TestIndexed("1");
+		t1.setName1("test1");
+		t1 = s.persist(t1);
+
+		TestIndexed t2 = new TestIndexed("2");
+		t2.setName1("test2");
+		t2 = s.persist(t2);
+		t1.setObj(t2);
+
+		TestIndexed t3 = new TestIndexed("3");
+		t3.setName1("test3");
+		t3 = s.persist(t3);
+		t1.setObj(t3);
+	}
+
+	@Test
+	public void testFindEq() {
+		RLiveObjectService s = redisson.getLiveObjectService();
+		TestIndexed t1 = new TestIndexed("1");
+		t1.setName1("test1");
+		t1 = s.persist(t1);
+
+		TestIndexed t2 = new TestIndexed("2");
+		t2 = s.persist(t2);
+		t2.setName1("test1");
+		t2.setObj(t1);
+
+		Collection<TestIndexed> objects0 = s.find(TestIndexed.class, Conditions.eq("obj", t1.getId()));
+		assertThat(objects0.iterator().next().getId()).isEqualTo(t2.getId());
+
+		t2.setObj(null);
+		Collection<TestIndexed> objects01 = s.find(TestIndexed.class, Conditions.eq("obj", t1.getId()));
+		assertThat(objects01).isEmpty();
+
+		Collection<TestIndexed> objects1 = s.find(TestIndexed.class, Conditions.eq("name1", "test1"));
+		assertThat(objects1).hasSize(2);
+
+		Collection<TestIndexed> objects2 = s.find(TestIndexed.class, Conditions.eq("name3", "test2"));
+		assertThat(objects2).isEmpty();
+
+		s.delete(t1);
+		s.delete(t2);
+
+		Collection<TestIndexed> objects3 = s.find(TestIndexed.class, Conditions.eq("name1", "test1"));
+		assertThat(objects3).isEmpty();
+
+		TestIndexed t3 = new TestIndexed("3");
+		t3.setName1("test31");
+		t3.setNum1(32);
+		t3.setBool1(false);
+		t3 = s.persist(t3);
+
+		TestIndexed t4 = new TestIndexed("4");
+		t4 = s.persist(t4);
+		t4.setName1("test41");
+		t4.setNum1(42);
+		t4.setBool1(true);
+
+		Collection<TestIndexed> objects4 = s.find(TestIndexed.class, Conditions.or(Conditions.eq("name1", "test31"), Conditions.eq("name1", "test41")));
+		assertThat(objects4).hasSize(2);
+
+		Collection<TestIndexed> objects41 = s.find(TestIndexed.class, Conditions.in("name1", "test31", "test41"));
+		assertThat(objects41).hasSize(2);
+
+		Collection<TestIndexed> objects5 = s.find(TestIndexed.class, Conditions.or(Conditions.and(Conditions.eq("name1", "test31"), Conditions.eq("num1", 32)),
+				Conditions.and(Conditions.eq("name1", "test41"), Conditions.eq("num1", 42))));
+		assertThat(objects5).hasSize(2);
+
+		Collection<TestIndexed> objects6 = s.find(TestIndexed.class, Conditions.or(Conditions.eq("name1", "test34"),
+				Conditions.and(Conditions.eq("name1", "test41"), Conditions.eq("num1", 42))));
+		assertThat(objects6.iterator().next().getId()).isEqualTo("4");
+
+		Collection<TestIndexed> objects7 = s.find(TestIndexed.class, Conditions.eq("bool1", true));
+		assertThat(objects7.iterator().next().getId()).isEqualTo("4");
+
+		Collection<TestIndexed> objects8 = s.find(TestIndexed.class, Conditions.and(Conditions.in("name1", "test31", "test30"),
+				Conditions.eq("bool1", true)));
+		assertThat(objects8).isEmpty();
+	}
+
+	@Test
+	public void testBasics() {
+		RLiveObjectService s = redisson.getLiveObjectService();
+		TestREntity t = new TestREntity("1", null);
+		t = s.persist(t);
+		assertEquals("1", t.getName());
+
+		DefaultNamingScheme scheme = new DefaultNamingScheme(redisson.getConfig().getCodec());
+		assertTrue(redisson.getMap(scheme.getName(TestREntity.class, "1")).isExists());
+		t.setName("3333");
+
+		assertEquals("3333", t.getName());
+		assertTrue(redisson.getMap(scheme.getName(TestREntity.class, "3333")).isExists());
+		t.setValue("111");
+		assertEquals("111", t.getValue());
+		assertTrue(redisson.getMap(scheme.getName(TestREntity.class, "3333")).isExists());
+		assertTrue(!redisson.getMap(scheme.getName(TestREntity.class, "1")).isExists());
+		assertEquals("111", redisson.getMap(scheme.getName(TestREntity.class, "3333")).get("value"));
+
+//        ((RLiveObject) t).getLiveObjectLiveMap().put("value", "555");
+//        assertEquals("555", redisson.getMap(REntity.DefaultNamingScheme.INSTANCE.getName(TestREntity.class, "name", "3333")).get("value"));
+//        assertEquals("3333", ((RObject) t).getName());//field access takes priority over the implemented interface.
+	}
+
+	@Test
+	public void testLiveObjectWithCollection() {
+		RLiveObjectService s = redisson.getLiveObjectService();
+		TestREntityWithMap t = new TestREntityWithMap("2", null);
+		t = s.persist(t);
+		RMap<String, String> map = redisson.<String, String>getMap("testMap");
+		t.setValue(map);
+		map.put("field", "123");
+
+		TestREntityWithMap t2 = s.get(TestREntityWithMap.class, "2");
+
+		assertEquals("123", t2.getValue().get("field"));
+
+		TestREntityWithMap t3 = s.get(TestREntityWithMap.class, "2");
+		Map<String, String> map1 = (Map<String, String>) t3.getValue();
+		if (map1 != null) {
+			map1.put("field", "333");
+		}
+
+		t3 = s.get(TestREntityWithMap.class, "2");
+		assertEquals("333", t3.getValue().get("field"));
+
+		HashMap<String, String> map2 = new HashMap<>();
+		map2.put("field", "hello");
+		t.setValue(map2);
+
+		t3 = s.get(TestREntityWithMap.class, "2");
+		assertEquals("hello", t3.getValue().get("field"));
+	}
+
+	@Test
+	public void testLiveObjectWithRObject() {
+		RLiveObjectService s = redisson.getLiveObjectService();
+		TestREntityWithRMap t = new TestREntityWithRMap("2", null);
+		t = s.persist(t);
+		RMap<String, String> map = redisson.<String, String>getMap("testMap");
+		t.setValue(map);
+		map.put("field", "123");
+		assertEquals("123",
+				s.<TestREntityWithRMap>get(TestREntityWithRMap.class, "2")
+						.getValue().get("field"));
+		t = s.get(TestREntityWithRMap.class, "2");
+		Map<String, String> map1 = (Map<String, String>) t.getValue();
+		if (map1 != null) {
+			map1.put("field", "333");
+		}
+		assertEquals("333",
+				s.<TestREntityWithRMap>get(TestREntityWithRMap.class, "2")
+						.getValue().get("field"));
+	}
+
+	@Test
+	public void testLiveObjectWithNestedLiveObjectAsId() {
+		RLiveObjectService s = redisson.getLiveObjectService();
+		TestREntity t1 = new TestREntity("1", null);
+		t1 = s.persist(t1);
+
+		try {
+			s.persist(new TestREntityIdNested(t1));
+			fail("Should not be here");
+		} catch (Exception e) {
+			assertEquals("Field with RId annotation cannot be a type of which class is annotated with REntity.", e.getMessage());
+		}
+	}
+
+	@Test
+	public void testLiveObjectWithNestedLiveObjectAsValue() throws Exception {
+		RLiveObjectService s = redisson.getLiveObjectService();
+
+		TestREntityWithRMap t1 = new TestREntityWithRMap("111", null);
+		t1 = s.persist(t1);
+
+		TestREntityValueNested t2 = new TestREntityValueNested("122");
+		t2 = s.persist(t2);
+
+		RMap<String, String> map = redisson.<String, String>getMap("32123");
+		t2.setValue(t1);
+		t2.getValue().setValue(map);
+		map.put("field", "123");
+		assertEquals("123",
+				s.get(TestREntityWithRMap.class, "111")
+						.getValue().get("field"));
+		assertEquals("123",
+				s.get(TestREntityValueNested.class, "122")
+						.getValue().getValue().get("field"));
+	}
+
+	@Test
+	public void testSerializerable() {
+		RLiveObjectService service = redisson.getLiveObjectService();
+		TestClass t = new TestClass("55555");
+		t = service.persist(t);
+		assertTrue(Objects.equals("55555", t.getId()));
+
+		t = new TestClass(90909l);
+		t = service.persist(t);
+		assertTrue(Objects.equals(90909l, t.getId()));
+
+		t = new TestClass(90909);
+		t = service.persist(t);
+		assertTrue(Objects.equals(90909, t.getId()));
+
+		t = new TestClass(new ObjectId(9090909));
+		t = service.persist(t);
+		assertTrue(Objects.equals(new ObjectId(9090909), t.getId()));
+
+		t = new TestClass(new Byte("0"));
+		t = service.persist(t);
+		assertEquals(new Byte("0"), Byte.valueOf(t.getId().toString()));
+
+		t = new TestClass((byte) 90);
+		assertEquals((byte) 90, Byte.parseByte(t.getId().toString()));
+
+		t = new TestClass((Serializable) Arrays.asList(1, 2, 3, 4));
+		t = service.persist(t);
+		List<Integer> l = new ArrayList();
+		l.addAll(Arrays.asList(1, 2, 3, 4));
+		assertTrue(l.removeAll((List) t.getId()));
+		assertTrue(l.isEmpty());
+
+		try {
+			t = new TestClass(new int[]{1, 2, 3, 4, 5});
+			t = service.persist(t);
+			fail("Should not be here");
+		} catch (Exception e) {
+			assertEquals("RId value cannot be an array.", e.getMessage());
+		}
+
+		try {
+			t = new TestClass(new byte[]{1, 2, 3, 4, 5});
+			t = service.persist(t);
+			fail("Should not be here");
+		} catch (Exception e) {
+			assertEquals("RId value cannot be an array.", e.getMessage());
+		}
+	}
+
+	@Test
+	public void testMergeList() {
+		Customer customer = new Customer("12");
+		Order order = new Order(customer);
+		customer.getOrders().add(order);
+		Order order2 = new Order(customer);
+		customer.getOrders().add(order2);
+
+        RLiveObjectService liveObjectService = redisson.getLiveObjectService();
+        liveObjectService.merge(customer);
+
+		Customer mergedCustomer = liveObjectService.get(Customer.class, "12");
+		String mergedCustomerId = mergedCustomer.getId();
+		assertThat(mergedCustomerId).isEqualTo(customer.getId());
+        List<Order> mergedOrders = mergedCustomer.getOrders();
+        int size = mergedOrders.size();
+        assertThat(size).isEqualTo(2);
+		for (Order orderElement : mergedOrders) {
+            Long orderId = orderElement.getId();
+            Customer fetchedCustomer = orderElement.getCustomer();
+            String customerId = fetchedCustomer.getId();
+            assertThat(orderId).isNotNull();
+            assertThat(customerId).isEqualTo("12");
+		}
+
+		try {
+			liveObjectService.persist(customer);
+			fail("Should not be here");
+		} catch (Exception e) {
+			assertEquals("This REntity already exists.", e.getMessage());
+		}
+	}
+
+	@Test
+	public void testPersistList() {
+		Customer customer = new Customer("12");
+		Order order = new Order(customer);
+		customer.getOrders().add(order);
+		Order order2 = new Order(customer);
+		customer.getOrders().add(order2);
+
+		redisson.getLiveObjectService().persist(customer);
+
+		customer = redisson.getLiveObjectService().get(Customer.class, "12");
+		assertThat(customer.getOrders().size()).isEqualTo(2);
+		for (Order orderElement : customer.getOrders()) {
+			assertThat(orderElement.getId()).isNotNull();
+			assertThat(orderElement.getCustomer().getId()).isEqualTo("12");
+		}
+	}
+
+	@Test
+	public void testPersist() {
+		RLiveObjectService service = redisson.getLiveObjectService();
+
+		TestClass ts = new TestClass(new ObjectId(100));
+		ts.setValue("VALUE");
+		ts.setContent(new TestREntity("123", null));
+		ts.addEntry("1", "2");
+		TestClass persisted = service.persist(ts);
+
+		assertEquals(3, redisson.getKeys().count());
+		assertEquals(1, persisted.getValues().size());
+		assertEquals("123", ((TestREntity) persisted.getContent()).getName());
+		assertEquals(new ObjectId(100), persisted.getId());
+		assertEquals("VALUE", persisted.getValue());
+		try {
+			service.persist(ts);
+			fail("Should not be here");
+		} catch (Exception e) {
+			assertEquals("This REntity already exists.", e.getMessage());
+		}
+	}
+
+	@Test
+	public void testMerge() {
+		RLiveObjectService service = redisson.getLiveObjectService();
+		TestClass ts = new TestClass(new ObjectId(100));
+		ts.setValue("VALUE");
+		TestClass merged = service.merge(ts);
+		assertEquals(new ObjectId(100), merged.getId());
+		assertEquals("VALUE", merged.getValue());
+		try {
+			service.persist(ts);
+			fail("Should not be here");
+		} catch (Exception e) {
+			assertEquals("This REntity already exists.", e.getMessage());
+		}
+		ts = new TestClass(new ObjectId(100));
+		ts.setCode("CODE");
+		merged = service.merge(ts);
+		assertNull(ts.getValue());
+		assertEquals("VALUE", merged.getValue());
+		assertEquals("CODE", merged.getCode());
+	}
+
+	@Test
+	public void testDetach() {
+		RLiveObjectService service = redisson.getLiveObjectService();
+		TestClass ts = new TestClass(new ObjectId(100));
+		ts.setValue("VALUE");
+		ts.setCode("CODE");
+		TestClass merged = service.merge(ts);
+		assertEquals("VALUE", merged.getValue());
+		assertEquals("CODE", merged.getCode());
+		TestClass detach = service.detach(merged);
+		assertEquals(ts, detach);
+	}
+
+	@Test
+	public void testIsPhantom() {
+		RLiveObjectService service = redisson.getLiveObjectService();
+		assertFalse(service.isExists(new Object()));
+		TestClass ts = new TestClass(new ObjectId(100));
+		assertFalse(service.isExists(service.get(TestClass.class, new ObjectId(100))));
+		assertFalse(service.isExists(ts));
+		ts.setValue("VALUE");
+		ts.setCode("CODE");
+		TestClass persisted = service.persist(ts);
+		assertTrue(service.isExists(service.get(TestClass.class, new ObjectId(100))));
+		assertFalse(service.isExists(ts));
+		assertTrue(service.isExists(persisted));
+	}
+
+	@Test
+	public void testIsLiveObject() {
+		RLiveObjectService service = redisson.getLiveObjectService();
+		TestClass ts = new TestClass(new ObjectId(100));
+		assertFalse(service.isLiveObject(ts));
+		TestClass persisted = service.persist(ts);
+		assertFalse(service.isLiveObject(ts));
+		assertTrue(service.isLiveObject(persisted));
+	}
+
+	@Test
+	public void testAsLiveObject() {
+		RLiveObjectService service = redisson.getLiveObjectService();
+		TestClass instance = new TestClass(new ObjectId(100));
+		instance = service.persist(instance);
+
+		RLiveObject liveObject = service.asLiveObject(instance);
+		assertEquals(new ObjectId(100), liveObject.getLiveObjectId());
+		try {
+			service.asLiveObject(new Object());
+			fail("Should not be here");
+		} catch (Exception e) {
+			assertTrue(e instanceof ClassCastException);
+		}
+	}
+
+	@Test
+	public void testClassRegistration() {
+		RLiveObjectService service = redisson.getLiveObjectService();
+		service.registerClass(TestClass.class);
+		assertTrue(service.isClassRegistered(TestClass.class));
+		RLiveObjectService newService = redisson.getLiveObjectService();
+		assertTrue(newService.isClassRegistered(TestClass.class));
+		RedissonClient newRedisson = Redisson.create(redisson.getConfig());
+		assertFalse(newRedisson.getLiveObjectService().isClassRegistered(TestClass.class));
+		newRedisson.shutdown(1, 5, TimeUnit.SECONDS);
+	}
+
+	@Test
+	public void testClassUnRegistration() {
+		RLiveObjectService service = redisson.getLiveObjectService();
+		service.registerClass(TestClass.class);
+		assertTrue(service.isClassRegistered(TestClass.class));
+		RLiveObjectService newService = redisson.getLiveObjectService();
+		RedissonClient newRedisson = Redisson.create(redisson.getConfig());
+		newRedisson.getLiveObjectService().registerClass(TestClass.class);
+		newService.unregisterClass(TestClass.class);
+		assertFalse(service.isClassRegistered(TestClass.class));
+		assertFalse(newService.isClassRegistered(TestClass.class));
+		assertTrue(newRedisson.getLiveObjectService().isClassRegistered(TestClass.class));
+		assertFalse(service.isClassRegistered(TestClass.class));
+		assertFalse(newService.isClassRegistered(TestClass.class));
+		newRedisson.shutdown(1, 5, TimeUnit.SECONDS);
+	}
+
+	@Test
+	public void testGet() {
+		RLiveObjectService service = redisson.getLiveObjectService();
+		assertNull(service.get(TestClass.class, new ObjectId(100)));
+		TestClass ts = new TestClass(new ObjectId(100));
+		TestClass persisted = service.persist(ts);
+		assertNotNull(service.get(TestClass.class, new ObjectId(100)));
+		persisted.setCode("CODE");
+		assertNotNull(service.get(TestClass.class, new ObjectId(100)));
+	}
+
+	@Test
+	public void testRemoveByInstance() {
+		RLiveObjectService service = redisson.getLiveObjectService();
+		TestClass ts = new TestClass(new ObjectId(100));
+		ts.setCode("CODE");
+		TestClass persisted = service.persist(ts);
+		assertTrue(service.isExists(persisted));
+		service.delete(persisted);
+		assertFalse(service.isExists(persisted));
+	}
+
+	@Test
+	public void testRemoveById() {
+		RLiveObjectService service = redisson.getLiveObjectService();
+		TestClass ts = new TestClass(new ObjectId(100));
+		ts.setCode("CODE");
+		TestClass persisted = service.persist(ts);
+		assertTrue(service.isExists(persisted));
+		assertThat(service.delete(TestClass.class, new ObjectId(100))).isEqualTo(1);
+		assertFalse(service.isExists(persisted));
+	}
+
+	@Test
+	public void testCreate() {
+		RLiveObjectService service = redisson.getLiveObjectService();
+		TestClass ts = new TestClass();
+		ts = service.persist(ts);
+		UUID uuid = UUID.fromString(ts.getId().toString());
+		assertEquals(4, uuid.version());
+
+		TestClassID1 tc1 = new TestClassID1();
+		tc1 = service.persist(tc1);
+		assertEquals(new Long(1), tc1.getName());
+		TestClassID2 tc2 = new TestClassID2();
+		tc2 = service.persist(tc2);
+		assertEquals(new Long(1), tc2.getName());
+	}
+
+	@Test
+	public void testFindIds() {
+		RLiveObjectService s = redisson.getLiveObjectService();
+		TestIndexed1 t1 = new TestIndexed1();
+		t1.setId("1");
+		t1.setKeywords(Collections.singletonList("132323"));
+		TestIndexed1 t2 = new TestIndexed1();
+		t2.setId("2");
+		t2.setKeywords(Collections.singletonList("fjdklj"));
+		s.persist(t1, t2);
+
+		Iterable<String> ids = s.findIds(TestIndexed1.class);
+		assertThat(ids).containsExactlyInAnyOrder("1", "2");
+	}
+
+	@Test
+	public void testMergeList2() {
+		RLiveObjectService s = redisson.getLiveObjectService();
+		TestIndexed1 t1 = new TestIndexed1();
+		t1.setId("1");
+		List<String> ws = new ArrayList<>();
+		ws.add("word1");
+		ws.add("word2");
+		t1.setKeywords(ws);
+		s.persist(t1);
+
+		List<String> ws2 = new ArrayList<>();
+		ws2.add("word3");
+		t1.setKeywords(ws2);
+		s.merge(t1);
+		assertThat(t1.getKeywords()).containsExactly("word3");
+
+		t1 = s.get(TestIndexed1.class, "1");
+		assertThat(t1.getKeywords()).containsExactly("word3");
+	}
+
+	@Test
+	public void testTransformation() {
+		RLiveObjectService service = redisson.getLiveObjectService();
+		TestClass ts = new TestClass();
+		ts = service.persist(ts);
+
+		HashMap<String, String> m = new HashMap<>();
+		ts.setContent(m);
+		assertFalse(HashMap.class.isAssignableFrom(ts.getContent().getClass()));
+		assertTrue(RMap.class.isAssignableFrom(ts.getContent().getClass()));
+
+		HashSet<String> s = new HashSet<>();
+		ts.setContent(s);
+		assertFalse(HashSet.class.isAssignableFrom(ts.getContent().getClass()));
+		assertTrue(RSet.class.isAssignableFrom(ts.getContent().getClass()));
+
+		TreeSet<String> ss = new TreeSet<>();
+		ts.setContent(ss);
+		assertFalse(TreeSet.class.isAssignableFrom(ts.getContent().getClass()));
+		assertTrue(RSortedSet.class.isAssignableFrom(ts.getContent().getClass()));
+
+		ArrayList<String> al = new ArrayList<>();
+		ts.setContent(al);
+		assertFalse(ArrayList.class.isAssignableFrom(ts.getContent().getClass()));
+		assertTrue(RList.class.isAssignableFrom(ts.getContent().getClass()));
+
+		ConcurrentHashMap<String, String> chm = new ConcurrentHashMap<>();
+		ts.setContent(chm);
+		assertFalse(ConcurrentHashMap.class.isAssignableFrom(ts.getContent().getClass()));
+		assertTrue(RMap.class.isAssignableFrom(ts.getContent().getClass()));
+
+		ArrayBlockingQueue<String> abq = new ArrayBlockingQueue<>(10);
+		ts.setContent(abq);
+		assertFalse(ArrayBlockingQueue.class.isAssignableFrom(ts.getContent().getClass()));
+		assertTrue(RBlockingQueue.class.isAssignableFrom(ts.getContent().getClass()));
+
+		ConcurrentLinkedQueue<String> clq = new ConcurrentLinkedQueue<>();
+		ts.setContent(clq);
+		assertFalse(ConcurrentLinkedQueue.class.isAssignableFrom(ts.getContent().getClass()));
+		assertTrue(RQueue.class.isAssignableFrom(ts.getContent().getClass()));
+
+		LinkedBlockingDeque<String> lbdq = new LinkedBlockingDeque<>();
+		ts.setContent(lbdq);
+		assertFalse(LinkedBlockingDeque.class.isAssignableFrom(ts.getContent().getClass()));
+		assertTrue(RBlockingDeque.class.isAssignableFrom(ts.getContent().getClass()));
+
+		LinkedList<String> ll = new LinkedList<>();
+		ts.setContent(ll);
+		assertFalse(LinkedList.class.isAssignableFrom(ts.getContent().getClass()));
+		assertTrue(RDeque.class.isAssignableFrom(ts.getContent().getClass()));
+
+	}
+
+	@Test
+	public void testNoTransformation() {
+		RLiveObjectService service = redisson.getLiveObjectService();
+		TestClassNoTransformation ts = new TestClassNoTransformation();
+		ts = service.persist(ts);
+
+		HashMap<String, String> m = new HashMap<>();
+		ts.setContent(m);
+		assertTrue(HashMap.class.isAssignableFrom(ts.getContent().getClass()));
+		assertFalse(RMap.class.isAssignableFrom(ts.getContent().getClass()));
+
+		HashSet<String> s = new HashSet<>();
+		ts.setContent(s);
+		assertTrue(HashSet.class.isAssignableFrom(ts.getContent().getClass()));
+		assertFalse(RSet.class.isAssignableFrom(ts.getContent().getClass()));
+
+		TreeSet<String> ss = new TreeSet<>();
+		ts.setContent(ss);
+		assertTrue(TreeSet.class.isAssignableFrom(ts.getContent().getClass()));
+		assertFalse(RSortedSet.class.isAssignableFrom(ts.getContent().getClass()));
+
+		ArrayList<String> al = new ArrayList<>();
+		ts.setContent(al);
+		assertTrue(ArrayList.class.isAssignableFrom(ts.getContent().getClass()));
+		assertFalse(RList.class.isAssignableFrom(ts.getContent().getClass()));
+
+		ConcurrentHashMap<String, String> chm = new ConcurrentHashMap<>();
+		ts.setContent(chm);
+		assertTrue(ConcurrentHashMap.class.isAssignableFrom(ts.getContent().getClass()));
+		assertFalse(RMap.class.isAssignableFrom(ts.getContent().getClass()));
+
+		ConcurrentLinkedQueue<String> clq = new ConcurrentLinkedQueue<>();
+		ts.setContent(clq);
+		assertTrue(ConcurrentLinkedQueue.class.isAssignableFrom(ts.getContent().getClass()));
+		assertFalse(RQueue.class.isAssignableFrom(ts.getContent().getClass()));
+
+		LinkedBlockingDeque<String> lbdq = new LinkedBlockingDeque<>();
+		ts.setContent(lbdq);
+		assertTrue(LinkedBlockingDeque.class.isAssignableFrom(ts.getContent().getClass()));
+		assertFalse(RBlockingDeque.class.isAssignableFrom(ts.getContent().getClass()));
+
+		LinkedList<String> ll = new LinkedList<>();
+		ts.setContent(ll);
+		assertTrue(LinkedList.class.isAssignableFrom(ts.getContent().getClass()));
+		assertFalse(RDeque.class.isAssignableFrom(ts.getContent().getClass()));
+
+	}
+
+	@Test
+	public void test() {
+		RLiveObjectService service = redisson.getLiveObjectService();
+
+		MyObject object = new MyObject(20L);
+		try {
+			service.attach(object);
+		} catch (Exception e) {
+			assertEquals("Non-null value is required for the field with RId annotation.", e.getMessage());
+		}
+	}
+
+	@Test
+	public void testExpirable() throws InterruptedException {
+		RLiveObjectService service = redisson.getLiveObjectService();
+		TestClass myObject = new TestClass();
+		myObject = service.persist(myObject);
+		myObject.setValue("123345");
+		assertTrue(service.asLiveObject(myObject).isExists());
+		service.asRMap(myObject).expire(1, TimeUnit.SECONDS);
+		Thread.sleep(2000);
+		assertFalse(service.asLiveObject(myObject).isExists());
+	}
+
+	@Test
+	public void testMap() {
+		RLiveObjectService service = redisson.getLiveObjectService();
+		TestClass myObject = new TestClass();
+		myObject = service.persist(myObject);
+
+		myObject.setValue("123345");
+		assertEquals("123345", service.asRMap(myObject).get("value"));
+		service.asRMap(myObject).put("value", "9999");
+		assertEquals("9999", myObject.getValue());
+	}
+
+	@Test
+	public void testRObject() {
+		RLiveObjectService service = redisson.getLiveObjectService();
+		TestClass myObject = new TestClass();
+		myObject = service.persist(myObject);
+		try {
+			((RObject) myObject).isExists();
+		} catch (Exception e) {
+			assertEquals("Please use RLiveObjectService instance for this type of functions", e.getMessage());
+		}
+	}
+
+	@Test
+	public void testStoreInnerObject() {
+		RLiveObjectService service = redisson.getLiveObjectService();
+		ObjectWithList so = new ObjectWithList();
+		so = service.persist(so);
+
+		SimpleObject s = new SimpleObject();
+		s = service.persist(s);
+		so.setSo(s);
+		assertThat(s.getId()).isNotNull();
+		so.getObjects().add(s);
+		so = redisson.getLiveObjectService().detach(so);
+		assertThat(so.getSo().getId()).isEqualTo(s.getId());
+		assertThat(so.getObjects().get(0).getId()).isEqualTo(so.getSo().getId());
+	}
+
+	@Test
+	public void testFieldWithoutIdSetter() {
+		RLiveObjectService service = redisson.getLiveObjectService();
+		SimpleObject so = new SimpleObject();
+		so = service.persist(so);
+		so.setValue(10L);
+
+		so = redisson.getLiveObjectService().detach(so);
+		assertThat(so.getId()).isNotNull();
+		assertThat(so.getValue()).isEqualTo(10L);
+
+		so = redisson.getLiveObjectService().get(SimpleObject.class, so.getId());
+		assertThat(so.getId()).isNotNull();
+		assertThat(so.getValue()).isEqualTo(10L);
+	}
+
+	@Test
+	public void testCreateObjectsInRuntime() {
+		RLiveObjectService service = redisson.getLiveObjectService();
+
+		TestREntityWithMap so = new TestREntityWithMap();
+		so = service.persist(so);
+
+		Map<String, String> map1 = (Map<String, String>) so.getValue();
+		map1.put("1", "2");
+
+		so = redisson.getLiveObjectService().detach(so);
+		Map<String, String> map2 = (Map<String, String>) so.getValue();
+		assertThat(so.getName()).isNotNull();
+		assertThat(map2).containsKey("1");
+		assertThat(map2).containsValue("2");
+
+		so = redisson.getLiveObjectService().get(TestREntityWithMap.class, so.getName());
+		Map<String, String> map3 = (Map<String, String>) so.getValue();
+		assertThat(so.getName()).isNotNull();
+		assertThat(map3).containsKey("1");
+		assertThat(map3).containsValue("2");
+	}
+
+	@Test
+	public void testFieldAccessor() {
+		RLiveObjectService service = redisson.getLiveObjectService();
+		TestClass myObject = new TestClass();
+		myObject = service.persist(myObject);
+
+		myObject.setValue("123345");
+		assertEquals("123345", myObject.get("value"));
+		myObject.set("value", "9999");
+		assertEquals("9999", myObject.get("value"));
+		assertEquals("9999", myObject.getValue());
+		try {
+			myObject.get("555555");
+		} catch (Exception e) {
+			assertTrue(e instanceof NoSuchFieldException);
+		}
+		try {
+			myObject.set("555555", "999");
+		} catch (Exception e) {
+			assertTrue(e instanceof NoSuchFieldException);
+		}
+	}
+
+	@Test
+	public void testCollectionRewrite() {
+		Customer c = new Customer("123");
+		c = redisson.getLiveObjectService().merge(c);
+
+		Order o1 = new Order(c);
+		o1 = redisson.getLiveObjectService().merge(o1);
+		assertThat(o1.getId()).isEqualTo(1);
+		c.getOrders().add(o1);
+
+		Order o2 = new Order(c);
+		o2 = redisson.getLiveObjectService().merge(o2);
+		assertThat(o2.getId()).isEqualTo(2);
+		c.getOrders().add(o2);
+
+		assertThat(c.getOrders().size()).isEqualTo(2);
+
+		assertThat(redisson.getKeys().count()).isEqualTo(7);
+
+		List<Order> list = new ArrayList<>();
+		Order o3 = new Order(c);
+		o3 = redisson.getLiveObjectService().merge(o3);
+		assertThat(o3.getId()).isEqualTo(3);
+		list.add(o3);
+		c.setOrders(list);
+
+		assertThat(c.getOrders().size()).isEqualTo(1);
+	}
+
+	@Test
+    // When a setter is encapsulated, kotlin optimizes by removing the setter inside the method.
+    // There is no setter method accessible from inside the methods of a class.
+	public void testSetterEncapsulation() {
+		SetterEncapsulation se = new SetterEncapsulation();
+        RLiveObjectService liveObjectService = redisson.getLiveObjectService();
+        se = liveObjectService.persist(se);
+
+        long count = redisson.getKeys().count();
+        assertThat(count).isEqualTo(2);
+
+		se.addItem("1", 1);
+		se.addItem("2", 2);
+
+        long count1 = redisson.getKeys().count();
+        assertThat(count1).isEqualTo(3);
+
+		se = liveObjectService.get(SetterEncapsulation.class, se.getId());
+
+		assertThat(se.getItem("1")).isEqualTo(1);
+		assertThat(se.getItem("2")).isEqualTo(2);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testObjectShouldNotBeAttached() {
+		Customer customer = new Customer("12");
+		customer = redisson.getLiveObjectService().persist(customer);
+		Order order = new Order();
+		customer.getOrders().add(order);
+	}
+
+	@Test
+	public void testObjectShouldNotBeAttached2() {
+		Customer customer = new Customer("12");
+		Order order = new Order(customer);
+		order = redisson.getLiveObjectService().persist(order);
+	}
+
+	@Test
+	public void testDeleteList() {
+		Customer customer = new Customer("12");
+		Order order = new Order(customer);
+		customer.getOrders().add(order);
+		Order order2 = new Order(customer);
+		customer.getOrders().add(order2);
+
+		order = redisson.getLiveObjectService().persist(order);
+		assertThat(redisson.getKeys().count()).isEqualTo(5);
+
+		redisson.getLiveObjectService().delete(order.getCustomer());
+		assertThat(redisson.getKeys().count()).isEqualTo(1);
+	}
+
+	@Test
+	public void testDeleteNotExisted() {
+		RLiveObjectService service = redisson.getLiveObjectService();
+		assertThat(service.delete(Customer.class, "id")).isZero();
+	}
+
+	@Test
+	public void testDeleteMultipleIds() {
+		Customer customer1 = new Customer("1");
+		Customer customer2 = new Customer("2");
+		RLiveObjectService ls = redisson.getLiveObjectService();
+		ls.persist(customer1, customer2);
+		assertThat(ls.delete(Customer.class, "1", "2")).isEqualTo(2);
+		assertThat(redisson.getKeys().count()).isZero();
+	}
+
+	@Test
+	public void testDelete() {
+		Customer customer = new Customer("12");
+		Order order = new Order(customer);
+		order = redisson.getLiveObjectService().persist(order);
+		assertThat(redisson.getKeys().count()).isEqualTo(3);
+
+		Customer persistedCustomer = order.getCustomer();
+		redisson.getLiveObjectService().delete(order);
+		assertThat(redisson.getKeys().count()).isEqualTo(2);
+
+		redisson.getLiveObjectService().delete(persistedCustomer);
+		assertThat(redisson.getKeys().count()).isEqualTo(1);
+	}
+
+	@Test
+	public void testObjectShouldBeAttached() {
+		Customer customer = new Customer("12");
+		customer = redisson.getLiveObjectService().persist(customer);
+		Order order = new Order();
+		order = redisson.getLiveObjectService().persist(order);
+		customer.getOrders().add(order);
+
+		customer = redisson.getLiveObjectService().detach(customer);
+		assertThat(customer.getClass()).isSameAs(Customer.class);
+		assertThat(customer.getId()).isNotNull();
+		List<Order> orders = customer.getOrders();
+		assertThat(orders.get(0)).isNotNull();
+
+		customer = redisson.getLiveObjectService().get(Customer.class, customer.getId());
+		assertThat(customer.getId()).isNotNull();
+		assertThat(customer.getOrders().get(0)).isNotNull();
+	}
+
+	@Test
+	public void testCyclicRefsDuringDetach() {
+		Customer customer = new Customer("12");
+		customer = redisson.getLiveObjectService().persist(customer);
+		Order order = new Order();
+		order = redisson.getLiveObjectService().persist(order);
+		order.setCustomer(customer);
+		customer.getOrders().add(order);
+
+		customer = redisson.getLiveObjectService().detach(customer);
+
+		assertThat(customer.getClass()).isSameAs(Customer.class);
+		assertThat(customer.getId()).isNotNull();
+		List<Order> orders = customer.getOrders();
+		assertThat(orders.get(0).getCustomer()).isSameAs(customer);
+
+		customer = redisson.getLiveObjectService().get(Customer.class, customer.getId());
+
+		assertThat(customer.getId()).isNotNull();
+		Order o = customer.getOrders().get(0);
+		assertThat(o.getCustomer().getId()).isEqualTo(customer.getId());
+	}
+
+	@Test
+	public void testWithoutIdSetterGetter() {
+		ClassWithoutIdSetterGetter sg = new ClassWithoutIdSetterGetter();
+		sg = redisson.getLiveObjectService().persist(sg);
+	}
+
+	@Test
+	public void testProtectedConstructor() {
+		ClassWithoutIdSetterGetter sg = new ClassWithoutIdSetterGetter("1234");
+		sg = redisson.getLiveObjectService().persist(sg);
+		assertThat(sg.getName()).isEqualTo("1234");
+	}
+
+	@Test
+	public void testEnum() {
+		RLiveObjectService liveObjectService = redisson.getLiveObjectService();
+		liveObjectService.registerClass(TestEnum.class);
+
+		String id = "1";
+		TestEnum entry = new TestEnum();
+		entry.setId(id);
+		entry.setMyEnum1(TestEnum.MyEnum.A);
+		entry = liveObjectService.persist(entry);
+
+		TestEnum liveEntry = liveObjectService.get(TestEnum.class, id);
+		assertThat(liveEntry.getMyEnum1()).isEqualTo(TestEnum.MyEnum.A);
+		assertThat(liveEntry.getMyEnum2()).isNull();
+
+		entry.setMyEnum2(TestEnum.MyEnum.B);
+		assertThat(liveEntry.getMyEnum2()).isEqualTo(TestEnum.MyEnum.B);
+	}
+
+	@Test
+	public void testInheritedREntity() {
+		Dog d = new Dog("Fido");
+		d.setBreed("lab");
+
+		d = redisson.getLiveObjectService().persist(d);
+
+		assertThat(d.getName()).isEqualTo("Fido");
+		assertThat(d.getBreed()).isEqualTo("lab");
+	}
+
+	@Test
+	public void testMapOfInheritedEntity() {
+		RMap<String, Dog> dogs = redisson.getMap("dogs");
+		Dog d = new Dog("Fido");
+		d = redisson.getLiveObjectService().persist(d);
+		d.setBreed("lab");
+		dogs.put("key", d);
+		dogs = redisson.getMap("dogs");
+		assertThat(dogs.size()).isEqualTo(1);
+		assertThat(dogs.get("key").getBreed()).isEqualTo("lab");
+	}
+
+	@Test
+	public void testCyclicRefsWithInheritedREntity() {
+		MyCustomer customer = new MyCustomer("12");
+		customer = redisson.getLiveObjectService().persist(customer);
+		Order order = new Order();
+		order = redisson.getLiveObjectService().persist(order);
+		order.setCustomer(customer);
+		customer.getOrders().add(order);
+		Order special = new Order();
+		special = redisson.getLiveObjectService().persist(special);
+		order.setCustomer(customer);
+		customer.addSpecialOrder(special);
+
+		customer = redisson.getLiveObjectService().detach(customer);
+		assertThat(customer.getClass()).isSameAs(MyCustomer.class);
+		assertThat(customer.getId()).isNotNull();
+		List<Order> orders = customer.getOrders();
+		assertThat(orders.get(0)).isNotNull();
+		List<Order> specials = customer.getSpecialOrders();
+		assertThat(specials.get(0)).isNotNull();
+
+		customer = redisson.getLiveObjectService().get(MyCustomer.class, customer.getId());
+		assertThat(customer.getId()).isNotNull();
+		assertThat(customer.getOrders().get(0)).isNotNull();
+		assertThat(customer.getSpecialOrders().get(0)).isNotNull();
+	}
+
+	@Test
+	public void testStoreInnerObjectWithInheritedREntity() {
+		RLiveObjectService service = redisson.getLiveObjectService();
+		MyObjectWithList so = new MyObjectWithList();
+		so = service.persist(so);
+
+		SimpleObject s = new SimpleObject();
+		s = service.persist(s);
+
+		so.setSo(s);
+		assertThat(s.getId()).isNotNull();
+		so.getObjects().add(s);
+		so.setName("name");
+
+		so = redisson.getLiveObjectService().detach(so);
+		assertThat(so.getSo().getId()).isEqualTo(s.getId());
+		assertThat(so.getObjects().get(0).getId()).isEqualTo(so.getSo().getId());
+		assertThat(so.getName()).isEqualTo("name");
+	}
+
+	@Test(timeout = 40 * 1000)
+	public void testBatchedPersist() {
+		RLiveObjectService s = redisson.getLiveObjectService();
+
+		List<TestREntity> objects = new ArrayList<>();
+		int objectsAmount = 1000000;
+		for (int i = 0; i < objectsAmount; i++) {
+			TestREntity e = new TestREntity();
+			e.setName("" + i);
+			e.setValue("value" + i);
+			objects.add(e);
+		}
+		List<Object> attachedObjects = s.persist(objects.toArray());
+		assertThat(attachedObjects).hasSize(objectsAmount);
+
+		assertThat(redisson.getKeys().count()).isEqualTo(objectsAmount);
+	}
+
+	@Test
+	public void testIsAccessor() {
+		HasIsAccessor o = new HasIsAccessor();
+		o.setGood(true);
+		o = redisson.getLiveObjectService().persist(o);
+		assertThat(o.getGood()).isEqualTo(true);
+	}
+
+}

--- a/redisson-kotlin-test/src/test/java/org/redisson/RedissonRuntimeEnvironment.java
+++ b/redisson-kotlin-test/src/test/java/org/redisson/RedissonRuntimeEnvironment.java
@@ -1,0 +1,35 @@
+package org.redisson;
+
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+/**
+ *
+ * @author Rui Gu (https://github.com/jackygurui)
+ */
+public class RedissonRuntimeEnvironment {
+
+	public static final boolean isTravis = "true".equalsIgnoreCase(System.getProperty("travisEnv"));
+	public static final String redisBinaryPath = System.getProperty("redisBinary", "C:\\redis\\redis-server.exe");
+	public static final String tempDir = System.getProperty("java.io.tmpdir");
+	public static final String OS;
+	public static final boolean isWindows;
+	public static final String redisPort;
+
+	static {
+		OS = System.getProperty("os.name", "generic");
+		isWindows = OS.toLowerCase(Locale.ENGLISH).contains("win");
+		String portString = System.getProperty("redisPort", "");
+        Pattern portPattern = Pattern.compile("[1-9]\\d+");
+
+        if (portString.isEmpty()) {
+            redisPort = "";
+        } else if (portPattern.matcher(portString).matches()) {
+            redisPort = portString;
+        } else {
+            String msg = String.format("REDIS RUNNER ENVIRONMENT: Chosen port '%s' does not match pattern '%s'", portString, portPattern.pattern());
+            System.out.println(msg);
+            redisPort = "";
+        }
+	}
+}

--- a/redisson/src/test/java/org/redisson/RedisRunner.java
+++ b/redisson/src/test/java/org/redisson/RedisRunner.java
@@ -206,6 +206,7 @@ public class RedisRunner {
 
     {
         this.options.put(REDIS_OPTIONS.BINARY_PATH, RedissonRuntimeEnvironment.redisBinaryPath);
+        if (!RedissonRuntimeEnvironment.redisPort.isEmpty()) this.options.put(REDIS_OPTIONS.PORT, RedissonRuntimeEnvironment.redisPort);
     }
 
     /**
@@ -1010,7 +1011,12 @@ public class RedisRunner {
     public static RedisRunner.RedisProcess startDefaultRedisServerInstance() throws IOException, InterruptedException, FailedToStartRedisException {
         if (defaultRedisInstance == null) {
             System.out.println("REDIS RUNNER: Starting up default instance...");
-            defaultRedisInstance = new RedisRunner().nosave().randomDir().randomPort().run();
+            RedisRunner runner = new RedisRunner();
+            if (runner.options.getOrDefault(REDIS_OPTIONS.PORT, "").isEmpty()) {
+                defaultRedisInstance = runner.nosave().randomDir().randomPort().run();
+            } else {
+                defaultRedisInstance = runner.nosave().randomDir().port(runner.port).run();
+            }
         }
         return defaultRedisInstance;
     }

--- a/redisson/src/test/java/org/redisson/RedissonRuntimeEnvironment.java
+++ b/redisson/src/test/java/org/redisson/RedissonRuntimeEnvironment.java
@@ -1,6 +1,7 @@
 package org.redisson;
 
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 /**
  *
@@ -13,9 +14,22 @@ public class RedissonRuntimeEnvironment {
     public static final String tempDir = System.getProperty("java.io.tmpdir");
     public static final String OS;
     public static final boolean isWindows;
+    public static final String redisPort;
 
     static {
         OS = System.getProperty("os.name", "generic");
         isWindows = OS.toLowerCase(Locale.ENGLISH).contains("win");
+        String portString = System.getProperty("redisPort", "");
+        Pattern portPattern = Pattern.compile("[1-9]\\d+");
+
+        if (portString.isEmpty()) {
+            redisPort = "";
+        } else if (portPattern.matcher(portString).matches()) {
+            redisPort = portString;
+        } else {
+            String msg = String.format("REDIS RUNNER ENVIRONMENT: Chosen port '%s' does not match pattern '%s'", portString, portPattern.pattern());
+            System.out.println(msg);
+            redisPort = "";
+        }
     }
 }


### PR DESCRIPTION
This should close issue #2977 .

It would be interesting to document the quick rules for Kotlin users.

- All classes must be declared `open`
- All fields must be declared `open`
- All fields must be declared `var`
- There are not any **is-accessors** in Kotlin as is common in Java beans. You must default to using `get` or `set`
- Fields may be declared `protected`
- Property setters may be declared `protected`
- Collections must be declared mutable
