### PR TITLE
SentinelServersConfig: copy username in copy constructor

### DIFF
--- a/redisson/src/main/java/org/redisson/config/SentinelServersConfig.java
+++ b/redisson/src/main/java/org/redisson/config/SentinelServersConfig.java
@@ -68,6 +68,7 @@ public class SentinelServersConfig extends BaseMasterSlaveServersConfig<Sentinel
         setScanInterval(config.getScanInterval());
         setNatMapper(config.getNatMapper());
         setCheckSentinelsList(config.isCheckSentinelsList());
+        setSentinelUsername(config.getSentinelUsername());
         setSentinelPassword(config.getSentinelPassword());
         setCheckSlaveStatusWithSyncing(config.isCheckSlaveStatusWithSyncing());
         setSentinelsDiscovery(config.isSentinelsDiscovery());


### PR DESCRIPTION
**https://github.com/redisson/redisson/issues/3948** introduced sentinel username, but forgot to copy it in copy constructor. Result: authentication with username and password is not possible because config is always copied in org.redisson.Redisson constructor.