### PR TITLE
Fix RList remove with count response when multiple items are removed

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonList.java
+++ b/redisson/src/main/java/org/redisson/RedissonList.java
@@ -136,7 +136,7 @@ public class RedissonList<V> extends RedissonExpirable implements RList<V> {
 
     @Override
     public RFuture<Boolean> removeAsync(Object o, int count) {
-        return commandExecutor.writeAsync(getRawName(), codec, LREM_SINGLE, getRawName(), count, encode(o));
+        return commandExecutor.writeAsync(getRawName(), codec, LREM, getRawName(), count, encode(o));
     }
 
     @Override

--- a/redisson/src/main/java/org/redisson/client/protocol/RedisCommands.java
+++ b/redisson/src/main/java/org/redisson/client/protocol/RedisCommands.java
@@ -172,7 +172,7 @@ public interface RedisCommands {
     RedisCommand<Void> LSET = new RedisCommand<Void>("LSET", new VoidReplayConvertor());
     RedisCommand<Object> LPOP = new RedisCommand<Object>("LPOP");
     RedisCommand<List<Object>> LPOP_LIST = new RedisCommand<>("LPOP", new ObjectListReplayDecoder<>());
-    RedisCommand<Boolean> LREM_SINGLE = new RedisCommand<Boolean>("LREM", new BooleanReplayConvertor());
+    RedisCommand<Boolean> LREM = new RedisCommand<Boolean>("LREM", new BooleanAmountReplayConvertor());
     RedisCommand<Object> LINDEX = new RedisCommand<Object>("LINDEX");
     RedisCommand<Object> LMOVE = new RedisCommand<Object>("LMOVE");
     RedisCommand<Integer> LINSERT_INT = new RedisCommand<Integer>("LINSERT", new IntegerReplayConvertor());

--- a/redisson/src/test/java/org/redisson/RedissonListTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonListTest.java
@@ -906,6 +906,22 @@ public class RedissonListTest extends BaseTest {
     }
 
     @Test
+    public void testRemoveWithCount() {
+        RList<Integer> list = redisson.getList("list");
+        list.add(1);
+        list.add(2);
+        list.add(3);
+        list.add(3);
+        list.add(4);
+
+        assertThat(list.remove(1, 5)).isTrue();
+        assertThat(list).containsExactly(2, 3, 3, 4);
+
+        assertThat(list.remove(3, 5)).isTrue();
+        assertThat(list).containsExactly(2, 4);
+    }
+
+    @Test
     public void testSubListRemove() {
         List<Integer> list = redisson.getList("list");
         list.add(1);


### PR DESCRIPTION
There appears to be a bug in how the response from `RList.remove(object, count)` is parsed when more than 1 object is removed. Previously `BooleanReplayConvertor` was used where it appears that `BooleanAmountReplayConvertor` should be used since the LREM response can be greater than 1 (if multiple items are removed).

Here's a fix & accompanying unit test - please let me know if I should make any changes or if you have any suggestions.

Example code that shows the problem:
```
redissonClient.getList("one_item").clear();
redissonClient.getList("two_items").clear();

redissonClient.getList("one_item").add("item");
redissonClient.getList("two_items").addAll(Arrays.asList("item", "item"));

assertEquals(1, redissonClient.getList("one_item").size());
assertEquals(2, redissonClient.getList("two_items").size());

assertFalse(redissonClient.getList("not_exist").remove("something"));
assertTrue(redissonClient.getList("one_item").remove("item"));
assertTrue(redissonClient.getList("two_items").remove("item", 2)); // This should be true, but returns false
```