### PR TITLE
Update MapOptions.java

### DIFF
--- a/redisson/src/main/java/org/redisson/api/MapOptions.java
+++ b/redisson/src/main/java/org/redisson/api/MapOptions.java
@@ -51,10 +51,10 @@ public class MapOptions<K, V> {
     private int writeBehindBatchSize = 50;
     private int writeBehindDelay = 1000;
     
-    protected MapOptions() {
+    public MapOptions() {
     }
     
-    protected MapOptions(MapOptions<K, V> copy) {
+    public MapOptions(MapOptions<K, V> copy) {
     }
     
     /**


### PR DESCRIPTION
It should be possible to create MapOptions in type-safe mode, not only as MapOptions<Object, Object>(); which provided by the default method