### PR TITLE
Lock info

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonBaseLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonBaseLock.java
@@ -17,12 +17,10 @@ package org.redisson;
 
 import io.netty.util.Timeout;
 import io.netty.util.TimerTask;
-import org.redisson.api.BatchOptions;
-import org.redisson.api.BatchResult;
-import org.redisson.api.RFuture;
-import org.redisson.api.RLock;
+import org.redisson.api.*;
 import org.redisson.client.codec.Codec;
 import org.redisson.client.codec.LongCodec;
+import org.redisson.client.codec.StringCodec;
 import org.redisson.client.protocol.RedisCommand;
 import org.redisson.client.protocol.RedisCommands;
 import org.redisson.client.protocol.convertor.IntegerReplayConvertor;
@@ -214,6 +212,26 @@ public abstract class RedissonBaseLock extends RedissonExpirable implements RLoc
         }
     }
 
+    protected <T> RFuture<T> evalReadAsync(String key, Codec codec, RedisCommand<T> evalCommandType, String script, List<Object> keys, Object... params) {
+        CommandBatchService executorService = createCommandBatchService();
+        RFuture<T> result = executorService.evalReadAsync(key, codec, evalCommandType, script, keys, params);
+        if (commandExecutor instanceof CommandBatchService) {
+            return result;
+        }
+
+        RPromise<T> r = new RedissonPromise<>();
+        RFuture<BatchResult<?>> future = executorService.executeAsync();
+        future.onComplete((res, ex) -> {
+            if (ex != null) {
+                r.tryFailure(ex);
+                return;
+            }
+
+            r.trySuccess(result.getNow());
+        });
+        return r;
+    }
+
     protected <T> RFuture<T> evalWriteAsync(String key, Codec codec, RedisCommand<T> evalCommandType, String script, List<Object> keys, Object... params) {
         CommandBatchService executorService = createCommandBatchService();
         RFuture<T> result = executorService.evalWriteAsync(key, codec, evalCommandType, script, keys, params);
@@ -330,4 +348,21 @@ public abstract class RedissonBaseLock extends RedissonExpirable implements RLoc
     }
 
     protected abstract RFuture<Boolean> unlockInnerAsync(long threadId);
+
+    public RFuture<LockInfo> getLockInfoAsync() {
+        return evalReadAsync(getName(), StringCodec.INSTANCE, RedisCommands.EVAL_LOCK_INFO,
+                "if(redis.call('exists', KEYS[1]) == 1) then " +
+                        "local ownerInfo = redis.call('hkeys', KEYS[1])[1];" +
+                        "local ttl = redis.call('pttl', KEYS[1]);" +
+                        "return {ownerInfo, ttl};" +
+                        "end;" +
+                        "return {};",
+                Collections.singletonList(getName())
+        );
+    }
+
+    @Override
+    public LockInfo getLockInfo() {
+        return get(getLockInfoAsync());
+    }
 }

--- a/redisson/src/main/java/org/redisson/RedissonMultiLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonMultiLock.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Condition;
 
+import org.redisson.api.LockInfo;
 import org.redisson.api.RFuture;
 import org.redisson.api.RLock;
 import org.redisson.api.RLockAsync;
@@ -556,4 +557,13 @@ public class RedissonMultiLock implements RLock {
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public RFuture<LockInfo> getLockInfoAsync() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public LockInfo getLockInfo() {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/redisson/src/main/java/org/redisson/api/LockInfo.java
+++ b/redisson/src/main/java/org/redisson/api/LockInfo.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2013-2020 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.api;
+
+import org.redisson.connection.ConnectionManager;
+
+import java.util.Objects;
+
+/**
+ * This class present information about lock information
+ *
+ * @author Sergey Kurenchuk
+ */
+public class LockInfo {
+
+    private final String connectionId;
+    private final Long threadOwnerId;
+    private final Long expired;
+
+    public LockInfo(String connectionId, Long threadOwnerId, Long expired) {
+        this.connectionId = connectionId;
+        this.threadOwnerId = threadOwnerId;
+        this.expired = expired;
+    }
+
+    /**
+     * Thread owner id, see {@link RLockReactive#lock(long)}
+     * @return thread id
+     */
+    public Long getThreadOwnerId() {
+        return threadOwnerId;
+    }
+
+    /**
+     * Connection id, see {@link ConnectionManager#getId()}
+     * @return connection id
+     */
+    public String getConnectionId() {
+        return connectionId;
+    }
+
+    /**
+     * @return current ttl
+     */
+    public Long getExpired() {
+        return expired;
+    }
+
+    /**
+     * @return boolean value if lock already acquired
+     */
+    public boolean isLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LockInfo lockInfo = (LockInfo) o;
+        return Objects.equals(getConnectionId(), lockInfo.getConnectionId()) && getThreadOwnerId().equals(lockInfo.getThreadOwnerId()) && Objects.equals(getExpired(), lockInfo.getExpired());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getConnectionId(), getThreadOwnerId(), getExpired());
+    }
+
+    @Override
+    public String toString() {
+        return "LockInfo{" +
+                "connectionId='" + connectionId + '\'' +
+                ", threadOwnerId=" + threadOwnerId +
+                ", expired=" + expired +
+                '}';
+    }
+
+}

