### PR TITLE
Add support for TOML configs (#4161)

### DIFF
--- a/redisson-hibernate/redisson-hibernate-5/src/main/java/org/redisson/hibernate/RedissonRegionFactory.java
+++ b/redisson-hibernate/redisson-hibernate-5/src/main/java/org/redisson/hibernate/RedissonRegionFactory.java
@@ -100,6 +100,9 @@ import java.util.concurrent.atomic.AtomicLong;
             if (config == null) {
                 config = loadConfig(RedissonRegionFactory.class.getClassLoader(), "redisson.yaml");
             }
+            if (config == null) {
+                config = loadConfig(RedissonRegionFactory.class.getClassLoader(), "redisson.toml");
+            }
         } else {
             String configPath = ConfigurationHelper.getString(REDISSON_CONFIG_PATH, properties);
             config = loadConfig(RedissonRegionFactory.class.getClassLoader(), configPath);
@@ -121,13 +124,18 @@ import java.util.concurrent.atomic.AtomicLong;
         } catch (IOException e) {
             // trying next format
             try {
-                return Config.fromJSON(new File(configPath));
+                return Config.fromTOML(new File(configPath));
             } catch (IOException e1) {
-                throw new CacheException("Can't parse default yaml config", e1);
+                // trying next format
+                try {
+                    return Config.fromJSON(new File(configPath));
+                } catch (IOException e2) {
+                    throw new CacheException("Can't parse default config", e2.initCause(e1.initCause(e)));
+                }
             }
         }
     }
-    
+
     private Config loadConfig(ClassLoader classLoader, String fileName) {
         InputStream is = classLoader.getResourceAsStream(fileName);
         if (is != null) {
@@ -136,9 +144,14 @@ import java.util.concurrent.atomic.AtomicLong;
             } catch (IOException e) {
                 try {
                     is = classLoader.getResourceAsStream(fileName);
-                    return Config.fromJSON(is);
+                    return Config.fromTOML(is);
                 } catch (IOException e1) {
-                    throw new CacheException("Can't parse yaml config", e1);
+                    try {
+                        is = classLoader.getResourceAsStream(fileName);
+                        return Config.fromJSON(is);
+                    } catch (IOException e2) {
+                        throw new CacheException("Can't parse config", e2.initCause(e1.initCause(e)));
+                    }
                 }
             }
         }

--- a/redisson-hibernate/redisson-hibernate-52/src/main/java/org/redisson/hibernate/RedissonRegionFactory.java
+++ b/redisson-hibernate/redisson-hibernate-52/src/main/java/org/redisson/hibernate/RedissonRegionFactory.java
@@ -101,6 +101,9 @@ public class RedissonRegionFactory implements RegionFactory {
             if (config == null) {
                 config = loadConfig(RedissonRegionFactory.class.getClassLoader(), "redisson.yaml");
             }
+            if (config == null) {
+                config = loadConfig(RedissonRegionFactory.class.getClassLoader(), "redisson.toml");
+            }
         } else {
             String configPath = ConfigurationHelper.getString(REDISSON_CONFIG_PATH, properties);
             config = loadConfig(RedissonRegionFactory.class.getClassLoader(), configPath);
@@ -122,9 +125,14 @@ public class RedissonRegionFactory implements RegionFactory {
         } catch (IOException e) {
             // trying next format
             try {
-                return Config.fromJSON(new File(configPath));
+                return Config.fromTOML(new File(configPath));
             } catch (IOException e1) {
-                throw new CacheException("Can't parse default yaml config", e1);
+                // trying next format
+                try {
+                    return Config.fromJSON(new File(configPath));
+                } catch (IOException e2) {
+                    throw new CacheException("Can't parse default config", e2.initCause(e1.initCause(e)));
+                }
             }
         }
     }
@@ -137,9 +145,14 @@ public class RedissonRegionFactory implements RegionFactory {
             } catch (IOException e) {
                 try {
                     is = classLoader.getResourceAsStream(fileName);
-                    return Config.fromJSON(is);
+                    return Config.fromTOML(is);
                 } catch (IOException e1) {
-                    throw new CacheException("Can't parse yaml config", e1);
+                    try {
+                        is = classLoader.getResourceAsStream(fileName);
+                        return Config.fromJSON(is);
+                    } catch (IOException e2) {
+                        throw new CacheException("Can't parse config", e2.initCause(e1.initCause(e)));
+                    }
                 }
             }
         }

