### PR TITLE
Fix Sentinel setup with dynamic redis IPs for hostnames

### DIFF
--- a/redisson/src/main/java/org/redisson/connection/SentinelConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/SentinelConnectionManager.java
@@ -247,6 +247,8 @@ public class SentinelConnectionManager extends MasterSlaveConnectionManager {
     
     @Override
     protected void startDNSMonitoring(RedisClient masterHost) {
+        super.startDNSMonitoring();
+
         if (config.getDnsMonitoringInterval() == -1 || sentinelHosts.isEmpty()) {
             return;
         }


### PR DESCRIPTION
In a sentinel setup (i.e. using Bitnami Redis Helm chart) and setting up Redis to use hostnames instead of IP addresses, a redisson configuration YAML might look like the following, where redis points to the load balancing service (like a Cluster IP service in Kubernetes):
```
sentinelServersConfig:
  sentinelAddresses:
    - "redis://redis:26379"
  username: "redisUsername"
  password: "redisPassword"
  sentinelPassword: "sentinelPassword"
  masterName: mymaster
codec: !<org.redisson.codec.SerializationCodec> {}
```

In the SentinelConnectionManager constructor, it will store hostnames for the master and replicas.

In a 3 node setup, let's say we restarted some redis containers (which will restart both redis's and sentinels) and they come back up as a different IP address, but same hostname.

From a Sentinel standpoint, there are no issues when sentinel containers restart with new IP addresses because the sentinel will go through the redis load balancer to get a working sentinel.

But for the master and/or replicas, InetAddress's stored will point to the old IP addresses in the MasterSlaveConnectionManager.masterSlaveEntry.

For Master Slave setups, it looks like this was fixed by adding a DNSMonitor to check that the IP addresses match and if it didn't, it would replace the masterSlaveEntry with the new IP addresses.  This PR will add start that same DNS Monitor for the SentinelConnectionManager.