--- a/redisson/src/main/java/org/redisson/api/RLock.java
+++ b/redisson/src/main/java/org/redisson/api/RLock.java
@@ -124,5 +124,12 @@ public interface RLock extends Lock, RLockAsync {
      *          -1 if the lock exists but has no associated expire.
      */
     long remainTimeToLive();
+
+    /**
+     * Current lock information
+     *
+     * @return information about current lock (owner, ttl)
+     */
+    LockInfo getLockInfo();
     
 }

--- a/redisson/src/main/java/org/redisson/api/RLockAsync.java
+++ b/redisson/src/main/java/org/redisson/api/RLockAsync.java
@@ -171,5 +171,11 @@ public interface RLockAsync {
      *          -1 if the lock exists but has no associated expire.
      */
     RFuture<Long> remainTimeToLiveAsync();
-    
+
+    /**
+     * Current lock information
+     *
+     * @return information about current lock (owner, ttl)
+     */
+    RFuture<LockInfo> getLockInfoAsync();
 }

--- a/redisson/src/main/java/org/redisson/api/RLockReactive.java
+++ b/redisson/src/main/java/org/redisson/api/RLockReactive.java
@@ -180,5 +180,11 @@ public interface RLockReactive {
      *          -1 if the lock exists but has no associated expire.
      */
     Mono<Long> remainTimeToLive();
-    
+
+    /**
+     * Current lock information
+     *
+     * @return information about current lock (owner, ttl)
+     */
+    Mono<LockInfo> getLockInfo();
 }

--- a/redisson/src/main/java/org/redisson/client/protocol/RedisCommands.java
+++ b/redisson/src/main/java/org/redisson/client/protocol/RedisCommands.java
@@ -15,10 +15,7 @@
  */
 package org.redisson.client.protocol;
 
-import org.redisson.api.FastAutoClaimResult;
-import org.redisson.api.RType;
-import org.redisson.api.StreamInfo;
-import org.redisson.api.StreamMessageId;
+import org.redisson.api.*;
 import org.redisson.client.codec.StringCodec;
 import org.redisson.client.protocol.convertor.*;
 import org.redisson.client.protocol.decoder.*;
@@ -234,6 +231,7 @@ public interface RedisCommands {
     RedisStrictCommand<Long> EVAL_LONG_SAFE = new RedisStrictCommand<Long>("EVAL", new LongReplayConvertor());
     RedisStrictCommand<Void> EVAL_VOID = new RedisStrictCommand<Void>("EVAL", new VoidReplayConvertor());
     RedisCommand<Object> EVAL_FIRST_LIST = new RedisCommand<Object>("EVAL", new ListFirstObjectDecoder());
+    RedisCommand<LockInfo> EVAL_LOCK_INFO = new RedisCommand<LockInfo>("EVAL", new LockInfoDecoder());
     RedisCommand<List<Object>> EVAL_LIST = new RedisCommand<List<Object>>("EVAL", new ObjectListReplayDecoder<Object>());
     RedisCommand<List<Object>> EVAL_LIST_REVERSE = new RedisCommand<List<Object>>("EVAL", new ObjectListReplayDecoder<>(true));
     RedisCommand<List<Integer>> EVAL_INT_LIST = new RedisCommand("EVAL", new ObjectListReplayDecoder<Integer>(), new IntegerReplayConvertor());

--- a/redisson/src/main/java/org/redisson/client/protocol/decoder/LockInfoDecoder.java
+++ b/redisson/src/main/java/org/redisson/client/protocol/decoder/LockInfoDecoder.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2013-2020 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.client.protocol.decoder;
+
+import io.micrometer.core.instrument.util.StringUtils;
+import org.redisson.api.LockInfo;
+import org.redisson.client.handler.State;
+
+import java.util.List;
+
+/**
+ * @author Sergey Kurenchuk
+ */
+public class LockInfoDecoder implements MultiDecoder<LockInfo> {
+
+    private static class FreeLockInfo extends LockInfo {
+
+        FreeLockInfo() {
+            super(null, null, null);
+        }
+
+        @Override
+        public boolean isLocked() {
+            return false;
+        }
+    }
+
+    @Override
+    public LockInfo decode(List<Object> parts, State state) {
+        if (parts.size() != 2) {
+            return new FreeLockInfo();
+        }
+        String lockOwnerInfo = parts.get(0).toString();
+        String expiredInMillis = parts.get(1).toString();
+        if (StringUtils.isBlank(lockOwnerInfo)) {
+            return new FreeLockInfo();
+        }
+        String[] split = lockOwnerInfo.split(":");
+        if (split.length != 2) {
+            return new FreeLockInfo();
+        }
+        String connectionId = split[0];
+        Long threadOwnerId = Long.valueOf(split[1]);
+        Long expired = Long.valueOf(expiredInMillis);
+        return new LockInfo(connectionId, threadOwnerId, expired);
+    }
+}


### PR DESCRIPTION
This addition method provides snapshot of current lock state. who is the owner, which application instance (connection id) and the last expire time point

from this discussion #3524 (comment) :
LockInfo should contain redissonId - id of Redisson instance which owns the lock.
I've been trying to understand what is the RedissonId, and how i found from the code - it is a ConnectionManager.getId()
in LockInfo - connectionId == ConnectionManager.getId()
If it is not true, pls @mrniko describe more what is the RedissonId

PS. Sorry for so long delay, I had some troubles and changes in my life