### PR TITLE
Create custom Trim parameter class and overload the trim methods

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonStream.java
+++ b/redisson/src/main/java/org/redisson/RedissonStream.java
@@ -1156,8 +1156,18 @@ public class RedissonStream<K, V> extends RedissonExpirable implements RStream<K
     }
 
     @Override
+    public long trim(TrimStrategy strategy, TrimParam param) {
+        return get(trimAsync(strategy, param));
+    }
+
+    @Override
     public long trimNonStrict(TrimStrategy strategy, int threshold, int limit) {
         return get(trimNonStrictAsync(strategy, threshold, limit));
+    }
+
+    @Override
+    public long trimNonStrict(TrimStrategy strategy, TrimParam param, int limit) {
+        return get(trimNonStrictAsync(strategy, param, limit));
     }
 
     @Override
@@ -1167,9 +1177,21 @@ public class RedissonStream<K, V> extends RedissonExpirable implements RStream<K
     }
 
     @Override
+    public RFuture<Long> trimAsync(TrimStrategy strategy, TrimParam param) {
+        return commandExecutor.writeAsync(getRawName(), StringCodec.INSTANCE, RedisCommands.XTRIM,
+                                            getRawName(), strategy.toString(), param.getValue());
+    }
+
+    @Override
     public RFuture<Long> trimNonStrictAsync(TrimStrategy strategy, int threshold, int limit) {
         return commandExecutor.writeAsync(getRawName(), StringCodec.INSTANCE, RedisCommands.XTRIM,
                                     getRawName(), strategy.toString(), "~", threshold, "LIMIT", limit);
+    }
+
+    @Override
+    public RFuture<Long> trimNonStrictAsync(TrimStrategy strategy, TrimParam param, int limit) {
+        return commandExecutor.writeAsync(getRawName(), StringCodec.INSTANCE, RedisCommands.XTRIM,
+                                    getRawName(), strategy.toString(), "~", param.getValue(), "LIMIT", limit);
     }
 
     @Override
@@ -1178,11 +1200,21 @@ public class RedissonStream<K, V> extends RedissonExpirable implements RStream<K
     }
 
     @Override
+    public long trimNonStrict(TrimStrategy strategy, TrimParam param) {
+        return get(trimNonStrictAsync(strategy, param));
+    }
+
+    @Override
     public RFuture<Long> trimNonStrictAsync(TrimStrategy strategy, int threshold) {
         return commandExecutor.writeAsync(getRawName(), StringCodec.INSTANCE, RedisCommands.XTRIM,
                                     getRawName(), strategy.toString(), "~", threshold);
     }
 
