### PR TITLE
Check expiration before release in RedissonPermitExpirableSemaphore

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonPermitExpirableSemaphore.java
+++ b/redisson/src/main/java/org/redisson/RedissonPermitExpirableSemaphore.java
@@ -552,22 +552,25 @@ public class RedissonPermitExpirableSemaphore extends RedissonExpirable implemen
     public boolean tryRelease(String permitId) {
         return get(tryReleaseAsync(permitId));
     }
-    
-    @Override
+
     public RFuture<Boolean> tryReleaseAsync(String permitId) {
         if (permitId == null) {
             throw new IllegalArgumentException("permitId can't be null");
         }
 
         return commandExecutor.evalWriteAsync(getRawName(), LongCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
-                "local removed = redis.call('zrem', KEYS[3], ARGV[1]);" + 
-                "if tonumber(removed) ~= 1 then " + 
-                    "return 0;" + 
-                "end;" +
-                "local value = redis.call('incrby', KEYS[1], ARGV[2]); " +
-                "redis.call('publish', KEYS[2], value); " + 
-                "return 1;",
-                Arrays.<Object>asList(getRawName(), getChannelName(), timeoutName), permitId, 1);
+                "local expire = redis.call('zscore', KEYS[3], ARGV[1]);" +
+                        "local removed = redis.call('zrem', KEYS[3], ARGV[1]);" +
+                        "if tonumber(removed) ~= 1 then " +
+                        "return 0;" +
+                        "end;" +
+                        "local value = redis.call('incrby', KEYS[1], ARGV[2]); " +
+                        "redis.call('publish', KEYS[2], value); " +
+                        "if tonumber(expire) <= tonumber(ARGV[3]) then " +
+                        "return 0;" +
+                        "end;" +
+                        "return 1;",
+                Arrays.<Object>asList(getRawName(), getChannelName(), timeoutName), permitId, 1, System.currentTimeMillis());
     }
     
     @Override

--- a/redisson/src/main/java/org/redisson/RedissonPermitExpirableSemaphore.java
+++ b/redisson/src/main/java/org/redisson/RedissonPermitExpirableSemaphore.java
@@ -559,7 +559,7 @@ public class RedissonPermitExpirableSemaphore extends RedissonExpirable implemen
         }
 
         return commandExecutor.evalWriteAsync(getRawName(), LongCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
-                "local expire = redis.call('zscore', KEYS[3], ARGV[1]);" +
+                  "local expire = redis.call('zscore', KEYS[3], ARGV[1]);" +
                         "local removed = redis.call('zrem', KEYS[3], ARGV[1]);" +
                         "if tonumber(removed) ~= 1 then " +
                         "return 0;" +
@@ -567,7 +567,7 @@ public class RedissonPermitExpirableSemaphore extends RedissonExpirable implemen
                         "local value = redis.call('incrby', KEYS[1], ARGV[2]); " +
                         "redis.call('publish', KEYS[2], value); " +
                         "if tonumber(expire) <= tonumber(ARGV[3]) then " +
-                        "return 0;" +
+                            "return 0;" +
                         "end;" +
                         "return 1;",
                 Arrays.<Object>asList(getRawName(), getChannelName(), timeoutName), permitId, 1, System.currentTimeMillis());

--- a/redisson/src/test/java/org/redisson/RedissonPermitExpirableSemaphoreTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonPermitExpirableSemaphoreTest.java
@@ -221,6 +221,16 @@ public class RedissonPermitExpirableSemaphoreTest extends BaseConcurrentTest {
     }
 
     @Test
+    public void testReleaseExpired() throws InterruptedException {
+        RPermitExpirableSemaphore s = redisson.getPermitExpirableSemaphore("test");
+        s.trySetPermits(1);
+        String permitId = s.tryAcquire(100, 100, TimeUnit.MILLISECONDS);
+        Thread.sleep(200);
+        boolean released = s.tryRelease(permitId);
+        assertThat(released).isFalse();
+    }
+
+    @Test
     public void testConcurrency_SingleInstance() throws InterruptedException {
         final AtomicInteger lockedCounter = new AtomicInteger();
 


### PR DESCRIPTION
Fix for issue [#4086](https://github.com/redisson/redisson/issues/4086). Checks expiry time of RedissonPermitExpirableSemaphore before releasing so that return value of releaseLock behavior is consistent  between expired and manually released locks.