### PR TITLE
Fixed - all scan, In cluster mode, all nodes cannot be scanned，Not only a single node#4238

### DIFF
--- a/redisson-spring-data/redisson-spring-data-16/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring-data/redisson-spring-data-16/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -243,7 +243,6 @@ public class RedissonConnection extends AbstractRedisConnection {
     public Cursor<byte[]> scan(ScanOptions options) {
         return new ScanCursor<byte[]>(0, options) {
 
-            private RedisClient client;
             private Iterator<MasterSlaveEntry> entries = redisson.getConnectionManager().getEntrySet().iterator();
             private MasterSlaveEntry entry = entries.next();
             
@@ -270,10 +269,9 @@ public class RedissonConnection extends AbstractRedisConnection {
                     args.add(options.getCount());
                 }
                 
-                RFuture<ListScanResult<byte[]>> f = executorService.readAsync(client, entry, ByteArrayCodec.INSTANCE, RedisCommands.SCAN, args.toArray());
+                RFuture<ListScanResult<byte[]>> f = executorService.readAsync(null, entry, ByteArrayCodec.INSTANCE, RedisCommands.SCAN, args.toArray());
                 ListScanResult<byte[]> res = syncFuture(f);
                 long pos = res.getPos();
-                client = res.getRedisClient();
                 if (pos == 0) {
                     if (entries.hasNext()) {
                         pos = -1;

--- a/redisson-spring-data/redisson-spring-data-17/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring-data/redisson-spring-data-17/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -262,7 +262,6 @@ public class RedissonConnection extends AbstractRedisConnection {
     public Cursor<byte[]> scan(ScanOptions options) {
         return new ScanCursor<byte[]>(0, options) {
 
-            private RedisClient client;
             private Iterator<MasterSlaveEntry> entries = redisson.getConnectionManager().getEntrySet().iterator();
             private MasterSlaveEntry entry = entries.next();
             
@@ -289,10 +288,9 @@ public class RedissonConnection extends AbstractRedisConnection {
                     args.add(options.getCount());
                 }
                 
-                RFuture<ListScanResult<byte[]>> f = executorService.readAsync(client, entry, ByteArrayCodec.INSTANCE, RedisCommands.SCAN, args.toArray());
+                RFuture<ListScanResult<byte[]>> f = executorService.readAsync(null, entry, ByteArrayCodec.INSTANCE, RedisCommands.SCAN, args.toArray());
                 ListScanResult<byte[]> res = syncFuture(f);
                 long pos = res.getPos();
-                client = res.getRedisClient();
                 if (pos == 0) {
                     if (entries.hasNext()) {
                         pos = -1;

--- a/redisson-spring-data/redisson-spring-data-18/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring-data/redisson-spring-data-18/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -265,7 +265,6 @@ public class RedissonConnection extends AbstractRedisConnection {
     public Cursor<byte[]> scan(ScanOptions options) {
         return new ScanCursor<byte[]>(0, options) {
 
-            private RedisClient client;
             private Iterator<MasterSlaveEntry> entries = redisson.getConnectionManager().getEntrySet().iterator();
             private MasterSlaveEntry entry = entries.next();
             
@@ -292,10 +291,9 @@ public class RedissonConnection extends AbstractRedisConnection {
                     args.add(options.getCount());
                 }
                 
-                RFuture<ListScanResult<byte[]>> f = executorService.readAsync(client, entry, ByteArrayCodec.INSTANCE, RedisCommands.SCAN, args.toArray());
+                RFuture<ListScanResult<byte[]>> f = executorService.readAsync(null, entry, ByteArrayCodec.INSTANCE, RedisCommands.SCAN, args.toArray());
                 ListScanResult<byte[]> res = syncFuture(f);
                 long pos = res.getPos();
-                client = res.getRedisClient();
                 if (pos == 0) {
                     if (entries.hasNext()) {
                         pos = -1;

--- a/redisson-spring-data/redisson-spring-data-20/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring-data/redisson-spring-data-20/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -247,7 +247,6 @@ public class RedissonConnection extends AbstractRedisConnection {
     public Cursor<byte[]> scan(ScanOptions options) {
         return new ScanCursor<byte[]>(0, options) {
 
-            private RedisClient client;
             private Iterator<MasterSlaveEntry> entries = redisson.getConnectionManager().getEntrySet().iterator();
             private MasterSlaveEntry entry = entries.next();
             
@@ -274,10 +273,9 @@ public class RedissonConnection extends AbstractRedisConnection {
                     args.add(options.getCount());
                 }
                 
-                RFuture<ListScanResult<byte[]>> f = executorService.readAsync(client, entry, ByteArrayCodec.INSTANCE, RedisCommands.SCAN, args.toArray());
+                RFuture<ListScanResult<byte[]>> f = executorService.readAsync(null, entry, ByteArrayCodec.INSTANCE, RedisCommands.SCAN, args.toArray());
                 ListScanResult<byte[]> res = syncFuture(f);
                 long pos = res.getPos();
-                client = res.getRedisClient();
                 if (pos == 0) {
                     if (entries.hasNext()) {
                         pos = -1;

--- a/redisson-spring-data/redisson-spring-data-21/src/main/java/org/redisson/spring/data/connection/RedissonClusterConnection.java
+++ b/redisson-spring-data/redisson-spring-data-21/src/main/java/org/redisson/spring/data/connection/RedissonClusterConnection.java
@@ -386,7 +386,6 @@ public class RedissonClusterConnection extends RedissonConnection implements Def
     public Cursor<byte[]> scan(RedisClusterNode node, ScanOptions options) {
         return new ScanCursor<byte[]>(0, options) {
 
-            private RedisClient client;
             private MasterSlaveEntry entry = getEntry(node);
             
             @Override
@@ -412,10 +411,9 @@ public class RedissonClusterConnection extends RedissonConnection implements Def
                     args.add(options.getCount());
                 }
                 
-                RFuture<ListScanResult<byte[]>> f = executorService.readAsync(client, entry, ByteArrayCodec.INSTANCE, RedisCommands.SCAN, args.toArray());
+                RFuture<ListScanResult<byte[]>> f = executorService.readAsync(null, entry, ByteArrayCodec.INSTANCE, RedisCommands.SCAN, args.toArray());
                 ListScanResult<byte[]> res = syncFuture(f);
                 long pos = res.getPos();
-                client = res.getRedisClient();
                 if (pos == 0) {
                     entry = null;
                 }

--- a/redisson-spring-data/redisson-spring-data-21/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring-data/redisson-spring-data-21/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -245,7 +245,6 @@ public class RedissonConnection extends AbstractRedisConnection {
     public Cursor<byte[]> scan(ScanOptions options) {
         return new ScanCursor<byte[]>(0, options) {
 
-            private RedisClient client;
             private Iterator<MasterSlaveEntry> entries = redisson.getConnectionManager().getEntrySet().iterator();
             private MasterSlaveEntry entry = entries.next();
             
@@ -272,10 +271,9 @@ public class RedissonConnection extends AbstractRedisConnection {
                     args.add(options.getCount());
                 }
                 
-                RFuture<ListScanResult<byte[]>> f = executorService.readAsync(client, entry, ByteArrayCodec.INSTANCE, RedisCommands.SCAN, args.toArray());
+                RFuture<ListScanResult<byte[]>> f = executorService.readAsync(null, entry, ByteArrayCodec.INSTANCE, RedisCommands.SCAN, args.toArray());
                 ListScanResult<byte[]> res = syncFuture(f);
                 long pos = res.getPos();
-                client = res.getRedisClient();
                 if (pos == 0) {
                     if (entries.hasNext()) {
                         pos = -1;

--- a/redisson-spring-data/redisson-spring-data-22/src/main/java/org/redisson/spring/data/connection/RedissonClusterConnection.java
+++ b/redisson-spring-data/redisson-spring-data-22/src/main/java/org/redisson/spring/data/connection/RedissonClusterConnection.java
@@ -386,7 +386,6 @@ public class RedissonClusterConnection extends RedissonConnection implements Def
     public Cursor<byte[]> scan(RedisClusterNode node, ScanOptions options) {
         return new ScanCursor<byte[]>(0, options) {
 
-            private RedisClient client;
             private MasterSlaveEntry entry = getEntry(node);
             
             @Override
@@ -412,10 +411,9 @@ public class RedissonClusterConnection extends RedissonConnection implements Def
                     args.add(options.getCount());
                 }
                 
-                RFuture<ListScanResult<byte[]>> f = executorService.readAsync(client, entry, ByteArrayCodec.INSTANCE, RedisCommands.SCAN, args.toArray());
+                RFuture<ListScanResult<byte[]>> f = executorService.readAsync(null, entry, ByteArrayCodec.INSTANCE, RedisCommands.SCAN, args.toArray());
                 ListScanResult<byte[]> res = syncFuture(f);
                 long pos = res.getPos();
-                client = res.getRedisClient();
                 if (pos == 0) {
                     entry = null;
                 }

--- a/redisson-spring-data/redisson-spring-data-22/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring-data/redisson-spring-data-22/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -245,7 +245,6 @@ public class RedissonConnection extends AbstractRedisConnection {
     public Cursor<byte[]> scan(ScanOptions options) {
         return new ScanCursor<byte[]>(0, options) {
 
-            private RedisClient client;
             private Iterator<MasterSlaveEntry> entries = redisson.getConnectionManager().getEntrySet().iterator();
             private MasterSlaveEntry entry = entries.next();
             
@@ -272,10 +271,9 @@ public class RedissonConnection extends AbstractRedisConnection {
                     args.add(options.getCount());
                 }
                 
-                RFuture<ListScanResult<byte[]>> f = executorService.readAsync(client, entry, ByteArrayCodec.INSTANCE, RedisCommands.SCAN, args.toArray());
+                RFuture<ListScanResult<byte[]>> f = executorService.readAsync(null, entry, ByteArrayCodec.INSTANCE, RedisCommands.SCAN, args.toArray());
                 ListScanResult<byte[]> res = syncFuture(f);
                 long pos = res.getPos();
-                client = res.getRedisClient();
                 if (pos == 0) {
                     if (entries.hasNext()) {
                         pos = -1;

--- a/redisson-spring-data/redisson-spring-data-23/src/main/java/org/redisson/spring/data/connection/RedissonClusterConnection.java
+++ b/redisson-spring-data/redisson-spring-data-23/src/main/java/org/redisson/spring/data/connection/RedissonClusterConnection.java
@@ -386,7 +386,6 @@ public class RedissonClusterConnection extends RedissonConnection implements Def
     public Cursor<byte[]> scan(RedisClusterNode node, ScanOptions options) {
         return new ScanCursor<byte[]>(0, options) {
 
-            private RedisClient client;
             private MasterSlaveEntry entry = getEntry(node);
             
             @Override
@@ -412,10 +411,9 @@ public class RedissonClusterConnection extends RedissonConnection implements Def
                     args.add(options.getCount());
                 }
                 
-                RFuture<ListScanResult<byte[]>> f = executorService.readAsync(client, entry, ByteArrayCodec.INSTANCE, RedisCommands.SCAN, args.toArray());
+                RFuture<ListScanResult<byte[]>> f = executorService.readAsync(null, entry, ByteArrayCodec.INSTANCE, RedisCommands.SCAN, args.toArray());
                 ListScanResult<byte[]> res = syncFuture(f);
                 long pos = res.getPos();
-                client = res.getRedisClient();
                 if (pos == 0) {
                     entry = null;
                 }

--- a/redisson-spring-data/redisson-spring-data-23/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring-data/redisson-spring-data-23/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -245,7 +245,6 @@ public class RedissonConnection extends AbstractRedisConnection {
     public Cursor<byte[]> scan(ScanOptions options) {
         return new ScanCursor<byte[]>(0, options) {
 
-            private RedisClient client;
             private Iterator<MasterSlaveEntry> entries = redisson.getConnectionManager().getEntrySet().iterator();
             private MasterSlaveEntry entry = entries.next();
             
@@ -272,10 +271,9 @@ public class RedissonConnection extends AbstractRedisConnection {
                     args.add(options.getCount());
                 }
                 
-                RFuture<ListScanResult<byte[]>> f = executorService.readAsync(client, entry, ByteArrayCodec.INSTANCE, RedisCommands.SCAN, args.toArray());
+                RFuture<ListScanResult<byte[]>> f = executorService.readAsync(null, entry, ByteArrayCodec.INSTANCE, RedisCommands.SCAN, args.toArray());
                 ListScanResult<byte[]> res = syncFuture(f);
                 long pos = res.getPos();
-                client = res.getRedisClient();
                 if (pos == 0) {
                     if (entries.hasNext()) {
                         pos = -1;

--- a/redisson-spring-data/redisson-spring-data-24/src/main/java/org/redisson/spring/data/connection/RedissonClusterConnection.java
+++ b/redisson-spring-data/redisson-spring-data-24/src/main/java/org/redisson/spring/data/connection/RedissonClusterConnection.java
@@ -386,7 +386,6 @@ public class RedissonClusterConnection extends RedissonConnection implements Def
     public Cursor<byte[]> scan(RedisClusterNode node, ScanOptions options) {
         return new ScanCursor<byte[]>(0, options) {
 
-            private RedisClient client;
             private MasterSlaveEntry entry = getEntry(node);
             
             @Override
@@ -412,10 +411,9 @@ public class RedissonClusterConnection extends RedissonConnection implements Def
                     args.add(options.getCount());
                 }
                 
-                RFuture<ListScanResult<byte[]>> f = executorService.readAsync(client, entry, ByteArrayCodec.INSTANCE, RedisCommands.SCAN, args.toArray());
+                RFuture<ListScanResult<byte[]>> f = executorService.readAsync(null, entry, ByteArrayCodec.INSTANCE, RedisCommands.SCAN, args.toArray());
                 ListScanResult<byte[]> res = syncFuture(f);
                 long pos = res.getPos();
-                client = res.getRedisClient();
                 if (pos == 0) {
                     entry = null;
                 }

--- a/redisson-spring-data/redisson-spring-data-24/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring-data/redisson-spring-data-24/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -245,7 +245,6 @@ public class RedissonConnection extends AbstractRedisConnection {
     public Cursor<byte[]> scan(ScanOptions options) {
         return new ScanCursor<byte[]>(0, options) {
 
-            private RedisClient client;
             private Iterator<MasterSlaveEntry> entries = redisson.getConnectionManager().getEntrySet().iterator();
             private MasterSlaveEntry entry = entries.next();
             
@@ -272,10 +271,9 @@ public class RedissonConnection extends AbstractRedisConnection {
                     args.add(options.getCount());
                 }
                 
-                RFuture<ListScanResult<byte[]>> f = executorService.readAsync(client, entry, ByteArrayCodec.INSTANCE, RedisCommands.SCAN, args.toArray());
+                RFuture<ListScanResult<byte[]>> f = executorService.readAsync(null, entry, ByteArrayCodec.INSTANCE, RedisCommands.SCAN, args.toArray());
                 ListScanResult<byte[]> res = syncFuture(f);
                 long pos = res.getPos();
-                client = res.getRedisClient();
                 if (pos == 0) {
                     if (entries.hasNext()) {
                         pos = -1;

--- a/redisson-spring-data/redisson-spring-data-25/src/main/java/org/redisson/spring/data/connection/RedissonClusterConnection.java
+++ b/redisson-spring-data/redisson-spring-data-25/src/main/java/org/redisson/spring/data/connection/RedissonClusterConnection.java
@@ -386,7 +386,6 @@ public class RedissonClusterConnection extends RedissonConnection implements Def
     public Cursor<byte[]> scan(RedisClusterNode node, ScanOptions options) {
         return new ScanCursor<byte[]>(0, options) {
 
-            private RedisClient client;
             private MasterSlaveEntry entry = getEntry(node);
             
             @Override
@@ -412,10 +411,9 @@ public class RedissonClusterConnection extends RedissonConnection implements Def
                     args.add(options.getCount());
                 }
                 
-                RFuture<ListScanResult<byte[]>> f = executorService.readAsync(client, entry, ByteArrayCodec.INSTANCE, RedisCommands.SCAN, args.toArray());
+                RFuture<ListScanResult<byte[]>> f = executorService.readAsync(null, entry, ByteArrayCodec.INSTANCE, RedisCommands.SCAN, args.toArray());
                 ListScanResult<byte[]> res = syncFuture(f);
                 long pos = res.getPos();
-                client = res.getRedisClient();
                 if (pos == 0) {
                     entry = null;
                 }

--- a/redisson-spring-data/redisson-spring-data-25/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring-data/redisson-spring-data-25/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -245,7 +245,6 @@ public class RedissonConnection extends AbstractRedisConnection {
     public Cursor<byte[]> scan(ScanOptions options) {
         return new ScanCursor<byte[]>(0, options) {
 
-            private RedisClient client;
             private Iterator<MasterSlaveEntry> entries = redisson.getConnectionManager().getEntrySet().iterator();
             private MasterSlaveEntry entry = entries.next();
             
@@ -272,10 +271,9 @@ public class RedissonConnection extends AbstractRedisConnection {
                     args.add(options.getCount());
                 }
                 
-                RFuture<ListScanResult<byte[]>> f = executorService.readAsync(client, entry, ByteArrayCodec.INSTANCE, RedisCommands.SCAN, args.toArray());
+                RFuture<ListScanResult<byte[]>> f = executorService.readAsync(null, entry, ByteArrayCodec.INSTANCE, RedisCommands.SCAN, args.toArray());
                 ListScanResult<byte[]> res = syncFuture(f);
                 long pos = res.getPos();
-                client = res.getRedisClient();
                 if (pos == 0) {
                     if (entries.hasNext()) {
                         pos = -1;

--- a/redisson-spring-data/redisson-spring-data-26/src/main/java/org/redisson/spring/data/connection/RedissonClusterConnection.java
+++ b/redisson-spring-data/redisson-spring-data-26/src/main/java/org/redisson/spring/data/connection/RedissonClusterConnection.java
@@ -386,7 +386,6 @@ public class RedissonClusterConnection extends RedissonConnection implements Def
     public Cursor<byte[]> scan(RedisClusterNode node, ScanOptions options) {
         return new ScanCursor<byte[]>(0, options) {
 
-            private RedisClient client;
             private MasterSlaveEntry entry = getEntry(node);
             
             @Override
@@ -412,10 +411,9 @@ public class RedissonClusterConnection extends RedissonConnection implements Def
                     args.add(options.getCount());
                 }
                 
-                RFuture<ListScanResult<byte[]>> f = executorService.readAsync(client, entry, ByteArrayCodec.INSTANCE, RedisCommands.SCAN, args.toArray());
+                RFuture<ListScanResult<byte[]>> f = executorService.readAsync(null, entry, ByteArrayCodec.INSTANCE, RedisCommands.SCAN, args.toArray());
                 ListScanResult<byte[]> res = syncFuture(f);
                 long pos = res.getPos();
-                client = res.getRedisClient();
                 if (pos == 0) {
                     entry = null;
                 }

--- a/redisson-spring-data/redisson-spring-data-26/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring-data/redisson-spring-data-26/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -245,7 +245,6 @@ public class RedissonConnection extends AbstractRedisConnection {
     public Cursor<byte[]> scan(ScanOptions options) {
         return new ScanCursor<byte[]>(0, options) {
 
-            private RedisClient client;
             private Iterator<MasterSlaveEntry> entries = redisson.getConnectionManager().getEntrySet().iterator();
             private MasterSlaveEntry entry = entries.next();
             
@@ -272,10 +271,9 @@ public class RedissonConnection extends AbstractRedisConnection {
                     args.add(options.getCount());
                 }
                 
-                RFuture<ListScanResult<byte[]>> f = executorService.readAsync(client, entry, ByteArrayCodec.INSTANCE, RedisCommands.SCAN, args.toArray());
+                RFuture<ListScanResult<byte[]>> f = executorService.readAsync(null, entry, ByteArrayCodec.INSTANCE, RedisCommands.SCAN, args.toArray());
                 ListScanResult<byte[]> res = syncFuture(f);
                 long pos = res.getPos();
-                client = res.getRedisClient();
                 if (pos == 0) {
                     if (entries.hasNext()) {
                         pos = -1;


### PR DESCRIPTION
Scan In cluster mode, other nodes cannot be scanned https://github.com/redisson/redisson/issues/4238
The reason is that the field client in the implementation of ScanCursor will affect the current entry node, resulting in the acquisition of connection is always the same node, and the node cannot be switched.  
 please give me more advice if there is something wrong