### PR TITLE
removed check for invocation of sync methods in async/rx/reactive listeners

### DIFF
--- a/redisson/src/main/java/org/redisson/command/CommandAsyncService.java
+++ b/redisson/src/main/java/org/redisson/command/CommandAsyncService.java
@@ -104,10 +104,6 @@ public class CommandAsyncService implements CommandAsyncExecutor {
 
     @Override
     public <V> V get(RFuture<V> future) {
-        if (Thread.currentThread().getName().startsWith("redisson-netty")) {
-            throw new IllegalStateException("Sync methods can't be invoked from async/rx/reactive listeners");
-        }
-
         try {
             future.await();
         } catch (InterruptedException e) {


### PR DESCRIPTION
Can't find an issue or document of why adding such condition checking. Maybe a fast work-around.