### PR TITLE
Update ExpirationEntry in RedissonBaseLock.java

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonBaseLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonBaseLock.java
@@ -57,7 +57,7 @@ public abstract class RedissonBaseLock extends RedissonExpirable implements RLoc
 
         public synchronized void addThreadId(long threadId) {
             threadIds.compute(threadId, (t, counter) -> {
-                counter = Optional.ofNullable(counter).orElse(0);
+                counter = Optional.ofNullable(counter).orElse(1);
                 counter++;
                 return counter;
             });

--- a/redisson/src/main/java/org/redisson/RedissonBaseLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonBaseLock.java
@@ -57,7 +57,7 @@ public abstract class RedissonBaseLock extends RedissonExpirable implements RLoc
 
         public synchronized void addThreadId(long threadId) {
             threadIds.compute(threadId, (t, counter) -> {
-                counter = Optional.ofNullable(counter).orElse(1);
+                counter = Optional.ofNullable(counter).orElse(0);
                 counter++;
                 return counter;
             });


### PR DESCRIPTION
The counter should start from 0. Otherwise, according to the program logic, even if the removethreadid method is called, the counter will not be reduced to 0.