--- a/redisson-hibernate/redisson-hibernate-53/src/main/java/org/redisson/hibernate/RedissonRegionFactory.java
+++ b/redisson-hibernate/redisson-hibernate-53/src/main/java/org/redisson/hibernate/RedissonRegionFactory.java
@@ -101,6 +101,9 @@ public class RedissonRegionFactory extends RegionFactoryTemplate {
             if (config == null) {
                 config = loadConfig(RedissonRegionFactory.class.getClassLoader(), "redisson.yaml");
             }
+            if (config == null) {
+                config = loadConfig(RedissonRegionFactory.class.getClassLoader(), "redisson.toml");
+            }
         } else {
             String configPath = ConfigurationHelper.getString(REDISSON_CONFIG_PATH, properties);
             config = loadConfig(RedissonRegionFactory.class.getClassLoader(), configPath);
@@ -115,20 +118,25 @@ public class RedissonRegionFactory extends RegionFactoryTemplate {
 
         return Redisson.create(config);
     }
-    
+
     private Config loadConfig(String configPath) {
         try {
             return Config.fromYAML(new File(configPath));
         } catch (IOException e) {
             // trying next format
             try {
-                return Config.fromJSON(new File(configPath));
+                return Config.fromTOML(new File(configPath));
             } catch (IOException e1) {
-                throw new CacheException("Can't parse default yaml config", e1);
+                // trying next format
+                try {
+                    return Config.fromJSON(new File(configPath));
+                } catch (IOException e2) {
+                    throw new CacheException("Can't parse default config", e2.initCause(e1.initCause(e)));
+                }
             }
         }
     }
-    
+
     private Config loadConfig(ClassLoader classLoader, String fileName) {
         InputStream is = classLoader.getResourceAsStream(fileName);
         if (is != null) {
@@ -137,9 +145,14 @@ public class RedissonRegionFactory extends RegionFactoryTemplate {
             } catch (IOException e) {
                 try {
                     is = classLoader.getResourceAsStream(fileName);
-                    return Config.fromJSON(is);
+                    return Config.fromTOML(is);
                 } catch (IOException e1) {
-                    throw new CacheException("Can't parse yaml config", e1);
+                    try {
+                        is = classLoader.getResourceAsStream(fileName);
+                        return Config.fromJSON(is);
+                    } catch (IOException e2) {
+                        throw new CacheException("Can't parse config", e2.initCause(e1.initCause(e)));
+                    }
                 }
             }
         }

--- a/redisson-mybatis/src/main/java/org/redisson/mybatis/RedissonCache.java
+++ b/redisson-mybatis/src/main/java/org/redisson/mybatis/RedissonCache.java
@@ -105,7 +105,12 @@ public class RedissonCache implements Cache {
             InputStream is = getClass().getClassLoader().getResourceAsStream(config);
             cfg = Config.fromYAML(is);
         } catch (IOException e) {
-            throw new IllegalArgumentException("Can't parse config", e);
+            try {
+                InputStream is = getClass().getClassLoader().getResourceAsStream(config);
+                cfg = Config.fromTOML(is);
+            } catch (IOException e1) {
+                throw new IllegalArgumentException("Can't parse config", e1.initCause(e));
+            }
         }
 
         RedissonClient redisson = Redisson.create(cfg);

--- a/redisson-tomcat/redisson-tomcat-10/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-10/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -344,10 +344,16 @@ public class RedissonSessionManager extends ManagerBase {
         } catch (IOException e) {
             // trying next format
             try {
-                config = Config.fromJSON(new File(configPath), getClass().getClassLoader());
+                config = Config.fromTOML(new File(configPath), getClass().getClassLoader());
             } catch (IOException e1) {
-                log.error("Can't parse json config " + configPath, e);
-                throw new LifecycleException("Can't parse yaml config " + configPath, e1);
+                // trying next format
+                try {
+                    config = Config.fromJSON(new File(configPath), getClass().getClassLoader());
+                } catch (IOException e2) {
+                    log.error("Can't parse yaml config " + configPath, e);
+                    log.error("Can't parse toml config " + configPath, e1);
+                    throw new LifecycleException("Can't parse json config " + configPath, e2);
+                }
             }
         }
         

--- a/redisson-tomcat/redisson-tomcat-10/src/test/webapp/WEB-INF/redisson.toml
+++ b/redisson-tomcat/redisson-tomcat-10/src/test/webapp/WEB-INF/redisson.toml
@@ -1,0 +1,2 @@
+[singleServerConfig]
+address = 'redis://127.0.0.1:6379'

--- a/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -344,10 +344,16 @@ public class RedissonSessionManager extends ManagerBase {
         } catch (IOException e) {
             // trying next format
             try {
-                config = Config.fromJSON(new File(configPath), getClass().getClassLoader());
+                config = Config.fromTOML(new File(configPath), getClass().getClassLoader());
             } catch (IOException e1) {
-                log.error("Can't parse json config " + configPath, e);
-                throw new LifecycleException("Can't parse yaml config " + configPath, e1);
+                // trying next format
+                try {
+                    config = Config.fromJSON(new File(configPath), getClass().getClassLoader());
+                } catch (IOException e2) {
+                    log.error("Can't parse yaml config " + configPath, e);
+                    log.error("Can't parse toml config " + configPath, e1);
+                    throw new LifecycleException("Can't parse json config " + configPath, e2);
+                }
             }
         }
         

--- a/redisson-tomcat/redisson-tomcat-7/src/test/java/org/redisson/tomcat/RedissonSessionManagerTest.java
+++ b/redisson-tomcat/redisson-tomcat-7/src/test/java/org/redisson/tomcat/RedissonSessionManagerTest.java
@@ -264,9 +264,23 @@ public class RedissonSessionManagerTest {
 
 
     @Test
-    public void testInvalidate() throws Exception {
-        File f = Paths.get("").toAbsolutePath().resolve("src/test/webapp/WEB-INF/redisson.yaml").toFile();
-        Config config = Config.fromYAML(f);
+    public void testInvalidateWithYamlConfig() throws Exception {
+        testInvalidate("src/test/webapp/WEB-INF/redisson.yaml");
+    }
+
+    @Test
+    public void testInvalidateWithTomlConfig() throws Exception {
+        testInvalidate("src/test/webapp/WEB-INF/redisson.toml");
+    }
+
+    private void testInvalidate(String configPath) throws Exception {
+        File f = Paths.get("").toAbsolutePath().resolve(configPath).toFile();
+        Config config;
+        try {
+            config = Config.fromYAML(f);
+        } catch (IOException ignored) {
+            config = Config.fromTOML(f);
+        }
         RedissonClient r = Redisson.create(config);
         r.getKeys().flushall();
 

--- a/redisson-tomcat/redisson-tomcat-7/src/test/webapp/WEB-INF/redisson.toml
+++ b/redisson-tomcat/redisson-tomcat-7/src/test/webapp/WEB-INF/redisson.toml
@@ -1,0 +1,2 @@
+[singleServerConfig]
+address = 'redis://127.0.0.1:6379'

--- a/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -344,10 +344,16 @@ public class RedissonSessionManager extends ManagerBase {
         } catch (IOException e) {
             // trying next format
             try {
-                config = Config.fromJSON(new File(configPath), getClass().getClassLoader());
+                config = Config.fromTOML(new File(configPath), getClass().getClassLoader());
             } catch (IOException e1) {
-                log.error("Can't parse json config " + configPath, e);
-                throw new LifecycleException("Can't parse yaml config " + configPath, e1);
+                // trying next format
+                try {
+                    config = Config.fromJSON(new File(configPath), getClass().getClassLoader());
+                } catch (IOException e2) {
+                    log.error("Can't parse yaml config " + configPath, e);
+                    log.error("Can't parse toml config " + configPath, e1);
+                    throw new LifecycleException("Can't parse json config " + configPath, e2);
+                }
             }
         }
         

--- a/redisson-tomcat/redisson-tomcat-8/src/test/java/org/redisson/tomcat/RedissonSessionManagerTest.java
+++ b/redisson-tomcat/redisson-tomcat-8/src/test/java/org/redisson/tomcat/RedissonSessionManagerTest.java
@@ -264,9 +264,23 @@ public class RedissonSessionManagerTest {
 
 
     @Test
-    public void testInvalidate() throws Exception {
-        File f = Paths.get("").toAbsolutePath().resolve("src/test/webapp/WEB-INF/redisson.yaml").toFile();
-        Config config = Config.fromYAML(f);
+    public void testInvalidateWithYamlConfig() throws Exception {
+        testInvalidate("src/test/webapp/WEB-INF/redisson.yaml");
+    }
+
+    @Test
+    public void testInvalidateWithTomlConfig() throws Exception {
+        testInvalidate("src/test/webapp/WEB-INF/redisson.toml");
+    }
+
+    private void testInvalidate(String configPath) throws Exception {
+        File f = Paths.get("").toAbsolutePath().resolve(configPath).toFile();
+        Config config;
+        try {
+            config = Config.fromYAML(f);
+        } catch (IOException ignored) {
+            config = Config.fromTOML(f);
+        }
         RedissonClient r = Redisson.create(config);
         r.getKeys().flushall();
 

--- a/redisson-tomcat/redisson-tomcat-8/src/test/webapp/WEB-INF/redisson.toml
+++ b/redisson-tomcat/redisson-tomcat-8/src/test/webapp/WEB-INF/redisson.toml
@@ -1,0 +1,2 @@
+[singleServerConfig]
+address = 'redis://127.0.0.1:6379'

--- a/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -344,10 +344,16 @@ public class RedissonSessionManager extends ManagerBase {
         } catch (IOException e) {
             // trying next format
             try {
-                config = Config.fromJSON(new File(configPath), getClass().getClassLoader());
+                config = Config.fromTOML(new File(configPath), getClass().getClassLoader());
             } catch (IOException e1) {
-                log.error("Can't parse json config " + configPath, e);
-                throw new LifecycleException("Can't parse yaml config " + configPath, e1);
+                // trying next format
+                try {
+                    config = Config.fromJSON(new File(configPath), getClass().getClassLoader());
+                } catch (IOException e2) {
+                    log.error("Can't parse yaml config " + configPath, e);
+                    log.error("Can't parse toml config " + configPath, e1);
+                    throw new LifecycleException("Can't parse json config " + configPath, e2);
+                }
             }
         }
         

--- a/redisson-tomcat/redisson-tomcat-9/src/test/java/org/redisson/tomcat/RedissonSessionManagerTest.java
+++ b/redisson-tomcat/redisson-tomcat-9/src/test/java/org/redisson/tomcat/RedissonSessionManagerTest.java
@@ -264,9 +264,23 @@ public class RedissonSessionManagerTest {
 
 
     @Test
-    public void testInvalidate() throws Exception {
-        File f = Paths.get("").toAbsolutePath().resolve("src/test/webapp/WEB-INF/redisson.yaml").toFile();
-        Config config = Config.fromYAML(f);
+    public void testInvalidateWithYamlConfig() throws Exception {
+        testInvalidate("src/test/webapp/WEB-INF/redisson.yaml");
+    }
+
+    @Test
+    public void testInvalidateWithTomlConfig() throws Exception {
+        testInvalidate("src/test/webapp/WEB-INF/redisson.toml");
+    }
+
+    private void testInvalidate(String configPath) throws Exception {
+        File f = Paths.get("").toAbsolutePath().resolve(configPath).toFile();
+        Config config;
+        try {
+            config = Config.fromYAML(f);
+        } catch (IOException ignored) {
+            config = Config.fromTOML(f);
+        }
         RedissonClient r = Redisson.create(config);
         r.getKeys().flushall();
 

--- a/redisson-tomcat/redisson-tomcat-9/src/test/webapp/WEB-INF/redisson.toml
+++ b/redisson-tomcat/redisson-tomcat-9/src/test/webapp/WEB-INF/redisson.toml
@@ -1,0 +1,2 @@
+[singleServerConfig]
+address = 'redis://127.0.0.1:6379'

--- a/redisson/pom.xml
+++ b/redisson/pom.xml
@@ -236,6 +236,10 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-toml</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
         </dependency>

--- a/redisson/src/main/java/org/redisson/JndiRedissonFactory.java
+++ b/redisson/src/main/java/org/redisson/JndiRedissonFactory.java
@@ -52,11 +52,16 @@ public class JndiRedissonFactory implements ObjectFactory {
         } catch (IOException e) {
             // trying next format
             try {
-                config = Config.fromJSON(new File(configPath), getClass().getClassLoader());
+                config = Config.fromTOML(new File(configPath), getClass().getClassLoader());
             } catch (IOException e1) {
-                NamingException ex = new NamingException("Can't parse yaml config " + configPath);
-                ex.initCause(e1);
-                throw ex;
+                // trying next format
+                try {
+                    config = Config.fromJSON(new File(configPath), getClass().getClassLoader());
+                } catch (IOException e2) {
+                    NamingException ex = new NamingException("Can't parse config " + configPath);
+                    ex.initCause(e2.initCause(e1.initCause(e)));
+                    throw ex;
+                }
             }
         }
         

--- a/redisson/src/main/java/org/redisson/RedissonNode.java
+++ b/redisson/src/main/java/org/redisson/RedissonNode.java
@@ -94,8 +94,14 @@ public final class RedissonNode {
             try {
                 config = RedissonNodeFileConfig.fromYAML(new File(configPath));
             } catch (IOException e1) {
-                log.error("Can't parse json config " + configPath, e);
-                throw new IllegalArgumentException("Can't parse yaml config " + configPath, e1);
+                // trying next format
+                try {
+                    config = RedissonNodeFileConfig.fromTOML(new File(configPath));
+                } catch (IOException e2) {
+                    log.error("Can't parse json config " + configPath, e);
+                    log.error("Can't parse yaml config " + configPath, e1);
+                    throw new IllegalArgumentException("Can't parse toml config " + configPath, e2);
+                }
             }
         }
         

--- a/redisson/src/main/java/org/redisson/config/Config.java
+++ b/redisson/src/main/java/org/redisson/config/Config.java
@@ -706,6 +706,81 @@ public class Config {
     }
 
     /**
+     * Read config object stored in TOML format from <code>String</code>
+     *
+     * @param content of config
+     * @return config
+     * @throws IOException error
+     */
+    public static Config fromTOML(String content) throws IOException {
+        ConfigSupport support = new ConfigSupport();
+        return support.fromTOML(content, Config.class);
+    }
+
+    /**
+     * Read config object stored in TOML format from <code>InputStream</code>
+     *
+     * @param inputStream object
+     * @return config
+     * @throws IOException error
+     */
+    public static Config fromTOML(InputStream inputStream) throws IOException {
+        ConfigSupport support = new ConfigSupport();
+        return support.fromTOML(inputStream, Config.class);
+    }
+
+    /**
+     * Read config object stored in TOML format from <code>File</code>
+     *
+     * @param file object
+     * @return config
+     * @throws IOException error
+     */
+    public static Config fromTOML(File file) throws IOException {
+        return fromTOML(file, null);
+    }
+
+    public static Config fromTOML(File file, ClassLoader classLoader) throws IOException {
+        ConfigSupport support = new ConfigSupport();
+        return support.fromTOML(file, Config.class, classLoader);
+    }
+
+    /**
+     * Read config object stored in TOML format from <code>URL</code>
+     *
+     * @param url object
+     * @return config
+     * @throws IOException error
+     */
+    public static Config fromTOML(URL url) throws IOException {
+        ConfigSupport support = new ConfigSupport();
+        return support.fromTOML(url, Config.class);
+    }
+
+    /**
+     * Read config object stored in TOML format from <code>Reader</code>
+     *
+     * @param reader object
+     * @return config
+     * @throws IOException error
+     */
+    public static Config fromTOML(Reader reader) throws IOException {
+        ConfigSupport support = new ConfigSupport();
+        return support.fromTOML(reader, Config.class);
+    }
+
+    /**
+     * Convert current configuration to TOML format
+     *
+     * @return config in toml format
+     * @throws IOException error
+     */
+    public String toTOML() throws IOException {
+        ConfigSupport support = new ConfigSupport();
+        return support.toTOML(this);
+    }
+
+    /**
      * Defines whether to use Lua-script cache on Redis side. 
      * Most Redisson methods are Lua-script based and this setting turned
      * on could increase speed of such methods execution and save network traffic.

--- a/redisson/src/main/java/org/redisson/config/RedissonNodeFileConfig.java
+++ b/redisson/src/main/java/org/redisson/config/RedissonNodeFileConfig.java
@@ -121,5 +121,17 @@ public class RedissonNodeFileConfig extends Config {
         ConfigSupport support = new ConfigSupport();
         return support.fromYAML(file, RedissonNodeFileConfig.class);
     }
-    
+
+    /**
+     * Read config object stored in TOML format from <code>File</code>
+     *
+     * @param file object
+     * @return config
+     * @throws IOException error
+     */
+    public static RedissonNodeFileConfig fromTOML(File file) throws IOException {
+        ConfigSupport support = new ConfigSupport();
+        return support.fromTOML(file, RedissonNodeFileConfig.class);
+    }
+
 }

--- a/redisson/src/main/java/org/redisson/jcache/JCachingProvider.java
+++ b/redisson/src/main/java/org/redisson/jcache/JCachingProvider.java
@@ -103,21 +103,33 @@ public class JCachingProvider implements CachingProvider {
             } else {
                 throw new FileNotFoundException("/redisson-jcache.yaml");
             }
-        } catch (JsonProcessingException e) {
-            throw new CacheException(e);
         } catch (IOException e) {
             try {
-                URL jsonUrl = null;
+                URL tomlUrl = null;
                 if (DEFAULT_URI_PATH.equals(uri.getPath())) {
-                    jsonUrl = JCachingProvider.class.getResource("/redisson-jcache.json");
+                    tomlUrl = JCachingProvider.class.getResource("/redisson-jcache.toml");
                 } else {
-                    jsonUrl = uri.toURL();
+                    tomlUrl = uri.toURL();
                 }
-                if (jsonUrl != null) {
-                    config = Config.fromJSON(jsonUrl);
+                if (tomlUrl != null) {
+                    config = Config.fromTOML(tomlUrl);
+                } else {
+                    throw new FileNotFoundException("/redisson-jcache.toml");
                 }
             } catch (IOException ex) {
-                // skip
+                try {
+                    URL jsonUrl = null;
+                    if (DEFAULT_URI_PATH.equals(uri.getPath())) {
+                        jsonUrl = JCachingProvider.class.getResource("/redisson-jcache.json");
+                    } else {
+                        jsonUrl = uri.toURL();
+                    }
+                    if (jsonUrl != null) {
+                        config = Config.fromJSON(jsonUrl);
+                    }
+                } catch (IOException ex1) {
+                    // skip
+                }
             }
         }
         return config;

--- a/redisson/src/test/java/org/redisson/RedissonTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonTest.java
@@ -973,6 +973,33 @@ public class RedissonTest extends BaseTest {
     }
 
     @Test
+    public void testSingleConfigTOML() throws IOException {
+        RedissonClient r = BaseTest.createInstance();
+        String t = r.getConfig().toTOML();
+        Config c = Config.fromTOML(t);
+        assertThat(c.toTOML()).isEqualTo(t);
+    }
+
+    @Test
+    public void testSentinelTOML() throws IOException {
+        Config c2 = new Config();
+        c2.useSentinelServers().addSentinelAddress("redis://123.1.1.1:1231").setMasterName("mymaster");
+        String t = c2.toTOML();
+        System.out.println(t);
+        Config c = Config.fromTOML(t);
+        assertThat(c.toTOML()).isEqualTo(t);
+    }
+
+    @Test
+    public void testMasterSlaveConfigTOML() throws IOException {
+        Config c2 = new Config();
+        c2.useMasterSlaveServers().setMasterAddress("redis://123.1.1.1:1231").addSlaveAddress("redis://82.12.47.12:1028", "redis://82.12.47.14:1028");
+        String t = c2.toTOML();
+        Config c = Config.fromTOML(t);
+        assertThat(c.toTOML()).isEqualTo(t);
+    }
+
+    @Test
     public void testEvalCache() throws InterruptedException, IOException {
         RedisRunner master1 = new RedisRunner().port(6896).randomDir().nosave();
         RedisRunner master2 = new RedisRunner().port(6891).randomDir().nosave();

--- a/redisson/src/test/java/org/redisson/config/ConfigSupportTest.java
+++ b/redisson/src/test/java/org/redisson/config/ConfigSupportTest.java
@@ -2,132 +2,162 @@ package org.redisson.config;
 
 import mockit.Mock;
 import mockit.MockUp;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class ConfigSupportTest {
-    
-    @Test
-    public void testParsingLiteral() throws IOException {
+
+    @ParameterizedTest
+    @MethodSource("formats")
+    public void testParsingLiteral(String format) throws IOException {
         mockHostEnv("1.1.1.1");
-        SingleServerConfig config = mkConfig("127.0.0.1");
+        SingleServerConfig config = mkConfig("127.0.0.1", format);
         
         assertEquals("redis://127.0.0.1", config.getAddress());
     }
-    
-    @Test
-    public void testParsingEnv() throws IOException {
+
+    @ParameterizedTest
+    @MethodSource("formats")
+    public void testParsingEnv(String format) throws IOException {
         mockHostEnv("1.1.1.1");
-        SingleServerConfig config = mkConfig("${REDIS_URI}");
+        SingleServerConfig config = mkConfig("${REDIS_URI}", format);
         
         assertEquals("redis://1.1.1.1", config.getAddress());
     }
 
-    @Test
-    public void testParsingProperty() throws IOException {
+    @ParameterizedTest
+    @MethodSource("formats")
+    public void testParsingProperty(String format) throws IOException {
         mockHostProperty("1.1.1.1");
-        SingleServerConfig config = mkConfig("${REDIS_URI}");
+        SingleServerConfig config = mkConfig("${REDIS_URI}", format);
 
         assertEquals("redis://1.1.1.1", config.getAddress());
     }
-    
-    @Test
-    public void testParsingEnv2() throws IOException {
+
+    @ParameterizedTest
+    @MethodSource("formats")
+    public void testParsingEnv2(String format) throws IOException {
         mockHostPortEnv("1.1.1.1", "6379");
-        SingleServerConfig config = mkConfig("${REDIS_HOST}:${REDIS_PORT}");
+        SingleServerConfig config = mkConfig("${REDIS_HOST}:${REDIS_PORT}", format);
 
         assertEquals("redis://1.1.1.1:6379", config.getAddress());
     }
 
-    @Test
-    public void testParsingProperty2() throws IOException {
+    @ParameterizedTest
+    @MethodSource("formats")
+    public void testParsingProperty2(String format) throws IOException {
         mockHostPortProperty("1.1.1.1", "6379");
-        SingleServerConfig config = mkConfig("${REDIS_HOST}:${REDIS_PORT}");
+        SingleServerConfig config = mkConfig("${REDIS_HOST}:${REDIS_PORT}", format);
 
         assertEquals("redis://1.1.1.1:6379", config.getAddress());
     }
 
-    @Test
-    public void testParsingEnv_envMissing() throws IOException {
+    @ParameterizedTest
+    @MethodSource("formats")
+    public void testParsingEnv_envMissing(String format) throws IOException {
         mockHostEnv(null);
         mockHostProperty(null);
-        final SingleServerConfig config = mkConfig("${REDIS_URI}");
+        final SingleServerConfig config = mkConfig("${REDIS_URI}", format);
 
         assertEquals("redis://${REDIS_URI}", config.getAddress());
     }
-    
-    @Test
-    public void testParsingDefault_envPresent() throws IOException {
+
+    @ParameterizedTest
+    @MethodSource("formats")
+    public void testParsingDefault_envPresent(String format) throws IOException {
         mockHostEnv("11.0.0.1");
-        SingleServerConfig config = mkConfig("${REDIS_URI:-10.0.0.1}");
+        SingleServerConfig config = mkConfig("${REDIS_URI:-10.0.0.1}", format);
         
         assertEquals("redis://11.0.0.1", config.getAddress());
     }
 
-    @Test
-    public void testParsingDefault_propertyPresent() throws IOException {
+    @ParameterizedTest
+    @MethodSource("formats")
+    public void testParsingDefault_propertyPresent(String format) throws IOException {
         mockHostProperty("11.0.0.1");
-        SingleServerConfig config = mkConfig("${REDIS_URI:-10.0.0.1}");
+        SingleServerConfig config = mkConfig("${REDIS_URI:-10.0.0.1}", format);
 
         assertEquals("redis://11.0.0.1", config.getAddress());
     }
-    
-    @Test
-    public void testParsingDefault_envPresent2() throws IOException {
+
+    @ParameterizedTest
+    @MethodSource("formats")
+    public void testParsingDefault_envPresent2(String format) throws IOException {
         mockHostPortEnv("11.0.0.1", "1234");
-        SingleServerConfig config = mkConfig("${REDIS_HOST:-127.0.0.1}:${REDIS_PORT:-6379}");
+        SingleServerConfig config = mkConfig("${REDIS_HOST:-127.0.0.1}:${REDIS_PORT:-6379}", format);
 
         assertEquals("redis://11.0.0.1:1234", config.getAddress());
     }
 
-    @Test
-    public void testParsingDefault_propertyPresent2() throws IOException {
+    @ParameterizedTest
+    @MethodSource("formats")
+    public void testParsingDefault_propertyPresent2(String format) throws IOException {
         mockHostPortProperty("11.0.0.1", "1234");
-        SingleServerConfig config = mkConfig("${REDIS_HOST:-127.0.0.1}:${REDIS_PORT:-6379}");
+        SingleServerConfig config = mkConfig("${REDIS_HOST:-127.0.0.1}:${REDIS_PORT:-6379}", format);
 
         assertEquals("redis://11.0.0.1:1234", config.getAddress());
     }
-    
-    @Test
-    public void testParsingDefault_envMissing() throws IOException {
+
+    @ParameterizedTest
+    @MethodSource("formats")
+    public void testParsingDefault_envMissing(String format) throws IOException {
         mockHostEnv(null);
         mockHostProperty(null);
-        SingleServerConfig config = mkConfig("${REDIS_URI:-10.0.0.1}");
+        SingleServerConfig config = mkConfig("${REDIS_URI:-10.0.0.1}", format);
         
         assertEquals("redis://10.0.0.1", config.getAddress());
     }
-    
-    @Test
-    public void testParsingDefault_envMissing2() throws IOException {
+
+    @ParameterizedTest
+    @MethodSource("formats")
+    public void testParsingDefault_envMissing2(String format) throws IOException {
         mockHostPortEnv(null, null);
         mockHostPortProperty(null, null);
-        SingleServerConfig config = mkConfig("${REDIS_HOST:-127.0.0.1}:${REDIS_PORT:-6379}");
+        SingleServerConfig config = mkConfig("${REDIS_HOST:-127.0.0.1}:${REDIS_PORT:-6379}", format);
 
         assertEquals("redis://127.0.0.1:6379", config.getAddress());
     }
 
-    @Test
-    public void testParsingDefaultPeriod_propertyPresent2() throws IOException {
+    @ParameterizedTest
+    @MethodSource("formats")
+    public void testParsingDefaultPeriod_propertyPresent2(String format) throws IOException {
         mockHostPortPropertyPeriod("11.0.0.1", "1234");
-        SingleServerConfig config = mkConfig("${REDIS.HOST:-127.0.0.1}:${REDIS.PORT:-6379}");
+        SingleServerConfig config = mkConfig("${REDIS.HOST:-127.0.0.1}:${REDIS.PORT:-6379}", format);
 
         assertEquals("redis://11.0.0.1:1234", config.getAddress());
     }
 
-    @Test
-    public void testParsingDefaultPeriod_envMissing() throws IOException {
+    @ParameterizedTest
+    @MethodSource("formats")
+    public void testParsingDefaultPeriod_envMissing(String format) throws IOException {
         mockHostPortProperty(null, null);
-        SingleServerConfig config = mkConfig("${REDIS.HOST:-127.0.0.1}:${REDIS.PORT:-6379}");
+        SingleServerConfig config = mkConfig("${REDIS.HOST:-127.0.0.1}:${REDIS.PORT:-6379}", format);
 
         assertEquals("redis://127.0.0.1:6379", config.getAddress());
     }
     
-    private SingleServerConfig mkConfig(String authorityValue) throws IOException {
-        String config = "singleServerConfig:\n  address: redis://" + authorityValue;
-        return new ConfigSupport().fromYAML(config, Config.class).getSingleServerConfig();
+    private SingleServerConfig mkConfig(String authorityValue, String format) throws IOException {
+        switch (format) {
+            case "yaml": {
+                String config = "singleServerConfig:\n  address: redis://" + authorityValue;
+                return new ConfigSupport().fromYAML(config, Config.class).getSingleServerConfig();
+            }
+
+            case "toml": {
+                String config = "singleServerConfig.address = 'redis://" + authorityValue + "'";
+                return new ConfigSupport().fromTOML(config, Config.class).getSingleServerConfig();
+            }
+
+            default: {
+                throw new UnsupportedEncodingException("format");
+            }
+        }
     }
     
     private void mockHostEnv(String value) {
@@ -194,6 +224,13 @@ public class ConfigSupportTest {
                 }
             }
         };
+    }
+
+    public static Iterable<Object[]> formats() {
+        return Arrays.asList(new Object[][] {
+          {"yaml"},
+          {"toml"}
+        });
     }
 
 }

--- a/redisson/src/test/java/org/redisson/jcache/JCacheTest.java
+++ b/redisson/src/test/java/org/redisson/jcache/JCacheTest.java
@@ -33,6 +33,8 @@ import javax.cache.expiry.Duration;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.redisson.BaseTest;
 import org.redisson.RedisRunner;
 import org.redisson.RedisRunner.FailedToStartRedisException;
@@ -49,16 +51,22 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 public class JCacheTest extends BaseTest {
 
-    @Test
-    public void testCreatedExpiryPolicy() throws Exception {
+    @ParameterizedTest
+    @MethodSource("configPaths")
+    public void testCreatedExpiryPolicy(String configPath) throws Exception {
         RedisProcess runner = new RedisRunner()
                 .nosave()
                 .randomDir()
                 .port(6311)
                 .run();
 
-        URL configUrl = getClass().getResource("redisson-jcache.yaml");
-        Config cfg = Config.fromYAML(configUrl);
+        URL configUrl = getClass().getResource(configPath);
+        Config cfg;
+        try {
+            cfg = Config.fromYAML(configUrl);
+        } catch (IOException ignored) {
+            cfg = Config.fromTOML(configUrl);
+        }
 
         MutableConfiguration c = new MutableConfiguration();
         c.setExpiryPolicyFactory(CreatedExpiryPolicy.factoryOf(new Duration(MILLISECONDS, 500)));
@@ -84,16 +92,22 @@ public class JCacheTest extends BaseTest {
         runner.stop();
     }
 
-    @Test
-    public void testClear() throws Exception {
+    @ParameterizedTest
+    @MethodSource("configPaths")
+    public void testClear(String configPath) throws Exception {
         RedisProcess runner = new RedisRunner()
                 .nosave()
                 .randomDir()
                 .port(6311)
                 .run();
 
-        URL configUrl = getClass().getResource("redisson-jcache.yaml");
-        Config cfg = Config.fromYAML(configUrl);
+        URL configUrl = getClass().getResource(configPath);
+        Config cfg;
+        try {
+            cfg = Config.fromYAML(configUrl);
+        } catch (IOException ignored) {
+            cfg = Config.fromTOML(configUrl);
+        }
 
         Configuration<String, String> config = RedissonConfiguration.fromConfig(cfg);
         Cache<String, String> cache = Caching.getCachingProvider().getCacheManager()
@@ -107,16 +121,22 @@ public class JCacheTest extends BaseTest {
         runner.stop();
     }
 
-    @Test
-    public void testAsync() throws Exception {
+    @ParameterizedTest
+    @MethodSource("configPaths")
+    public void testAsync(String configPath) throws Exception {
         RedisProcess runner = new RedisRunner()
                 .nosave()
                 .randomDir()
                 .port(6311)
                 .run();
         
-        URL configUrl = getClass().getResource("redisson-jcache.yaml");
-        Config cfg = Config.fromYAML(configUrl);
+        URL configUrl = getClass().getResource(configPath);
+        Config cfg;
+        try {
+            cfg = Config.fromYAML(configUrl);
+        } catch (IOException ignored) {
+            cfg = Config.fromTOML(configUrl);
+        }
         
         Configuration<String, String> config = RedissonConfiguration.fromConfig(cfg);
         Cache<String, String> cache = Caching.getCachingProvider().getCacheManager()
@@ -129,17 +149,23 @@ public class JCacheTest extends BaseTest {
         cache.close();
         runner.stop();
     }
-    
-    @Test
-    public void testReactive() throws Exception {
+
+    @ParameterizedTest
+    @MethodSource("configPaths")
+    public void testReactive(String configPath) throws Exception {
         RedisProcess runner = new RedisRunner()
                 .nosave()
                 .randomDir()
                 .port(6311)
                 .run();
         
-        URL configUrl = getClass().getResource("redisson-jcache.yaml");
-        Config cfg = Config.fromYAML(configUrl);
+        URL configUrl = getClass().getResource(configPath);
+        Config cfg;
+        try {
+            cfg = Config.fromYAML(configUrl);
+        } catch (IOException ignored) {
+            cfg = Config.fromTOML(configUrl);
+        }
         
         Configuration<String, String> config = RedissonConfiguration.fromConfig(cfg);
         Cache<String, String> cache = Caching.getCachingProvider().getCacheManager()
@@ -152,17 +178,23 @@ public class JCacheTest extends BaseTest {
         cache.close();
         runner.stop();
     }
-    
-    @Test
-    public void testRx() throws Exception {
+
+    @ParameterizedTest
+    @MethodSource("configPaths")
+    public void testRx(String configPath) throws Exception {
         RedisProcess runner = new RedisRunner()
                 .nosave()
                 .randomDir()
                 .port(6311)
                 .run();
-        
-        URL configUrl = getClass().getResource("redisson-jcache.yaml");
-        Config cfg = Config.fromYAML(configUrl);
+
+        URL configUrl = getClass().getResource(configPath);
+        Config cfg;
+        try {
+            cfg = Config.fromYAML(configUrl);
+        } catch (IOException ignored) {
+            cfg = Config.fromTOML(configUrl);
+        }
         
         Configuration<String, String> config = RedissonConfiguration.fromConfig(cfg);
         Cache<String, String> cache = Caching.getCachingProvider().getCacheManager()
@@ -175,17 +207,23 @@ public class JCacheTest extends BaseTest {
         cache.close();
         runner.stop();
     }
-    
-    @Test
-    public void testPutAll() throws Exception {
+
+    @ParameterizedTest
+    @MethodSource("configPaths")
+    public void testPutAll(String configPath) throws Exception {
         RedisProcess runner = new RedisRunner()
                 .nosave()
                 .randomDir()
                 .port(6311)
                 .run();
         
-        URL configUrl = getClass().getResource("redisson-jcache.yaml");
-        Config cfg = Config.fromYAML(configUrl);
+        URL configUrl = getClass().getResource(configPath);
+        Config cfg;
+        try {
+            cfg = Config.fromYAML(configUrl);
+        } catch (IOException ignored) {
+            cfg = Config.fromTOML(configUrl);
+        }
         
         Configuration<String, String> config = RedissonConfiguration.fromConfig(cfg);
         Cache<String, String> cache = Caching.getCachingProvider().getCacheManager()
@@ -207,17 +245,23 @@ public class JCacheTest extends BaseTest {
         cache.close();
         runner.stop();
     }
-    
-    @Test
-    public void testRemoveAll() throws Exception {
+
+    @ParameterizedTest
+    @MethodSource("configPaths")
+    public void testRemoveAll(String configPath) throws Exception {
         RedisProcess runner = new RedisRunner()
                 .nosave()
                 .randomDir()
                 .port(6311)
                 .run();
-        
-        URL configUrl = getClass().getResource("redisson-jcache.yaml");
-        Config cfg = Config.fromYAML(configUrl);
+
+        URL configUrl = getClass().getResource(configPath);
+        Config cfg;
+        try {
+            cfg = Config.fromYAML(configUrl);
+        } catch (IOException ignored) {
+            cfg = Config.fromTOML(configUrl);
+        }
         
         Configuration<String, String> config = RedissonConfiguration.fromConfig(cfg);
         Cache<String, String> cache = Caching.getCachingProvider().getCacheManager()
@@ -239,16 +283,22 @@ public class JCacheTest extends BaseTest {
         runner.stop();
     }
 
-    @Test
-    public void testGetAllHighVolume() throws Exception {
+    @ParameterizedTest
+    @MethodSource("configPaths")
+    public void testGetAllHighVolume(String configPath) throws Exception {
         RedisProcess runner = new RedisRunner()
                 .nosave()
                 .randomDir()
                 .port(6311)
                 .run();
-        
-        URL configUrl = getClass().getResource("redisson-jcache.yaml");
-        Config cfg = Config.fromYAML(configUrl);
+
+        URL configUrl = getClass().getResource(configPath);
+        Config cfg;
+        try {
+            cfg = Config.fromYAML(configUrl);
+        } catch (IOException ignored) {
+            cfg = Config.fromTOML(configUrl);
+        }
         
         Configuration<String, String> config = RedissonConfiguration.fromConfig(cfg);
         Cache<String, String> cache = Caching.getCachingProvider().getCacheManager()
@@ -266,17 +316,23 @@ public class JCacheTest extends BaseTest {
         cache.close();
         runner.stop();
     }
-    
-    @Test
-    public void testGetAll() throws Exception {
+
+    @ParameterizedTest
+    @MethodSource("configPaths")
+    public void testGetAll(String configPath) throws Exception {
         RedisProcess runner = new RedisRunner()
                 .nosave()
                 .randomDir()
                 .port(6311)
                 .run();
-        
-        URL configUrl = getClass().getResource("redisson-jcache.yaml");
-        Config cfg = Config.fromYAML(configUrl);
+
+        URL configUrl = getClass().getResource(configPath);
+        Config cfg;
+        try {
+            cfg = Config.fromYAML(configUrl);
+        } catch (IOException ignored) {
+            cfg = Config.fromTOML(configUrl);
+        }
         
         Configuration<String, String> config = RedissonConfiguration.fromConfig(cfg);
         Cache<String, String> cache = Caching.getCachingProvider().getCacheManager()
@@ -294,17 +350,23 @@ public class JCacheTest extends BaseTest {
         cache.close();
         runner.stop();
     }
-    
-    @Test
-    public void testJson() throws InterruptedException, IllegalArgumentException, URISyntaxException, IOException {
+
+    @ParameterizedTest
+    @MethodSource("configPaths")
+    public void testJson(String configPath) throws InterruptedException, IllegalArgumentException, URISyntaxException, IOException {
         RedisProcess runner = new RedisRunner()
                 .nosave()
                 .randomDir()
                 .port(6311)
                 .run();
-        
-        URL configUrl = getClass().getResource("redisson-jcache.yaml");
-        Config cfg = Config.fromYAML(configUrl);
+
+        URL configUrl = getClass().getResource(configPath);
+        Config cfg;
+        try {
+            cfg = Config.fromYAML(configUrl);
+        } catch (IOException ignored) {
+            cfg = Config.fromTOML(configUrl);
+        }
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.registerModule(new JavaTimeModule());
         cfg.setCodec(new TypedJsonJacksonCodec(String.class, LocalDateTime.class, objectMapper));
@@ -321,16 +383,22 @@ public class JCacheTest extends BaseTest {
         runner.stop();
     }
 
-    @Test
-    public void testRedissonConfig() throws InterruptedException, IllegalArgumentException, IOException {
+    @ParameterizedTest
+    @MethodSource("configPaths")
+    public void testRedissonConfig(String configPath) throws InterruptedException, IllegalArgumentException, IOException {
         RedisProcess runner = new RedisRunner()
                 .nosave()
                 .randomDir()
                 .port(6311)
                 .run();
-        
-        URL configUrl = getClass().getResource("redisson-jcache.yaml");
-        Config cfg = Config.fromYAML(configUrl);
+
+        URL configUrl = getClass().getResource(configPath);
+        Config cfg;
+        try {
+            cfg = Config.fromYAML(configUrl);
+        } catch (IOException ignored) {
+            cfg = Config.fromTOML(configUrl);
+        }
         
         Configuration<String, String> config = RedissonConfiguration.fromConfig(cfg);
         Cache<String, String> cache = Caching.getCachingProvider().getCacheManager()
@@ -365,8 +433,9 @@ public class JCacheTest extends BaseTest {
         cache.close();
     }
 
-    @Test
-    public void testExpiration() throws InterruptedException, IllegalArgumentException, URISyntaxException, FailedToStartRedisException, IOException {
+    @ParameterizedTest
+    @MethodSource("configPaths")
+    public void testExpiration(String configPath) throws InterruptedException, IllegalArgumentException, URISyntaxException, FailedToStartRedisException, IOException {
         RedisProcess runner = new RedisRunner()
                 .nosave()
                 .randomDir()
@@ -377,7 +446,7 @@ public class JCacheTest extends BaseTest {
         config.setExpiryPolicyFactory(CreatedExpiryPolicy.factoryOf(new Duration(TimeUnit.SECONDS, 1)));
         config.setStoreByValue(true);
         
-        URI configUri = getClass().getResource("redisson-jcache.yaml").toURI();
+        URI configUri = getClass().getResource(configPath).toURI();
         Cache<String, String> cache = Caching.getCachingProvider().getCacheManager(configUri, null)
                 .createCache("test", config);
 
@@ -400,8 +469,9 @@ public class JCacheTest extends BaseTest {
         runner.stop();
     }
 
-    @Test
-    public void testUpdate() throws IOException, InterruptedException, URISyntaxException {
+    @ParameterizedTest
+    @MethodSource("configPaths")
+    public void testUpdate(String configPath) throws IOException, InterruptedException, URISyntaxException {
         RedisProcess runner = new RedisRunner()
                 .nosave()
                 .randomDir()
@@ -411,7 +481,7 @@ public class JCacheTest extends BaseTest {
         MutableConfiguration<String, String> config = new MutableConfiguration<>();
         config.setStoreByValue(true);
 
-        URI configUri = getClass().getResource("redisson-jcache.yaml").toURI();
+        URI configUri = getClass().getResource(configPath).toURI();
         Cache<String, String> cache = Caching.getCachingProvider().getCacheManager(configUri, null)
                 .createCache("test", config);
 
@@ -437,8 +507,9 @@ public class JCacheTest extends BaseTest {
         runner.stop();
     }
 
-    @Test
-    public void testUpdateAsync() throws IOException, InterruptedException, URISyntaxException {
+    @ParameterizedTest
+    @MethodSource("configPaths")
+    public void testUpdateAsync(String configPath) throws IOException, InterruptedException, URISyntaxException {
         RedisProcess runner = new RedisRunner()
                 .nosave()
                 .randomDir()
@@ -448,7 +519,7 @@ public class JCacheTest extends BaseTest {
         MutableConfiguration<String, String> config = new MutableConfiguration<>();
         config.setStoreByValue(true);
 
-        URI configUri = getClass().getResource("redisson-jcache.yaml").toURI();
+        URI configUri = getClass().getResource(configPath).toURI();
         Cache<String, String> cache = Caching.getCachingProvider().getCacheManager(configUri, null)
                 .createCache("test", config);
 
@@ -479,8 +550,9 @@ public class JCacheTest extends BaseTest {
         runner.stop();
     }
 
-    @Test
-    public void testUpdateWithoutOldValue() throws IOException, InterruptedException, URISyntaxException {
+    @ParameterizedTest
+    @MethodSource("configPaths")
+    public void testUpdateWithoutOldValue(String configPath) throws IOException, InterruptedException, URISyntaxException {
         RedisProcess runner = new RedisRunner()
                 .nosave()
                 .randomDir()
@@ -490,7 +562,7 @@ public class JCacheTest extends BaseTest {
         MutableConfiguration<String, String> config = new MutableConfiguration<>();
         config.setStoreByValue(true);
 
-        URI configUri = getClass().getResource("redisson-jcache.yaml").toURI();
+        URI configUri = getClass().getResource(configPath).toURI();
         Cache<String, String> cache = Caching.getCachingProvider().getCacheManager(configUri, null)
                 .createCache("test", config);
 
@@ -516,8 +588,9 @@ public class JCacheTest extends BaseTest {
         runner.stop();
     }
 
-    @Test
-    public void testRemoveListener() throws IOException, InterruptedException, URISyntaxException {
+    @ParameterizedTest
+    @MethodSource("configPaths")
+    public void testRemoveListener(String configPath) throws IOException, InterruptedException, URISyntaxException {
                 RedisProcess runner = new RedisRunner()
                 .nosave()
                 .randomDir()
@@ -527,7 +600,7 @@ public class JCacheTest extends BaseTest {
         MutableConfiguration<String, String> config = new MutableConfiguration<>();
         config.setStoreByValue(true);
 
-        URI configUri = getClass().getResource("redisson-jcache.yaml").toURI();
+        URI configUri = getClass().getResource(configPath).toURI();
         Cache<String, String> cache = Caching.getCachingProvider().getCacheManager(configUri, null)
                 .createCache("test", config);
 
@@ -551,6 +624,13 @@ public class JCacheTest extends BaseTest {
 
         cache.close();
         runner.stop();
+    }
+
+    public static Iterable<Object[]> configPaths() {
+        return Arrays.asList(new Object[][] {
+          {"redisson-jcache.yaml"},
+          {"redisson-jcache.toml"}
+        });
     }
     
     public static class ExpiredListener implements CacheEntryExpiredListener<String, String>, Serializable {

--- a/redisson/src/test/resources/org/redisson/jcache/redisson-jcache.toml
+++ b/redisson/src/test/resources/org/redisson/jcache/redisson-jcache.toml
@@ -1,0 +1,2 @@
+[singleServerConfig]
+address = 'redis://127.0.0.1:6311'


### PR DESCRIPTION
This PR is intended to add TOML configs support per issue #4161.

TOML configs can now be loaded via the `Config` API in addition to being automatically discovered by other middleware like Spring and Hibernate.

This PR includes changes to the tests for JCache and RedissonSessionManager. This was done to ensure coverage parity with the YAML code. If this isn't desirable, please let me know.

Please share your thoughts and feedback!