### PR TITLE
Add custom tasks injector support to worker options

### DIFF
--- a/redisson/src/main/java/org/redisson/api/WorkerOptions.java
+++ b/redisson/src/main/java/org/redisson/api/WorkerOptions.java
@@ -83,6 +83,20 @@ public final class WorkerOptions {
         return this;
     }
 
+    /**
+     * Defines a custom TasksInjector to be used. This is mutually exclusive with the {@link WorkerOptions#beanFactory}
+     * which will create a {@link SpringTasksInjector(BeanFactory)}.
+     *
+     * @param tasksInjector - TasksInjector instance
+     * @return self instance
+     */
+    public WorkerOptions taskInjector(TasksInjector tasksInjector) {
+        if (tasksInjector != null) {
+            this.tasksInjector = tasksInjector;
+        }
+        return this;
+    }
+
     public TasksInjector getTasksInjector() {
         return tasksInjector;
     }

--- a/redisson/src/test/java/org/redisson/executor/RedissonExecutorServiceTest.java
+++ b/redisson/src/test/java/org/redisson/executor/RedissonExecutorServiceTest.java
@@ -583,6 +583,22 @@ public class RedissonExecutorServiceTest extends BaseTest {
         redisson.getKeys().delete("runnableCounter", "counter");
         assertThat(redisson.getKeys().count()).isZero();
     }
+
+    @Test
+    public void testCustomTasksInjector() throws InterruptedException, ExecutionException {
+        RExecutorService executor = redisson.getExecutorService("testCustom");
+        CountDownLatch l = new CountDownLatch(1);
+        executor.registerWorkers(WorkerOptions.defaults().taskInjector(task -> {
+            assertThat(task).isNotNull();
+            l.countDown();
+        }));
+
+        executor.submit(new RunnableTask()).get();
+
+        l.await();
+
+        executor.shutdown();
+    }
     
     @Test
     public void testParameterizedTask() throws InterruptedException, ExecutionException {


### PR DESCRIPTION
This should allow users of non-spring applications to provide dependency injection support to their redisson workers.