### PR TITLE
Draft/RFC: add way to only unlock acquired locks

### DIFF
--- a/redisson/src/main/java/org/redisson/api/RLockHandle.java
+++ b/redisson/src/main/java/org/redisson/api/RLockHandle.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2013-2021 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.api;
+
+public interface RLockHandle {
+    /**
+     * @return <code>true</code> if lock acquired otherwise <code>false</code>
+     */
+    Boolean isLocked();
+
+    /**
+     * Unlocks the lock
+     *
+     * @return void
+     */
+    RFuture<Void> unlockAsync();
+
+    /**
+     * Unlocks the lock. Throws {@link IllegalMonitorStateException}
+     * if lock isn't locked by thread with specified <code>threadId</code>.
+     *
+     * @param threadId id of thread
+     * @return void
+     */
+    RFuture<Void> unlockAsync(long threadId);
+}


### PR DESCRIPTION
`RedissonMultiLock` subclasses can override `failedLocksLimit()` to successfully acquire a lock if not all of the individual locks were acquired (eg, `RedissonRedLock`). The problem is that when `unlockAsync()` is called, it's called with the original list of locks. If any of those failed to acquire (but enough succeeded to obtain the lock), the `RFuture` returned from the unlock call is always failed even if all acquired locks successfully released.

I thought I'd propose a change to avoid this happening (at least in the tryAsync path); since `tryLockAsync()` uses the `LockState` which keeps track of which locks were acquired, I added new methods that allow a caller to get a handle from a new call which has an unlock method that only attempts to unlock acquired locks, removing the spurious failures.

I was trying to keep this diff small for comments/feedback, there's other options like having the state as a field on the multi lock, changing the behavior of current methods without adding new ones, trying to change behavior of `lockAsync` and `lock` paths, refactoring a few lines of duplicated code between `tryLockAsync` and `tryLockAsyncHandle`, etc. But I believe this should get the point across.

Thanks, I welcome any feedback