+    @Override
+    public RFuture<Long> trimNonStrictAsync(TrimStrategy strategy, TrimParam param) {
+        return commandExecutor.writeAsync(getRawName(), StringCodec.INSTANCE, RedisCommands.XTRIM,
+                                    getRawName(), strategy.toString(), "~", param.getValue());
+    }
     @Override
     public RFuture<Long> trimAsync(int count) {
         return commandExecutor.writeAsync(getRawName(), StringCodec.INSTANCE, RedisCommands.XTRIM, getRawName(), "MAXLEN", count);

--- a/redisson/src/main/java/org/redisson/api/RStream.java
+++ b/redisson/src/main/java/org/redisson/api/RStream.java
@@ -751,15 +751,15 @@ public interface RStream<K, V> extends RStreamAsync<K, V>, RExpirable {
 
     /**
      * Removes messages by id.
-     * 
+     *
      * @param ids - id of messages to remove
      * @return deleted messages amount
      */
     long remove(StreamMessageId... ids);
-    
+
     /**
      * Trims stream using MAXLEN strategy to specified size
-     * 
+     *
      * @param size - new size of stream
      * @return number of deleted messages
      */
@@ -768,15 +768,27 @@ public interface RStream<K, V> extends RStreamAsync<K, V>, RExpirable {
     /**
      * Trims stream to specified size
      *
+     * @deprecated - use {@link #trim(TrimStrategy, TrimParam)} instead
+     *
      * @param strategy - trim strategy
      * @param threshold - new size of stream
      * @return number of deleted messages
      */
+    @Deprecated
     long trim(TrimStrategy strategy, int threshold);
 
     /**
+     * Trims stream with a custom strategy
+     *
+     * @param strategy - trim strategy
+     * @param trimParam - a param specific for the strategy
+     * @return number of deleted messages
+     */
+    long trim(TrimStrategy strategy, TrimParam param);
+
+    /**
      * Trims stream using MAXLEN strategy to almost exact trimming threshold..
-     * 
+     *
      * @param size - new size of stream
      * @return number of deleted messages
      */
@@ -785,6 +797,8 @@ public interface RStream<K, V> extends RStreamAsync<K, V>, RExpirable {
     /**
      * Trims stream using almost exact trimming threshold.
      *
+     * @deprecated - use {@link #trimNonStrict(TrimStrategy, TrimParam)} instead
+     *
      * @param strategy - trim strategy
      * @param threshold - trim threshold
      * @return number of deleted messages
@@ -792,7 +806,18 @@ public interface RStream<K, V> extends RStreamAsync<K, V>, RExpirable {
     long trimNonStrict(TrimStrategy strategy, int threshold);
 
     /**
+     * Trims stream using almost exact trimming with a custom strategy
+     *
+     * @param strategy - trim strategy
+     * @param trimParam - a param specific for the strategy
+     * @return number of deleted messages
+     */
+    long trimNonStrict(TrimStrategy strategy, TrimParam param);
+
+    /**
      * Trims stream using almost exact trimming threshold up to limit.
+     *
+     * @deprecated - use {@link #trimNonStrict(TrimStrategy, TrimParam, int)} instead
      *
      * @param strategy - trim strategy
      * @param threshold - trim threshold
@@ -802,25 +827,35 @@ public interface RStream<K, V> extends RStreamAsync<K, V>, RExpirable {
     long trimNonStrict(TrimStrategy strategy, int threshold, int limit);
 
     /**
+     * Trims stream using almost exact trimming with a custom strategy up to limit.
+     *
+     * @param strategy - trim strategy
+     * @param trimParam - a param specific for the strategy
+     * @param limit - trim limit
+     * @return number of deleted messages
+     */
+    long trimNonStrict(TrimStrategy strategy, TrimParam param, int limit);
+
+    /**
      * Returns information about this stream.
-     * 
+     *
      * @return info object
      */
     StreamInfo<K, V> getInfo();
-    
+
     /**
      * Returns list of common info about groups belonging to this stream.
-     * 
-     * @return list of info objects 
+     *
+     * @return list of info objects
      */
     List<StreamGroup> listGroups();
 
     /**
      * Returns list of common info about group customers for specified <code>groupName</code>.
-     * 
+     *
      * @param groupName - name of group
      * @return list of info objects
      */
     List<StreamConsumer> listConsumers(String groupName);
-    
+
 }

--- a/redisson/src/main/java/org/redisson/api/RStreamAsync.java
+++ b/redisson/src/main/java/org/redisson/api/RStreamAsync.java
@@ -804,11 +804,23 @@ public interface RStreamAsync<K, V> extends RExpirableAsync {
     /**
      * Trims stream to specified size
      *
+     * @deprecated - use {@link #trimAsync(TrimStrategy, TrimParam)} instead
+     *
      * @param strategy - trim strategy
      * @param threshold - new size of stream
      * @return number of deleted messages
      */
+    @Deprecated
     RFuture<Long> trimAsync(TrimStrategy strategy, int threshold);
+
+    /**
+     * Trims stream with a custom strategy
+     *
+     * @param strategy - trim strategy
+     * @param param - a param specific for the strategy
+     * @return number of deleted messages
+     */
+    RFuture<Long> trimAsync(TrimStrategy strategy, TrimParam param);
 
     /**
      * Trims stream using MAXLEN strategy to almost exact trimming threshold.
@@ -821,21 +833,45 @@ public interface RStreamAsync<K, V> extends RExpirableAsync {
     /**
      * Trims stream using almost exact trimming threshold.
      *
+     * @deprecated - use {@link #trimNonStrictAsync(TrimStrategy, TrimParam)} instead
+     *
      * @param strategy - trim strategy
      * @param threshold - trim threshold
      * @return number of deleted messages
      */
+    @Deprecated
     RFuture<Long> trimNonStrictAsync(TrimStrategy strategy, int threshold);
 
     /**
+     * Trims stream with a custom strategy using almost exact trimming threshold.
+     *
+     * @param strategy - trim strategy
+     * @param param - a param specific for the strategy
+     * @return number of deleted messages
+     */
+    RFuture<Long> trimNonStrictAsync(TrimStrategy strategy, TrimParam param);
+
+    /**
      * Trims stream using almost exact trimming threshold up to limit.
+     *
+     * @deprecated - use {@link #trimNonStrictAsync(TrimStrategy, TrimParam, int)} instead
      *
      * @param strategy - trim strategy
      * @param threshold - trim threshold
      * @param limit - trim limit
      * @return number of deleted messages
      */
+    @Deprecated
     RFuture<Long> trimNonStrictAsync(TrimStrategy strategy, int threshold, int limit);
+
+    /**
+     * Trims stream with a custom strategy using almost exact trimming threshold up to limit.
+     *
+     * @param strategy - trim strategy
+     * @param param - a param specific for the strategy
+     * @return number of deleted messages
+     */
+    RFuture<Long> trimNonStrictAsync(TrimStrategy strategy, TrimParam param, int limit);
 
     /**
      * Returns information about this stream.

--- a/redisson/src/main/java/org/redisson/api/RStreamReactive.java
+++ b/redisson/src/main/java/org/redisson/api/RStreamReactive.java
@@ -700,7 +700,7 @@ public interface RStreamReactive<K, V> extends RExpirableReactive {
 
     /**
      * Removes messages by id.
-     * 
+     *
      * @param ids - id of messages to remove
      * @return deleted messages amount
      */
@@ -708,7 +708,7 @@ public interface RStreamReactive<K, V> extends RExpirableReactive {
 
     /**
      * Trims stream to specified size
-     * 
+     *
      * @param size - new size of stream
      * @return number of deleted messages
      */
@@ -716,7 +716,7 @@ public interface RStreamReactive<K, V> extends RExpirableReactive {
 
     /**
      * Trims stream to few tens of entries more than specified length to trim.
-     * 
+     *
      * @param size - new size of stream
      * @return number of deleted messages
      */
@@ -725,48 +725,85 @@ public interface RStreamReactive<K, V> extends RExpirableReactive {
     /**
      * Trims stream to specified size
      *
+     * @deprecated - use {@link #trim(TrimStrategy, TrimParam)} instead
+     *
      * @param strategy - trim strategy
      * @param threshold - new size of stream
      * @return number of deleted messages
      */
+    @Deprecated
     Mono<Long> trim(TrimStrategy strategy, int threshold);
 
     /**
+     * Trims stream with a custom strategy
+     *
+     * @param strategy - trim strategy
+     * @param param - a param specific for the strategy
+     * @return number of deleted messages
+     */
+    Mono<Long> trim(TrimStrategy strategy, TrimParam param);
+
+    /**
      * Trims stream using almost exact trimming threshold.
+     *
+     * @deprecated - use {@link #trimNonStrict(TrimStrategy, TrimParam)} instead
      *
      * @param strategy - trim strategy
      * @param threshold - trim threshold
      * @return number of deleted messages
      */
+    @Deprecated
     Mono<Long> trimNonStrict(TrimStrategy strategy, int threshold);
 
     /**
+     * Trims stream using almost exact trimming with a custom strategy
+     *
+     * @param strategy - trim strategy
+     * @param param - a param specific for the strategy
+     * @return number of deleted messages
+     */
+    Mono<Long> trimNonStrict(TrimStrategy strategy, TrimParam param);
+
+    /**
      * Trims stream using almost exact trimming threshold up to limit.
+     *
+     * @deprecated - use {@link #trimNonStrict(TrimStrategy, TrimParam, int)} instead
      *
      * @param strategy - trim strategy
      * @param threshold - trim threshold
      * @param limit - trim limit
      * @return number of deleted messages
      */
+    @Deprecated
     Mono<Long> trimNonStrict(TrimStrategy strategy, int threshold, int limit);
 
     /**
+     * Trims stream using almost exact trimming with a custom strategy up to limit.
+     *
+     * @param strategy - trim strategy
+     * @param param - a param specific for the strategy
+     * @param limit - trim limit
+     * @return number of deleted messages
+     */
+    Mono<Long> trimNonStrict(TrimStrategy strategy, TrimParam param, int limit);
+
+    /**
      * Returns information about this stream.
-     * 
+     *
      * @return info object
      */
     Mono<StreamInfo<K, V>> getInfo();
-    
+
     /**
      * Returns list of objects with information about groups belonging to this stream.
-     * 
-     * @return list of info objects 
+     *
+     * @return list of info objects
      */
     Mono<List<StreamGroup>> listGroups();
 
     /**
      * Returns list of objects with information about group customers for specified <code>groupName</code>.
-     * 
+     *
      * @param groupName - name of group
      * @return list of info objects
      */

--- a/redisson/src/main/java/org/redisson/api/RStreamRx.java
+++ b/redisson/src/main/java/org/redisson/api/RStreamRx.java
@@ -653,17 +653,17 @@ public interface RStreamRx<K, V> extends RExpirableRx {
      */
     @Deprecated
     Single<Map<String, Map<StreamMessageId, Map<K, V>>>> read(int count, long timeout, TimeUnit unit, StreamMessageId id, String name2, StreamMessageId id2, String name3, StreamMessageId id3);
-    
+
     /*
      * Use read(StreamMultiReadArgs) method instead
      *
      */
     @Deprecated
     Single<Map<String, Map<StreamMessageId, Map<K, V>>>> read(int count, long timeout, TimeUnit unit, StreamMessageId id, Map<String, StreamMessageId> nameToId);
-    
+
     /**
      * Returns stream data in range by specified start Stream ID (included) and end Stream ID (included).
-     * 
+     *
      * @param startId - start Stream ID
      * @param endId - end Stream ID
      * @return stream data mapped by Stream ID
@@ -672,36 +672,36 @@ public interface RStreamRx<K, V> extends RExpirableRx {
 
     /**
      * Returns stream data in range by specified start Stream ID (included) and end Stream ID (included).
-     * 
+     *
      * @param count - stream data size limit
      * @param startId - start Stream ID
      * @param endId - end Stream ID
      * @return stream data mapped by Stream ID
      */
     Single<Map<StreamMessageId, Map<K, V>>> range(int count, StreamMessageId startId, StreamMessageId endId);
-    
+
     /**
      * Returns stream data in reverse order in range by specified start Stream ID (included) and end Stream ID (included).
-     * 
+     *
      * @param startId - start Stream ID
      * @param endId - end Stream ID
      * @return stream data mapped by Stream ID
      */
     Single<Map<StreamMessageId, Map<K, V>>> rangeReversed(StreamMessageId startId, StreamMessageId endId);
-    
+
     /**
      * Returns stream data in reverse order in range by specified start Stream ID (included) and end Stream ID (included).
-     * 
+     *
      * @param count - stream data size limit
      * @param startId - start Stream ID
      * @param endId - end Stream ID
      * @return stream data mapped by Stream ID
      */
     Single<Map<StreamMessageId, Map<K, V>>> rangeReversed(int count, StreamMessageId startId, StreamMessageId endId);
-    
+
     /**
      * Removes messages by id.
-     * 
+     *
      * @param ids - id of messages to remove
      * @return deleted messages amount
      */
@@ -709,7 +709,7 @@ public interface RStreamRx<K, V> extends RExpirableRx {
 
     /**
      * Trims stream to specified size
-     * 
+     *
      * @param size - new size of stream
      * @return number of deleted messages
      */
@@ -717,7 +717,7 @@ public interface RStreamRx<K, V> extends RExpirableRx {
 
     /**
      * Trims stream to few tens of entries more than specified length to trim.
-     * 
+     *
      * @param size - new size of stream
      * @return number of deleted messages
      */
@@ -726,62 +726,99 @@ public interface RStreamRx<K, V> extends RExpirableRx {
     /**
      * Trims stream to specified size
      *
+     * @deprecated - use {@link #trim(TrimStrategy, TrimParam)} instead
+     *
      * @param strategy - trim strategy
      * @param threshold - new size of stream
      * @return number of deleted messages
      */
+    @Deprecated
     Single<Long> trim(TrimStrategy strategy, int threshold);
 
     /**
+     * Trims stream with a custom strategy
+     *
+     * @param strategy - trim strategy
+     * @param param - a param specific for the strategy
+     * @return number of deleted messages
+     */
+    Single<Long> trim(TrimStrategy strategy, TrimParam param);
+
+    /**
      * Trims stream using almost exact trimming threshold.
+     *
+     * @deprecated - use {@link #trimNonStrict(TrimStrategy, TrimParam)} instead
      *
      * @param strategy - trim strategy
      * @param threshold - trim threshold
      * @return number of deleted messages
      */
+    @Deprecated
     Single<Long> trimNonStrict(TrimStrategy strategy, int threshold);
 
     /**
+     * Trims stream using almost exact trimming with a custom strategy
+     *
+     * @param strategy - trim strategy
+     * @param param - a param specific for the strategy
+     * @return number of deleted messages
+     */
+    Single<Long> trimNonStrict(TrimStrategy strategy, TrimParam param);
+
+    /**
      * Trims stream using almost exact trimming threshold up to limit.
+     *
+     * @deprecated - use {@link #trimNonStrict(TrimStrategy, TrimParam, int)} instead
      *
      * @param strategy - trim strategy
      * @param threshold - trim threshold
      * @param limit - trim limit
      * @return number of deleted messages
      */
+    @Deprecated
     Single<Long> trimNonStrict(TrimStrategy strategy, int threshold, int limit);
 
     /**
+     * Trims stream using almost exact trimming with a custom strategy up to limit.
+     *
+     * @param strategy - trim strategy
+     * @param param - a param specific for the strategy
+     * @param limit - trim limit
+     * @return number of deleted messages
+     */
+    Single<Long> trimNonStrict(TrimStrategy strategy, TrimParam param, int limit);
+
+    /**
      * Returns information about this stream.
-     * 
+     *
      * @return info object
      */
     Single<StreamInfo<K, V>> getInfo();
-    
+
     /**
      * Returns list of objects with information about groups belonging to this stream.
-     * 
-     * @return list of info objects 
+     *
+     * @return list of info objects
      */
     Single<List<StreamGroup>> listGroups();
 
     /**
      * Returns list of objects with information about group customers for specified <code>groupName</code>.
-     * 
+     *
      * @param groupName - name of group
      * @return list of info objects
      */
     Single<List<StreamConsumer>> listConsumers(String groupName);
-    
+
     /**
      * Returns stream data of pending messages by group name.
      * Limited by start Stream Message ID and end Stream Message ID and count.
      * <p>
      * {@link StreamMessageId#MAX} is used as max Stream Message ID
      * {@link StreamMessageId#MIN} is used as min Stream Message ID
-     * 
+     *
      * @see #listPending
-     * 
+     *
      * @param groupName - name of group
      * @param startId - start Stream Message ID
      * @param endId - end Stream Message ID
@@ -789,16 +826,16 @@ public interface RStreamRx<K, V> extends RExpirableRx {
      * @return map
      */
     Single<Map<StreamMessageId, Map<K, V>>> pendingRange(String groupName, StreamMessageId startId, StreamMessageId endId, int count);
-    
+
     /**
      * Returns stream data of pending messages by group and customer name.
      * Limited by start Stream Message ID and end Stream Message ID and count.
      * <p>
      * {@link StreamMessageId#MAX} is used as max Stream Message ID
      * {@link StreamMessageId#MIN} is used as min Stream Message ID
-     * 
+     *
      * @see #listPending
-     * 
+     *
      * @param consumerName - name of consumer
      * @param groupName - name of group
      * @param startId - start Stream Message ID
@@ -807,5 +844,5 @@ public interface RStreamRx<K, V> extends RExpirableRx {
      * @return map
      */
     Single<Map<StreamMessageId, Map<K, V>>> pendingRange(String groupName, String consumerName, StreamMessageId startId, StreamMessageId endId, int count);
-    
+
 }

--- a/redisson/src/main/java/org/redisson/api/stream/TrimParam.java
+++ b/redisson/src/main/java/org/redisson/api/stream/TrimParam.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2021 Ivano Pagano
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.api.stream;
+
+import org.redisson.api.StreamMessageId;
+
+/**
+ * Use the static methods to build a parameter used in stream trimming.
+ * Different {@link TrimStrategy} require different types of TrimParam.
+ * Use the constructor docs as guidance.
+ */
+public abstract class TrimParam {
+	/* We use a design pattern to enforce usage of "smart constructors", i.e. factory methods.
+	 * Constructors visibility is made private, so client code has limited choice.
+	 */
+
+	/* Limit access */
+	private TrimParam() {
+	}
+
+	/* Utility */
+	private static TrimParam fromValue(Object value) {
+		return new TrimParam() {
+			@Override
+			public Object getValue() {
+				return value;
+			}
+		};
+	}
+
+	/**
+	 * Provides a value used to support the trimming command
+	 * @return a generic parameter
+	 */
+	public abstract Object getValue();
+
+	/**
+	 * Creates a param compatible with the {@link TrimStrategy.MAXLEN}.
+	 */
+	public static TrimParam maxLen(int max) {
+		return fromValue(Integer.valueOf(max));
+	}
+
+	/**
+	 * Creates a param compatible with the {@link TrimStrategy.MINID}.
+	 * The id will be fromValue exactly matching the passed-in StreamMessageId
+	 */
+	public static TrimParam minId(StreamMessageId id) {
+		return fromValue(String.join("-", String.valueOf(id.getId0()), String.valueOf(id.getId1())));
+	}
+
+	/**
+	 * Creates a param compatible with the {@link TrimStrategy.MINID}.
+	 * The id will be matched partially using the passed-in string.
+	 */
+	public static TrimParam minId(String idMatcher) {
+		return fromValue(idMatcher);
+	}
+
+
+}

--- a/redisson/src/main/java/org/redisson/api/stream/TrimParam.java
+++ b/redisson/src/main/java/org/redisson/api/stream/TrimParam.java
@@ -56,10 +56,11 @@ public abstract class TrimParam {
 
 	/**
 	 * Creates a param compatible with the {@link TrimStrategy.MINID}.
-	 * The id will be fromValue exactly matching the passed-in StreamMessageId
+	 * The min-id will be required to exactly match the passed-in {@link StreamMessageId}
 	 */
 	public static TrimParam minId(StreamMessageId id) {
-		return fromValue(String.join("-", String.valueOf(id.getId0()), String.valueOf(id.getId1())));
+		Object stringId = id.toString();
+		return fromValue(stringId);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3803 

Deprecate the existing XTRIM methods available in any interface where the TrimStrategy is supported, and overload with one
that accepts a generic TrimParam.

This allows to pass in different types than the current `int` values, to support the full semantics of MINID.

Such TrimParam can only be created via smart constructors, to improve on type safety and user ergonomics.

**CAVEAT**

Currently I can't manage to run the test suite, as explained in the related issue.
I'll report here the problem I have

---

I'm locally testing my fix, but I can't seem to properly run the overall tests as per instructions.

Essentially it looks like my mvn installation can't properly pick up the argLine property to feed to the tests, as the default redis binary path is not properly overridden.

This is the starting log when I try to run the mvn tests as per contribution's instructions
```
Apache Maven 3.8.2 (ea98e05a04480131370aa0c110b8c54cf726c06f)                                                                                                                                                                                                                  
Maven home: /usr/local/Cellar/maven/3.8.2/libexec                                                                                                                                                                                                                              
Java version: 11.0.11, vendor: AdoptOpenJDK, runtime: /Users/ivanopagano/.sdkman/candidates/java/11.0.11.hs-adpt                                                                                                                                                               
Default locale: en_IT, platform encoding: UTF-8                                                                                                                                                                                                                                
OS name: "mac os x", version: "11.5", arch: "x86_64", family: "mac"
```

Are there specific jdk/mvn versions settings required to run the project, apart from what's directly configured via the pom file?