### PR TITLE
Simplify code using Map::computeIfAbsent

### DIFF
--- a/redisson/src/main/java/org/redisson/remote/BaseRemoteProxy.java
+++ b/redisson/src/main/java/org/redisson/remote/BaseRemoteProxy.java
@@ -67,12 +67,7 @@ public abstract class BaseRemoteProxy {
     private final Map<Class<?>, String> requestQueueNameCache = new ConcurrentHashMap<>();
     
     public String getRequestQueueName(Class<?> remoteInterface) {
-        String str = requestQueueNameCache.get(remoteInterface);
-        if (str == null) {
-            str = "{" + name + ":" + remoteInterface.getName() + "}";
-            requestQueueNameCache.put(remoteInterface, str);
-        }
-        return str;
+        return requestQueueNameCache.computeIfAbsent(remoteInterface, k -> "{" + name + ":" + k.getName() + "}");
     }
     
     protected RFuture<RemoteServiceAck> tryPollAckAgainAsync(RemoteInvocationOptions optionsCopy,

--- a/redisson/src/main/java/org/redisson/remote/BaseRemoteService.java
+++ b/redisson/src/main/java/org/redisson/remote/BaseRemoteService.java
@@ -92,12 +92,7 @@ public abstract class BaseRemoteService {
 
 
     public String getRequestQueueName(Class<?> remoteInterface) {
-        String str = requestQueueNameCache.get(remoteInterface);
-        if (str == null) {
-            str = "{" + name + ":" + remoteInterface.getName() + "}";
-            requestQueueNameCache.put(remoteInterface, str);
-        }
-        return str;
+        return requestQueueNameCache.computeIfAbsent(remoteInterface, k -> "{" + name + ":" + k.getName() + "}");
     }
 
     protected ByteBuf encode(Object obj) {


### PR DESCRIPTION
This pull request simplifies the implementation of `getRequestQueueName` using `Map::computeIfAbsent`.

This patch was generated automatically using the static analysis tool [Logifix](https://github.com/lyxell/logifix) as part of a research project.