### PR TITLE
Fix primary update condition for cluster mode.

### DIFF
--- a/redisson/src/main/java/org/redisson/cluster/ClusterConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/cluster/ClusterConnectionManager.java
@@ -566,8 +566,8 @@ public class ClusterConnectionManager extends MasterSlaveConnectionManager {
                     continue;
                 }
                 masterFound = true;
-                // current master marked as failed
-                if (!newPart.isMasterFail() || newPart.getSlotsAmount() == 0) {
+                // skip the new master if it is marked as failed or has no slots
+                if (newPart.isMasterFail() || newPart.getSlotsAmount() == 0) {
                     continue;
                 }
                 for (Integer slot : currentPart.getSlots()) {
@@ -593,7 +593,7 @@ public class ClusterConnectionManager extends MasterSlaveConnectionManager {
                 break;
             }
 
-            if (!masterFound && newPart.getSlotsAmount() > 0) {
+            if (!masterFound && !newPart.isMasterFail() && newPart.getSlotsAmount() > 0) {
                 addedPartitions.put(newPart.getMasterAddress(), newPart);
             }
         }


### PR DESCRIPTION
I'm using Redisson to interact with my Elasticache Redis cluster. The configuration is 15 shards with only primary nodes.

If I create a replica for one shard and failover the primary node to the replica, the new connection won't be established.