### PR TITLE
Fix NPE thrown by RedisURI.compare()

### DIFF
--- a/redisson/src/main/java/org/redisson/misc/RedisURI.java
+++ b/redisson/src/main/java/org/redisson/misc/RedisURI.java
@@ -88,12 +88,18 @@ public class RedisURI {
     }
     
     public static boolean compare(InetSocketAddress entryAddr, RedisURI addr) {
-        if (((entryAddr.getHostName() != null && entryAddr.getHostName().equals(trimIpv6Brackets(addr.getHost())))
-                || entryAddr.getAddress().getHostAddress().equals(trimIpv6Brackets(addr.getHost())))
-                && entryAddr.getPort() == addr.getPort()) {
-            return true;
+        if (entryAddr == null || addr == null || addr.getHost() == null) {
+            return false;
         }
-        return false;
+
+        boolean matchesHostName = entryAddr.getHostName() != null
+                && entryAddr.getHostName().equals(trimIpv6Brackets(addr.getHost()));
+
+        boolean matchesHostAddress = entryAddr.getAddress() != null
+                && entryAddr.getAddress().getHostAddress() != null
+                && entryAddr.getAddress().getHostAddress().equals(trimIpv6Brackets(addr.getHost()));
+
+        return (matchesHostName || matchesHostAddress) && entryAddr.getPort() == addr.getPort();
     }
 
     @Override


### PR DESCRIPTION
We are using Redisson to connect to an AWS ElastiCache Redis cluster.
When scaling up the cluster by adding new shards, we notice long lasting exceptions:
```
 org.redisson.client.RedisNodeNotFoundException: Node for slot: xxxx hasn't been discovered yet. Check cluster slots coverage using CLUSTER NODES command. Increase value of retryAttempts and/or retryInterval settings. | at org.redisson.connection.MasterSlaveConnectionManager.createNodeNotFoundException(MasterSlaveConnectionManager.java:559) | at org.redisson.connection.MasterSlaveConnectionManager.connectionReadOp(MasterSlaveConnectionManager.java:543) | at org.redisson.command.RedisExecutor.getConnection(RedisExecutor.java:532) | at org.redisson.command.RedisExecutor.execute(RedisExecutor.java:121) | at org.redisson.command.RedisExecutor$2.run(RedisExecutor.java:251) | at io.netty.util.HashedWheelTimer$HashedWheelTimeout.expire(HashedWheelTimer.java:672)

```

In our logs we also noticed the following NPE:

```
An exception was thrown by   org.redisson.misc.RedissonPromise$$Lambda$371/0x00000008006b0440.operationComplete()   java.lang.NullPointerException | at org.redisson.misc.RedisURI.compare(RedisURI.java:91) | at   org.redisson.cluster.ClusterConnectionManager.getEntry(ClusterConnectionManager.java:172) | at   org.redisson.cluster.ClusterConnectionManager.checkSlotsChange(ClusterConnectionManager.java:642) | at org.redisson.cluster.ClusterConnectionManager.lambda$null$9(ClusterConnectionManager.java:474) | at org.redisson.misc.RedissonPromise.lambda$onComplete$0(RedissonPromise.java:187)
```

I believe the two errors are related. Therefore I made `RedisURI.compare()` null safe.