### PR TITLE
try fix the issue #3404, SENTINEL SENTINELS timeout

### DIFF
--- a/redisson/src/main/java/org/redisson/client/RedisClient.java
+++ b/redisson/src/main/java/org/redisson/client/RedisClient.java
@@ -180,7 +180,7 @@ public final class RedisClient {
         byte[] addr = NetUtil.createByteArrayFromIpAddressString(uri.getHost());
         if (addr != null) {
             try {
-                resolvedAddr = new InetSocketAddress(InetAddress.getByAddress(addr), uri.getPort());
+                resolvedAddr = new InetSocketAddress(InetAddress.getByAddress(uri.getHost(), addr), uri.getPort());
             } catch (UnknownHostException e) {
                 // skip
             }


### PR DESCRIPTION
#3404, The netty enentLoop was blocked by try to resolve the hostname of the org.redisson.client.RedisClient#resolveAddr's InetSocketAddress.
