### PR TITLE
Fixed a problem when Redis Sentinels deployed on K8S using Deployment and Service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.76.Final</version>
+                <version>4.1.77.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/redisson-spring-boot-starter/pom.xml
+++ b/redisson-spring-boot-starter/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <properties>
-        <spring-boot.version>2.6.1</spring-boot.version>
+        <spring-boot.version>2.7.0</spring-boot.version>
     </properties>
 
     <artifactId>redisson-spring-boot-starter</artifactId>
@@ -131,7 +131,7 @@
 
         <dependency>
             <groupId>org.redisson</groupId>
-            <artifactId>redisson-spring-data-26</artifactId>
+            <artifactId>redisson-spring-data-27</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/redisson-spring-data/redisson-spring-data-16/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring-data/redisson-spring-data-16/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -16,7 +16,6 @@
 package org.redisson.spring.data.connection;
 
 import org.redisson.Redisson;
-import org.redisson.SlotCallback;
 import org.redisson.api.BatchOptions;
 import org.redisson.api.BatchOptions.ExecutionMode;
 import org.redisson.api.BatchResult;
@@ -51,7 +50,7 @@ import java.math.BigDecimal;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 import static org.redisson.client.protocol.RedisCommands.LRANGE;
 
@@ -226,9 +225,10 @@ public class RedissonConnection extends AbstractRedisConnection {
             return read(null, ByteArrayCodec.INSTANCE, KEYS, pattern);
         }
 
-        RFuture<Collection<byte[]>> f = executorService.readAllAsync(ByteArrayCodec.INSTANCE, KEYS, pattern);
-        CompletableFuture<Set<byte[]>> future = f.thenApply(r -> {
-            return (Set<byte[]>)new HashSet<>(r);
+        List<CompletableFuture<Set<byte[]>>> futures = executorService.readAllAsync(ByteArrayCodec.INSTANCE, KEYS, pattern);
+        CompletableFuture<Void> ff = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+        CompletableFuture<Set<byte[]>> future = ff.thenApply(r -> {
+            return futures.stream().flatMap(f -> f.getNow(new HashSet<>()).stream()).collect(Collectors.toSet());
         }).toCompletableFuture();
         return sync(new CompletableFutureWrapper<>(future));
     }
@@ -1600,20 +1600,12 @@ public class RedissonConnection extends AbstractRedisConnection {
         if (isQueueing()) {
             return read(null, StringCodec.INSTANCE, RedisCommands.DBSIZE);
         }
-        
-        RFuture<Long> f = executorService.readAllAsync(RedisCommands.DBSIZE, new SlotCallback<Long, Long>() {
-            AtomicLong results = new AtomicLong();
-            @Override
-            public void onSlotResult(Long result) {
-                results.addAndGet(result);
-            }
 
-            @Override
-            public Long onFinish() {
-                return results.get();
-            }
-        });
-        return sync(f);
+        List<CompletableFuture<Long>> futures = executorService.readAllAsync(RedisCommands.DBSIZE);
+        CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+        CompletableFuture<Long> s = f.thenApply(r -> futures.stream().mapToLong(v -> v.getNow(0L)).sum());
+        CompletableFutureWrapper<Long> ff = new CompletableFutureWrapper<>(s);
+        return sync(ff);
     }
 
     @Override
@@ -1623,13 +1615,13 @@ public class RedissonConnection extends AbstractRedisConnection {
             return;
         }
         
-        RFuture<Void> f = executorService.writeAllAsync(RedisCommands.FLUSHDB);
+        RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.FLUSHDB);
         sync(f);
     }
 
     @Override
     public void flushAll() {
-        RFuture<Void> f = executorService.writeAllAsync(RedisCommands.FLUSHALL);
+        RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.FLUSHALL);
         sync(f);
     }
 
@@ -1714,7 +1706,7 @@ public class RedissonConnection extends AbstractRedisConnection {
             throw new UnsupportedOperationException();
         }
 
-        RFuture<Void> f = executorService.writeAllAsync(RedisCommands.SCRIPT_FLUSH);
+        RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.SCRIPT_FLUSH);
         sync(f);
     }
 
@@ -1732,7 +1724,7 @@ public class RedissonConnection extends AbstractRedisConnection {
             throw new UnsupportedOperationException();
         }
 
-        List<CompletableFuture<String>> futures = executorService.executeAll(RedisCommands.SCRIPT_LOAD, (Object)script);
+        List<CompletableFuture<String>> futures = executorService.executeAllAsync(RedisCommands.SCRIPT_LOAD, (Object)script);
         CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
         CompletableFuture<String> s = f.thenApply(r -> futures.get(0).getNow(null));
         return sync(new CompletableFutureWrapper<>(s));
@@ -1744,7 +1736,7 @@ public class RedissonConnection extends AbstractRedisConnection {
             throw new UnsupportedOperationException();
         }
 
-        List<CompletableFuture<List<Boolean>>> futures = executorService.executeMasters(RedisCommands.SCRIPT_EXISTS, (Object[]) scriptShas);
+        List<CompletableFuture<List<Boolean>>> futures = executorService.writeAllAsync(RedisCommands.SCRIPT_EXISTS, (Object[]) scriptShas);
         CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
         CompletableFuture<List<Boolean>> s = f.thenApply(r -> {
             List<Boolean> result = futures.get(0).getNow(new ArrayList<>());

--- a/redisson-spring-data/redisson-spring-data-17/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring-data/redisson-spring-data-17/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -23,19 +23,15 @@ import java.math.BigDecimal;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 
 import org.redisson.Redisson;
-import org.redisson.SlotCallback;
 import org.redisson.api.BatchOptions;
 import org.redisson.api.BatchOptions.ExecutionMode;
 import org.redisson.api.BatchResult;
 import org.redisson.api.RFuture;
 import org.redisson.api.RedissonClient;
 import org.redisson.client.RedisClient;
-import org.redisson.client.RedisException;
 import org.redisson.client.codec.ByteArrayCodec;
 import org.redisson.client.codec.Codec;
 import org.redisson.client.codec.DoubleCodec;
@@ -246,9 +242,10 @@ public class RedissonConnection extends AbstractRedisConnection {
             return read(null, ByteArrayCodec.INSTANCE, KEYS, pattern);
         }
 
-        RFuture<Collection<byte[]>> f = executorService.readAllAsync(ByteArrayCodec.INSTANCE, KEYS, pattern);
-        CompletableFuture<Set<byte[]>> future = f.thenApply(r -> {
-            return (Set<byte[]>)new HashSet<>(r);
+        List<CompletableFuture<Set<byte[]>>> futures = executorService.readAllAsync(ByteArrayCodec.INSTANCE, KEYS, pattern);
+        CompletableFuture<Void> ff = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+        CompletableFuture<Set<byte[]>> future = ff.thenApply(r -> {
+            return futures.stream().flatMap(f -> f.getNow(new HashSet<>()).stream()).collect(Collectors.toSet());
         }).toCompletableFuture();
         return sync(new CompletableFutureWrapper<>(future));
     }
@@ -1647,20 +1644,12 @@ public class RedissonConnection extends AbstractRedisConnection {
         if (isQueueing()) {
             return read(null, StringCodec.INSTANCE, RedisCommands.DBSIZE);
         }
-        
-        RFuture<Long> f = executorService.readAllAsync(RedisCommands.DBSIZE, new SlotCallback<Long, Long>() {
-            AtomicLong results = new AtomicLong();
-            @Override
-            public void onSlotResult(Long result) {
-                results.addAndGet(result);
-            }
 
-            @Override
-            public Long onFinish() {
-                return results.get();
-            }
-        });
-        return sync(f);
+        List<CompletableFuture<Long>> futures = executorService.readAllAsync(RedisCommands.DBSIZE);
+        CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+        CompletableFuture<Long> s = f.thenApply(r -> futures.stream().mapToLong(v -> v.getNow(0L)).sum());
+        CompletableFutureWrapper<Long> ff = new CompletableFutureWrapper<>(s);
+        return sync(ff);
     }
 
     @Override
@@ -1670,13 +1659,13 @@ public class RedissonConnection extends AbstractRedisConnection {
             return;
         }
         
-        RFuture<Void> f = executorService.writeAllAsync(RedisCommands.FLUSHDB);
+        RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.FLUSHDB);
         sync(f);
     }
 
     @Override
     public void flushAll() {
-        RFuture<Void> f = executorService.writeAllAsync(RedisCommands.FLUSHALL);
+        RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.FLUSHALL);
         sync(f);
     }
 
@@ -1771,7 +1760,7 @@ public class RedissonConnection extends AbstractRedisConnection {
             throw new UnsupportedOperationException();
         }
 
-        RFuture<Void> f = executorService.writeAllAsync(RedisCommands.SCRIPT_FLUSH);
+        RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.SCRIPT_FLUSH);
         sync(f);
     }
 
@@ -1789,7 +1778,7 @@ public class RedissonConnection extends AbstractRedisConnection {
             throw new UnsupportedOperationException();
         }
 
-        List<CompletableFuture<String>> futures = executorService.executeAll(RedisCommands.SCRIPT_LOAD, (Object)script);
+        List<CompletableFuture<String>> futures = executorService.executeAllAsync(RedisCommands.SCRIPT_LOAD, (Object)script);
         CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
         CompletableFuture<String> s = f.thenApply(r -> futures.get(0).getNow(null));
         return sync(new CompletableFutureWrapper<>(s));
@@ -1801,7 +1790,7 @@ public class RedissonConnection extends AbstractRedisConnection {
             throw new UnsupportedOperationException();
         }
 
-        List<CompletableFuture<List<Boolean>>> futures = executorService.executeMasters(RedisCommands.SCRIPT_EXISTS, (Object[]) scriptShas);
+        List<CompletableFuture<List<Boolean>>> futures = executorService.writeAllAsync(RedisCommands.SCRIPT_EXISTS, (Object[]) scriptShas);
         CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
         CompletableFuture<List<Boolean>> s = f.thenApply(r -> {
             List<Boolean> result = futures.get(0).getNow(new ArrayList<>());

--- a/redisson-spring-data/redisson-spring-data-20/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring-data/redisson-spring-data-20/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -16,14 +16,12 @@
 package org.redisson.spring.data.connection;
 
 import org.redisson.Redisson;
-import org.redisson.SlotCallback;
 import org.redisson.api.BatchOptions;
 import org.redisson.api.BatchOptions.ExecutionMode;
 import org.redisson.api.BatchResult;
 import org.redisson.api.RFuture;
 import org.redisson.api.RedissonClient;
 import org.redisson.client.RedisClient;
-import org.redisson.client.RedisException;
 import org.redisson.client.codec.*;
 import org.redisson.client.protocol.RedisCommand;
 import org.redisson.client.protocol.RedisCommands;
@@ -57,9 +55,7 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 
 import static org.redisson.client.protocol.RedisCommands.LRANGE;
 
@@ -234,9 +230,10 @@ public class RedissonConnection extends AbstractRedisConnection {
             return read(null, ByteArrayCodec.INSTANCE, KEYS, pattern);
         }
 
-        RFuture<Collection<byte[]>> f = executorService.readAllAsync(ByteArrayCodec.INSTANCE, KEYS, pattern);
-        CompletableFuture<Set<byte[]>> future = f.thenApply(r -> {
-            return (Set<byte[]>)new HashSet<>(r);
+        List<CompletableFuture<Set<byte[]>>> futures = executorService.readAllAsync(ByteArrayCodec.INSTANCE, KEYS, pattern);
+        CompletableFuture<Void> ff = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+        CompletableFuture<Set<byte[]>> future = ff.thenApply(r -> {
+            return futures.stream().flatMap(f -> f.getNow(new HashSet<>()).stream()).collect(Collectors.toSet());
         }).toCompletableFuture();
         return sync(new CompletableFutureWrapper<>(future));
     }
@@ -1661,20 +1658,12 @@ public class RedissonConnection extends AbstractRedisConnection {
         if (isQueueing()) {
             return read(null, StringCodec.INSTANCE, RedisCommands.DBSIZE);
         }
-        
-        RFuture<Long> f = executorService.readAllAsync(RedisCommands.DBSIZE, new SlotCallback<Long, Long>() {
-            AtomicLong results = new AtomicLong();
-            @Override
-            public void onSlotResult(Long result) {
-                results.addAndGet(result);
-            }
 
-            @Override
-            public Long onFinish() {
-                return results.get();
-            }
-        });
-        return sync(f);
+        List<CompletableFuture<Long>> futures = executorService.readAllAsync(RedisCommands.DBSIZE);
+        CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+        CompletableFuture<Long> s = f.thenApply(r -> futures.stream().mapToLong(v -> v.getNow(0L)).sum());
+        CompletableFutureWrapper<Long> ff = new CompletableFutureWrapper<>(s);
+        return sync(ff);
     }
 
     @Override
@@ -1684,13 +1673,13 @@ public class RedissonConnection extends AbstractRedisConnection {
             return;
         }
         
-        RFuture<Void> f = executorService.writeAllAsync(RedisCommands.FLUSHDB);
+        RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.FLUSHDB);
         sync(f);
     }
 
     @Override
     public void flushAll() {
-        RFuture<Void> f = executorService.writeAllAsync(RedisCommands.FLUSHALL);
+        RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.FLUSHALL);
         sync(f);
     }
 
@@ -1787,7 +1776,7 @@ public class RedissonConnection extends AbstractRedisConnection {
             throw new UnsupportedOperationException();
         }
 
-        RFuture<Void> f = executorService.writeAllAsync(RedisCommands.SCRIPT_FLUSH);
+        RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.SCRIPT_FLUSH);
         sync(f);
     }
 
@@ -1805,7 +1794,7 @@ public class RedissonConnection extends AbstractRedisConnection {
             throw new UnsupportedOperationException();
         }
 
-        List<CompletableFuture<String>> futures = executorService.executeAll(RedisCommands.SCRIPT_LOAD, (Object)script);
+        List<CompletableFuture<String>> futures = executorService.executeAllAsync(RedisCommands.SCRIPT_LOAD, (Object)script);
         CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
         CompletableFuture<String> s = f.thenApply(r -> futures.get(0).getNow(null));
         return sync(new CompletableFutureWrapper<>(s));
@@ -1817,7 +1806,7 @@ public class RedissonConnection extends AbstractRedisConnection {
             throw new UnsupportedOperationException();
         }
 
-        List<CompletableFuture<List<Boolean>>> futures = executorService.executeMasters(RedisCommands.SCRIPT_EXISTS, (Object[]) scriptShas);
+        List<CompletableFuture<List<Boolean>>> futures = executorService.writeAllAsync(RedisCommands.SCRIPT_EXISTS, (Object[]) scriptShas);
         CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
         CompletableFuture<List<Boolean>> s = f.thenApply(r -> {
             List<Boolean> result = futures.get(0).getNow(new ArrayList<>());

--- a/redisson-spring-data/redisson-spring-data-20/src/main/java/org/redisson/spring/data/connection/RedissonReactiveScriptingCommands.java
+++ b/redisson-spring-data/redisson-spring-data-20/src/main/java/org/redisson/spring/data/connection/RedissonReactiveScriptingCommands.java
@@ -47,7 +47,7 @@ public class RedissonReactiveScriptingCommands extends RedissonBaseReactive impl
     @Override
     public Mono<String> scriptFlush() {
         return executorService.reactive(() -> {
-            RFuture<Void> f = executorService.writeAllAsync(RedisCommands.SCRIPT_FLUSH);
+            RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.SCRIPT_FLUSH);
             return toStringFuture(f);
         });
     }
@@ -60,7 +60,7 @@ public class RedissonReactiveScriptingCommands extends RedissonBaseReactive impl
     @Override
     public Mono<String> scriptLoad(ByteBuffer script) {
         return executorService.reactive(() -> {
-            List<CompletableFuture<String>> futures = executorService.executeAll(RedisCommands.SCRIPT_LOAD, (Object)toByteArray(script));
+            List<CompletableFuture<String>> futures = executorService.executeAllAsync(RedisCommands.SCRIPT_LOAD, (Object)toByteArray(script));
             CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
             CompletableFuture<String> s = f.thenApply(r -> futures.get(0).getNow(null));
             return new CompletableFutureWrapper<>(s);
@@ -70,7 +70,7 @@ public class RedissonReactiveScriptingCommands extends RedissonBaseReactive impl
     @Override
     public Flux<Boolean> scriptExists(List<String> scriptShas) {
         Mono<List<Boolean>> m = executorService.reactive(() -> {
-            List<CompletableFuture<List<Boolean>>> futures = executorService.executeMasters(RedisCommands.SCRIPT_EXISTS, scriptShas.toArray());
+            List<CompletableFuture<List<Boolean>>> futures = executorService.writeAllAsync(RedisCommands.SCRIPT_EXISTS, scriptShas.toArray());
             CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
             CompletableFuture<List<Boolean>> s = f.thenApply(r -> {
                 List<Boolean> result = futures.get(0).getNow(new ArrayList<>());

--- a/redisson-spring-data/redisson-spring-data-20/src/main/java/org/redisson/spring/data/connection/RedissonReactiveServerCommands.java
+++ b/redisson-spring-data/redisson-spring-data-20/src/main/java/org/redisson/spring/data/connection/RedissonReactiveServerCommands.java
@@ -15,18 +15,18 @@
  */
 package org.redisson.spring.data.connection;
 
+import java.util.List;
 import java.util.Properties;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.CompletableFuture;
 
-import org.redisson.SlotCallback;
 import org.redisson.api.RFuture;
 import org.redisson.client.codec.LongCodec;
 import org.redisson.client.codec.StringCodec;
 import org.redisson.client.protocol.RedisCommands;
 import org.redisson.client.protocol.RedisStrictCommand;
-import org.redisson.client.protocol.convertor.VoidReplayConvertor;
 import org.redisson.client.protocol.decoder.ObjectDecoder;
 import org.redisson.client.protocol.decoder.TimeLongObjectDecoder;
+import org.redisson.misc.CompletableFutureWrapper;
 import org.redisson.reactive.CommandReactiveExecutor;
 import org.springframework.data.redis.connection.ReactiveServerCommands;
 import org.springframework.data.redis.core.types.RedisClientInfo;
@@ -74,18 +74,10 @@ public class RedissonReactiveServerCommands extends RedissonBaseReactive impleme
     @Override
     public Mono<Long> dbSize() {
         return executorService.reactive(() -> {
-            return executorService.readAllAsync(RedisCommands.DBSIZE, new SlotCallback<Long, Long>() {
-                AtomicLong results = new AtomicLong();
-                @Override
-                public void onSlotResult(Long result) {
-                    results.addAndGet(result);
-                }
-                
-                @Override
-                public Long onFinish() {
-                    return results.get();
-                }
-            });
+            List<CompletableFuture<Long>> futures = executorService.readAllAsync(RedisCommands.DBSIZE);
+            CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+            CompletableFuture<Long> s = f.thenApply(r -> futures.stream().mapToLong(v -> v.getNow(0L)).sum());
+            return new CompletableFutureWrapper<>(s);
         });
     }
     
@@ -94,7 +86,7 @@ public class RedissonReactiveServerCommands extends RedissonBaseReactive impleme
     @Override
     public Mono<String> flushDb() {
         return executorService.reactive(() -> {
-            RFuture<Void> f = executorService.writeAllAsync(FLUSHDB);
+            RFuture<Void> f = executorService.writeAllVoidAsync(FLUSHDB);
             return toStringFuture(f);
         });
     }
@@ -104,7 +96,7 @@ public class RedissonReactiveServerCommands extends RedissonBaseReactive impleme
     @Override
     public Mono<String> flushAll() {
         return executorService.reactive(() -> {
-            RFuture<Void> f = executorService.writeAllAsync(FLUSHALL);
+            RFuture<Void> f = executorService.writeAllVoidAsync(FLUSHALL);
             return toStringFuture(f);
         });
     }

--- a/redisson-spring-data/redisson-spring-data-21/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring-data/redisson-spring-data-21/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -16,7 +16,6 @@
 package org.redisson.spring.data.connection;
 
 import org.redisson.Redisson;
-import org.redisson.SlotCallback;
 import org.redisson.api.BatchOptions;
 import org.redisson.api.BatchOptions.ExecutionMode;
 import org.redisson.api.BatchResult;
@@ -54,7 +53,7 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 import static org.redisson.client.protocol.RedisCommands.LRANGE;
 
@@ -234,9 +233,10 @@ public class RedissonConnection extends AbstractRedisConnection {
             return read(null, ByteArrayCodec.INSTANCE, KEYS, pattern);
         }
 
-        RFuture<Collection<byte[]>> f = executorService.readAllAsync(ByteArrayCodec.INSTANCE, KEYS, pattern);
-        CompletableFuture<Set<byte[]>> future = f.thenApply(r -> {
-            return (Set<byte[]>)new HashSet<>(r);
+        List<CompletableFuture<Set<byte[]>>> futures = executorService.readAllAsync(ByteArrayCodec.INSTANCE, KEYS, pattern);
+        CompletableFuture<Void> ff = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+        CompletableFuture<Set<byte[]>> future = ff.thenApply(r -> {
+            return futures.stream().flatMap(f -> f.getNow(new HashSet<>()).stream()).collect(Collectors.toSet());
         }).toCompletableFuture();
         return sync(new CompletableFutureWrapper<>(future));
     }
@@ -1661,20 +1661,12 @@ public class RedissonConnection extends AbstractRedisConnection {
         if (isQueueing()) {
             return read(null, StringCodec.INSTANCE, RedisCommands.DBSIZE);
         }
-        
-        RFuture<Long> f = executorService.readAllAsync(RedisCommands.DBSIZE, new SlotCallback<Long, Long>() {
-            AtomicLong results = new AtomicLong();
-            @Override
-            public void onSlotResult(Long result) {
-                results.addAndGet(result);
-            }
 
-            @Override
-            public Long onFinish() {
-                return results.get();
-            }
-        });
-        return sync(f);
+        List<CompletableFuture<Long>> futures = executorService.readAllAsync(RedisCommands.DBSIZE);
+        CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+        CompletableFuture<Long> s = f.thenApply(r -> futures.stream().mapToLong(v -> v.getNow(0L)).sum());
+        CompletableFutureWrapper<Long> ff = new CompletableFutureWrapper<>(s);
+        return sync(ff);
     }
 
     @Override
@@ -1684,13 +1676,13 @@ public class RedissonConnection extends AbstractRedisConnection {
             return;
         }
         
-        RFuture<Void> f = executorService.writeAllAsync(RedisCommands.FLUSHDB);
+        RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.FLUSHDB);
         sync(f);
     }
 
     @Override
     public void flushAll() {
-        RFuture<Void> f = executorService.writeAllAsync(RedisCommands.FLUSHALL);
+        RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.FLUSHALL);
         sync(f);
     }
 
@@ -1787,7 +1779,7 @@ public class RedissonConnection extends AbstractRedisConnection {
             throw new UnsupportedOperationException();
         }
 
-        RFuture<Void> f = executorService.writeAllAsync(RedisCommands.SCRIPT_FLUSH);
+        RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.SCRIPT_FLUSH);
         sync(f);
     }
 
@@ -1805,7 +1797,7 @@ public class RedissonConnection extends AbstractRedisConnection {
             throw new UnsupportedOperationException();
         }
 
-        List<CompletableFuture<String>> futures = executorService.executeAll(RedisCommands.SCRIPT_LOAD, (Object)script);
+        List<CompletableFuture<String>> futures = executorService.executeAllAsync(RedisCommands.SCRIPT_LOAD, (Object)script);
         CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
         CompletableFuture<String> s = f.thenApply(r -> futures.get(0).getNow(null));
         return sync(new CompletableFutureWrapper<>(s));
@@ -1817,7 +1809,7 @@ public class RedissonConnection extends AbstractRedisConnection {
             throw new UnsupportedOperationException();
         }
 
-        List<CompletableFuture<List<Boolean>>> futures = executorService.executeMasters(RedisCommands.SCRIPT_EXISTS, (Object[]) scriptShas);
+        List<CompletableFuture<List<Boolean>>> futures = executorService.writeAllAsync(RedisCommands.SCRIPT_EXISTS, (Object[]) scriptShas);
         CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
         CompletableFuture<List<Boolean>> s = f.thenApply(r -> {
             List<Boolean> result = futures.get(0).getNow(new ArrayList<>());

--- a/redisson-spring-data/redisson-spring-data-21/src/main/java/org/redisson/spring/data/connection/RedissonReactiveClusterKeyCommands.java
+++ b/redisson-spring-data/redisson-spring-data-21/src/main/java/org/redisson/spring/data/connection/RedissonReactiveClusterKeyCommands.java
@@ -16,16 +16,18 @@
 package org.redisson.spring.data.connection;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import org.reactivestreams.Publisher;
-import org.redisson.api.RFuture;
 import org.redisson.client.codec.ByteArrayCodec;
 import org.redisson.client.codec.StringCodec;
 import org.redisson.client.protocol.RedisCommands;
 import org.redisson.connection.MasterSlaveEntry;
+import org.redisson.misc.CompletableFutureWrapper;
 import org.redisson.reactive.CommandReactiveExecutor;
 import org.springframework.data.redis.connection.ReactiveClusterKeyCommands;
 import org.springframework.data.redis.connection.ReactiveRedisConnection;
@@ -52,7 +54,12 @@ public class RedissonReactiveClusterKeyCommands extends RedissonReactiveKeyComma
     @Override
     public Mono<List<ByteBuffer>> keys(RedisClusterNode node, ByteBuffer pattern) {
         Mono<List<String>> m = executorService.reactive(() -> {
-            return (RFuture<List<String>>)(Object) executorService.readAllAsync(StringCodec.INSTANCE, RedisCommands.KEYS, toByteArray(pattern));
+            List<CompletableFuture<List<String>>> futures = executorService.readAllAsync(StringCodec.INSTANCE, RedisCommands.KEYS, toByteArray(pattern));
+            CompletableFuture<Void> ff = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+            CompletableFuture<List<String>> future = ff.thenApply(r -> {
+                return futures.stream().flatMap(f -> f.getNow(new ArrayList<>()).stream()).collect(Collectors.toList());
+            }).toCompletableFuture();
+            return new CompletableFutureWrapper<>(future);
         });
         return m.map(v -> v.stream().map(t -> ByteBuffer.wrap(t.getBytes(CharsetUtil.UTF_8))).collect(Collectors.toList()));
     }

--- a/redisson-spring-data/redisson-spring-data-21/src/main/java/org/redisson/spring/data/connection/RedissonReactiveScriptingCommands.java
+++ b/redisson-spring-data/redisson-spring-data-21/src/main/java/org/redisson/spring/data/connection/RedissonReactiveScriptingCommands.java
@@ -47,7 +47,7 @@ public class RedissonReactiveScriptingCommands extends RedissonBaseReactive impl
     @Override
     public Mono<String> scriptFlush() {
         return executorService.reactive(() -> {
-            RFuture<Void> f = executorService.writeAllAsync(RedisCommands.SCRIPT_FLUSH);
+            RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.SCRIPT_FLUSH);
             return toStringFuture(f);
         });
     }
@@ -60,7 +60,7 @@ public class RedissonReactiveScriptingCommands extends RedissonBaseReactive impl
     @Override
     public Mono<String> scriptLoad(ByteBuffer script) {
         return executorService.reactive(() -> {
-            List<CompletableFuture<String>> futures = executorService.executeAll(RedisCommands.SCRIPT_LOAD, (Object)toByteArray(script));
+            List<CompletableFuture<String>> futures = executorService.executeAllAsync(RedisCommands.SCRIPT_LOAD, (Object)toByteArray(script));
             CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
             CompletableFuture<String> s = f.thenApply(r -> futures.get(0).getNow(null));
             return new CompletableFutureWrapper<>(s);
@@ -70,7 +70,7 @@ public class RedissonReactiveScriptingCommands extends RedissonBaseReactive impl
     @Override
     public Flux<Boolean> scriptExists(List<String> scriptShas) {
         Mono<List<Boolean>> m = executorService.reactive(() -> {
-            List<CompletableFuture<List<Boolean>>> futures = executorService.executeMasters(RedisCommands.SCRIPT_EXISTS, scriptShas.toArray());
+            List<CompletableFuture<List<Boolean>>> futures = executorService.writeAllAsync(RedisCommands.SCRIPT_EXISTS, scriptShas.toArray());
             CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
             CompletableFuture<List<Boolean>> s = f.thenApply(r -> {
                 List<Boolean> result = futures.get(0).getNow(new ArrayList<>());

--- a/redisson-spring-data/redisson-spring-data-22/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring-data/redisson-spring-data-22/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -16,7 +16,6 @@
 package org.redisson.spring.data.connection;
 
 import org.redisson.Redisson;
-import org.redisson.SlotCallback;
 import org.redisson.api.BatchOptions;
 import org.redisson.api.BatchOptions.ExecutionMode;
 import org.redisson.api.BatchResult;
@@ -54,7 +53,7 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 import static org.redisson.client.protocol.RedisCommands.LRANGE;
 
@@ -234,9 +233,10 @@ public class RedissonConnection extends AbstractRedisConnection {
             return read(null, ByteArrayCodec.INSTANCE, KEYS, pattern);
         }
 
-        RFuture<Collection<byte[]>> f = executorService.readAllAsync(ByteArrayCodec.INSTANCE, KEYS, pattern);
-        CompletableFuture<Set<byte[]>> future = f.thenApply(r -> {
-            return (Set<byte[]>)new HashSet<>(r);
+        List<CompletableFuture<Set<byte[]>>> futures = executorService.readAllAsync(ByteArrayCodec.INSTANCE, KEYS, pattern);
+        CompletableFuture<Void> ff = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+        CompletableFuture<Set<byte[]>> future = ff.thenApply(r -> {
+            return futures.stream().flatMap(f -> f.getNow(new HashSet<>()).stream()).collect(Collectors.toSet());
         }).toCompletableFuture();
         return sync(new CompletableFutureWrapper<>(future));
     }
@@ -1661,20 +1661,12 @@ public class RedissonConnection extends AbstractRedisConnection {
         if (isQueueing()) {
             return read(null, StringCodec.INSTANCE, RedisCommands.DBSIZE);
         }
-        
-        RFuture<Long> f = executorService.readAllAsync(RedisCommands.DBSIZE, new SlotCallback<Long, Long>() {
-            AtomicLong results = new AtomicLong();
-            @Override
-            public void onSlotResult(Long result) {
-                results.addAndGet(result);
-            }
 
-            @Override
-            public Long onFinish() {
-                return results.get();
-            }
-        });
-        return sync(f);
+        List<CompletableFuture<Long>> futures = executorService.readAllAsync(RedisCommands.DBSIZE);
+        CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+        CompletableFuture<Long> s = f.thenApply(r -> futures.stream().mapToLong(v -> v.getNow(0L)).sum());
+        CompletableFutureWrapper<Long> ff = new CompletableFutureWrapper<>(s);
+        return sync(ff);
     }
 
     @Override
@@ -1684,13 +1676,13 @@ public class RedissonConnection extends AbstractRedisConnection {
             return;
         }
         
-        RFuture<Void> f = executorService.writeAllAsync(RedisCommands.FLUSHDB);
+        RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.FLUSHDB);
         sync(f);
     }
 
     @Override
     public void flushAll() {
-        RFuture<Void> f = executorService.writeAllAsync(RedisCommands.FLUSHALL);
+        RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.FLUSHALL);
         sync(f);
     }
 
@@ -1787,7 +1779,7 @@ public class RedissonConnection extends AbstractRedisConnection {
             throw new UnsupportedOperationException();
         }
 
-        RFuture<Void> f = executorService.writeAllAsync(RedisCommands.SCRIPT_FLUSH);
+        RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.SCRIPT_FLUSH);
         sync(f);
     }
 
@@ -1805,7 +1797,7 @@ public class RedissonConnection extends AbstractRedisConnection {
             throw new UnsupportedOperationException();
         }
 
-        List<CompletableFuture<String>> futures = executorService.executeAll(RedisCommands.SCRIPT_LOAD, (Object)script);
+        List<CompletableFuture<String>> futures = executorService.executeAllAsync(RedisCommands.SCRIPT_LOAD, (Object)script);
         CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
         CompletableFuture<String> s = f.thenApply(r -> futures.get(0).getNow(null));
         return sync(new CompletableFutureWrapper<>(s));
@@ -1817,7 +1809,7 @@ public class RedissonConnection extends AbstractRedisConnection {
             throw new UnsupportedOperationException();
         }
 
-        List<CompletableFuture<List<Boolean>>> futures = executorService.executeMasters(RedisCommands.SCRIPT_EXISTS, (Object[]) scriptShas);
+        List<CompletableFuture<List<Boolean>>> futures = executorService.writeAllAsync(RedisCommands.SCRIPT_EXISTS, (Object[]) scriptShas);
         CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
         CompletableFuture<List<Boolean>> s = f.thenApply(r -> {
             List<Boolean> result = futures.get(0).getNow(new ArrayList<>());

--- a/redisson-spring-data/redisson-spring-data-22/src/main/java/org/redisson/spring/data/connection/RedissonReactiveClusterKeyCommands.java
+++ b/redisson-spring-data/redisson-spring-data-22/src/main/java/org/redisson/spring/data/connection/RedissonReactiveClusterKeyCommands.java
@@ -16,16 +16,18 @@
 package org.redisson.spring.data.connection;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import org.reactivestreams.Publisher;
-import org.redisson.api.RFuture;
 import org.redisson.client.codec.ByteArrayCodec;
 import org.redisson.client.codec.StringCodec;
 import org.redisson.client.protocol.RedisCommands;
 import org.redisson.connection.MasterSlaveEntry;
+import org.redisson.misc.CompletableFutureWrapper;
 import org.redisson.reactive.CommandReactiveExecutor;
 import org.springframework.data.redis.connection.ReactiveClusterKeyCommands;
 import org.springframework.data.redis.connection.ReactiveRedisConnection;
@@ -52,7 +54,12 @@ public class RedissonReactiveClusterKeyCommands extends RedissonReactiveKeyComma
     @Override
     public Mono<List<ByteBuffer>> keys(RedisClusterNode node, ByteBuffer pattern) {
         Mono<List<String>> m = executorService.reactive(() -> {
-            return (RFuture<List<String>>)(Object) executorService.readAllAsync(StringCodec.INSTANCE, RedisCommands.KEYS, toByteArray(pattern));
+            List<CompletableFuture<List<String>>> futures = executorService.readAllAsync(StringCodec.INSTANCE, RedisCommands.KEYS, toByteArray(pattern));
+            CompletableFuture<Void> ff = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+            CompletableFuture<List<String>> future = ff.thenApply(r -> {
+                return futures.stream().flatMap(f -> f.getNow(new ArrayList<>()).stream()).collect(Collectors.toList());
+            }).toCompletableFuture();
+            return new CompletableFutureWrapper<>(future);
         });
         return m.map(v -> v.stream().map(t -> ByteBuffer.wrap(t.getBytes(CharsetUtil.UTF_8))).collect(Collectors.toList()));
     }

--- a/redisson-spring-data/redisson-spring-data-22/src/main/java/org/redisson/spring/data/connection/RedissonReactiveScriptingCommands.java
+++ b/redisson-spring-data/redisson-spring-data-22/src/main/java/org/redisson/spring/data/connection/RedissonReactiveScriptingCommands.java
@@ -47,7 +47,7 @@ public class RedissonReactiveScriptingCommands extends RedissonBaseReactive impl
     @Override
     public Mono<String> scriptFlush() {
         return executorService.reactive(() -> {
-            RFuture<Void> f = executorService.writeAllAsync(RedisCommands.SCRIPT_FLUSH);
+            RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.SCRIPT_FLUSH);
             return toStringFuture(f);
         });
     }
@@ -60,7 +60,7 @@ public class RedissonReactiveScriptingCommands extends RedissonBaseReactive impl
     @Override
     public Mono<String> scriptLoad(ByteBuffer script) {
         return executorService.reactive(() -> {
-            List<CompletableFuture<String>> futures = executorService.executeAll(RedisCommands.SCRIPT_LOAD, (Object)toByteArray(script));
+            List<CompletableFuture<String>> futures = executorService.executeAllAsync(RedisCommands.SCRIPT_LOAD, (Object)toByteArray(script));
             CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
             CompletableFuture<String> s = f.thenApply(r -> futures.get(0).getNow(null));
             return new CompletableFutureWrapper<>(s);
@@ -70,7 +70,7 @@ public class RedissonReactiveScriptingCommands extends RedissonBaseReactive impl
     @Override
     public Flux<Boolean> scriptExists(List<String> scriptShas) {
         Mono<List<Boolean>> m = executorService.reactive(() -> {
-            List<CompletableFuture<List<Boolean>>> futures = executorService.executeMasters(RedisCommands.SCRIPT_EXISTS, scriptShas.toArray());
+            List<CompletableFuture<List<Boolean>>> futures = executorService.writeAllAsync(RedisCommands.SCRIPT_EXISTS, scriptShas.toArray());
             CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
             CompletableFuture<List<Boolean>> s = f.thenApply(r -> {
                 List<Boolean> result = futures.get(0).getNow(new ArrayList<>());

--- a/redisson-spring-data/redisson-spring-data-23/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring-data/redisson-spring-data-23/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -16,7 +16,6 @@
 package org.redisson.spring.data.connection;
 
 import org.redisson.Redisson;
-import org.redisson.SlotCallback;
 import org.redisson.api.BatchOptions;
 import org.redisson.api.BatchOptions.ExecutionMode;
 import org.redisson.api.BatchResult;
@@ -54,7 +53,7 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 import static org.redisson.client.protocol.RedisCommands.LRANGE;
 
@@ -234,9 +233,10 @@ public class RedissonConnection extends AbstractRedisConnection {
             return read(null, ByteArrayCodec.INSTANCE, KEYS, pattern);
         }
 
-        RFuture<Collection<byte[]>> f = executorService.readAllAsync(ByteArrayCodec.INSTANCE, KEYS, pattern);
-        CompletableFuture<Set<byte[]>> future = f.thenApply(r -> {
-            return (Set<byte[]>)new HashSet<>(r);
+        List<CompletableFuture<Set<byte[]>>> futures = executorService.readAllAsync(ByteArrayCodec.INSTANCE, KEYS, pattern);
+        CompletableFuture<Void> ff = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+        CompletableFuture<Set<byte[]>> future = ff.thenApply(r -> {
+            return futures.stream().flatMap(f -> f.getNow(new HashSet<>()).stream()).collect(Collectors.toSet());
         }).toCompletableFuture();
         return sync(new CompletableFutureWrapper<>(future));
     }
@@ -1661,20 +1661,12 @@ public class RedissonConnection extends AbstractRedisConnection {
         if (isQueueing()) {
             return read(null, StringCodec.INSTANCE, RedisCommands.DBSIZE);
         }
-        
-        RFuture<Long> f = executorService.readAllAsync(RedisCommands.DBSIZE, new SlotCallback<Long, Long>() {
-            AtomicLong results = new AtomicLong();
-            @Override
-            public void onSlotResult(Long result) {
-                results.addAndGet(result);
-            }
 
-            @Override
-            public Long onFinish() {
-                return results.get();
-            }
-        });
-        return sync(f);
+        List<CompletableFuture<Long>> futures = executorService.readAllAsync(RedisCommands.DBSIZE);
+        CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+        CompletableFuture<Long> s = f.thenApply(r -> futures.stream().mapToLong(v -> v.getNow(0L)).sum());
+        CompletableFutureWrapper<Long> ff = new CompletableFutureWrapper<>(s);
+        return sync(ff);
     }
 
     @Override
@@ -1684,13 +1676,13 @@ public class RedissonConnection extends AbstractRedisConnection {
             return;
         }
         
-        RFuture<Void> f = executorService.writeAllAsync(RedisCommands.FLUSHDB);
+        RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.FLUSHDB);
         sync(f);
     }
 
     @Override
     public void flushAll() {
-        RFuture<Void> f = executorService.writeAllAsync(RedisCommands.FLUSHALL);
+        RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.FLUSHALL);
         sync(f);
     }
 
@@ -1787,7 +1779,7 @@ public class RedissonConnection extends AbstractRedisConnection {
             throw new UnsupportedOperationException();
         }
 
-        RFuture<Void> f = executorService.writeAllAsync(RedisCommands.SCRIPT_FLUSH);
+        RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.SCRIPT_FLUSH);
         sync(f);
     }
 
@@ -1805,7 +1797,7 @@ public class RedissonConnection extends AbstractRedisConnection {
             throw new UnsupportedOperationException();
         }
 
-        List<CompletableFuture<String>> futures = executorService.executeAll(RedisCommands.SCRIPT_LOAD, (Object)script);
+        List<CompletableFuture<String>> futures = executorService.executeAllAsync(RedisCommands.SCRIPT_LOAD, (Object)script);
         CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
         CompletableFuture<String> s = f.thenApply(r -> futures.get(0).getNow(null));
         return sync(new CompletableFutureWrapper<>(s));
@@ -1817,7 +1809,7 @@ public class RedissonConnection extends AbstractRedisConnection {
             throw new UnsupportedOperationException();
         }
 
-        List<CompletableFuture<List<Boolean>>> futures = executorService.executeMasters(RedisCommands.SCRIPT_EXISTS, (Object[]) scriptShas);
+        List<CompletableFuture<List<Boolean>>> futures = executorService.writeAllAsync(RedisCommands.SCRIPT_EXISTS, (Object[]) scriptShas);
         CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
         CompletableFuture<List<Boolean>> s = f.thenApply(r -> {
             List<Boolean> result = futures.get(0).getNow(new ArrayList<>());

--- a/redisson-spring-data/redisson-spring-data-23/src/main/java/org/redisson/spring/data/connection/RedissonReactiveClusterKeyCommands.java
+++ b/redisson-spring-data/redisson-spring-data-23/src/main/java/org/redisson/spring/data/connection/RedissonReactiveClusterKeyCommands.java
@@ -16,16 +16,18 @@
 package org.redisson.spring.data.connection;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import org.reactivestreams.Publisher;
-import org.redisson.api.RFuture;
 import org.redisson.client.codec.ByteArrayCodec;
 import org.redisson.client.codec.StringCodec;
 import org.redisson.client.protocol.RedisCommands;
 import org.redisson.connection.MasterSlaveEntry;
+import org.redisson.misc.CompletableFutureWrapper;
 import org.redisson.reactive.CommandReactiveExecutor;
 import org.springframework.data.redis.connection.ReactiveClusterKeyCommands;
 import org.springframework.data.redis.connection.ReactiveRedisConnection;
@@ -52,7 +54,12 @@ public class RedissonReactiveClusterKeyCommands extends RedissonReactiveKeyComma
     @Override
     public Mono<List<ByteBuffer>> keys(RedisClusterNode node, ByteBuffer pattern) {
         Mono<List<String>> m = executorService.reactive(() -> {
-            return (RFuture<List<String>>)(Object) executorService.readAllAsync(StringCodec.INSTANCE, RedisCommands.KEYS, toByteArray(pattern));
+            List<CompletableFuture<List<String>>> futures = executorService.readAllAsync(StringCodec.INSTANCE, RedisCommands.KEYS, toByteArray(pattern));
+            CompletableFuture<Void> ff = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+            CompletableFuture<List<String>> future = ff.thenApply(r -> {
+                return futures.stream().flatMap(f -> f.getNow(new ArrayList<>()).stream()).collect(Collectors.toList());
+            }).toCompletableFuture();
+            return new CompletableFutureWrapper<>(future);
         });
         return m.map(v -> v.stream().map(t -> ByteBuffer.wrap(t.getBytes(CharsetUtil.UTF_8))).collect(Collectors.toList()));
     }

--- a/redisson-spring-data/redisson-spring-data-23/src/main/java/org/redisson/spring/data/connection/RedissonReactiveScriptingCommands.java
+++ b/redisson-spring-data/redisson-spring-data-23/src/main/java/org/redisson/spring/data/connection/RedissonReactiveScriptingCommands.java
@@ -47,7 +47,7 @@ public class RedissonReactiveScriptingCommands extends RedissonBaseReactive impl
     @Override
     public Mono<String> scriptFlush() {
         return executorService.reactive(() -> {
-            RFuture<Void> f = executorService.writeAllAsync(RedisCommands.SCRIPT_FLUSH);
+            RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.SCRIPT_FLUSH);
             return toStringFuture(f);
         });
     }
@@ -60,7 +60,7 @@ public class RedissonReactiveScriptingCommands extends RedissonBaseReactive impl
     @Override
     public Mono<String> scriptLoad(ByteBuffer script) {
         return executorService.reactive(() -> {
-            List<CompletableFuture<String>> futures = executorService.executeAll(RedisCommands.SCRIPT_LOAD, (Object)toByteArray(script));
+            List<CompletableFuture<String>> futures = executorService.executeAllAsync(RedisCommands.SCRIPT_LOAD, (Object)toByteArray(script));
             CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
             CompletableFuture<String> s = f.thenApply(r -> futures.get(0).getNow(null));
             return new CompletableFutureWrapper<>(s);
@@ -70,7 +70,7 @@ public class RedissonReactiveScriptingCommands extends RedissonBaseReactive impl
     @Override
     public Flux<Boolean> scriptExists(List<String> scriptShas) {
         Mono<List<Boolean>> m = executorService.reactive(() -> {
-            List<CompletableFuture<List<Boolean>>> futures = executorService.executeMasters(RedisCommands.SCRIPT_EXISTS, scriptShas.toArray());
+            List<CompletableFuture<List<Boolean>>> futures = executorService.writeAllAsync(RedisCommands.SCRIPT_EXISTS, scriptShas.toArray());
             CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
             CompletableFuture<List<Boolean>> s = f.thenApply(r -> {
                 List<Boolean> result = futures.get(0).getNow(new ArrayList<>());

--- a/redisson-spring-data/redisson-spring-data-24/src/main/java/org/redisson/spring/data/connection/RedissonReactiveClusterKeyCommands.java
+++ b/redisson-spring-data/redisson-spring-data-24/src/main/java/org/redisson/spring/data/connection/RedissonReactiveClusterKeyCommands.java
@@ -16,16 +16,18 @@
 package org.redisson.spring.data.connection;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import org.reactivestreams.Publisher;
-import org.redisson.api.RFuture;
 import org.redisson.client.codec.ByteArrayCodec;
 import org.redisson.client.codec.StringCodec;
 import org.redisson.client.protocol.RedisCommands;
 import org.redisson.connection.MasterSlaveEntry;
+import org.redisson.misc.CompletableFutureWrapper;
 import org.redisson.reactive.CommandReactiveExecutor;
 import org.springframework.data.redis.connection.ReactiveClusterKeyCommands;
 import org.springframework.data.redis.connection.ReactiveRedisConnection;
@@ -52,7 +54,12 @@ public class RedissonReactiveClusterKeyCommands extends RedissonReactiveKeyComma
     @Override
     public Mono<List<ByteBuffer>> keys(RedisClusterNode node, ByteBuffer pattern) {
         Mono<List<String>> m = executorService.reactive(() -> {
-            return (RFuture<List<String>>)(Object) executorService.readAllAsync(StringCodec.INSTANCE, RedisCommands.KEYS, toByteArray(pattern));
+            List<CompletableFuture<List<String>>> futures = executorService.readAllAsync(StringCodec.INSTANCE, RedisCommands.KEYS, toByteArray(pattern));
+            CompletableFuture<Void> ff = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+            CompletableFuture<List<String>> future = ff.thenApply(r -> {
+                return futures.stream().flatMap(f -> f.getNow(new ArrayList<>()).stream()).collect(Collectors.toList());
+            }).toCompletableFuture();
+            return new CompletableFutureWrapper<>(future);
         });
         return m.map(v -> v.stream().map(t -> ByteBuffer.wrap(t.getBytes(CharsetUtil.UTF_8))).collect(Collectors.toList()));
     }

--- a/redisson-spring-data/redisson-spring-data-24/src/main/java/org/redisson/spring/data/connection/RedissonReactiveScriptingCommands.java
+++ b/redisson-spring-data/redisson-spring-data-24/src/main/java/org/redisson/spring/data/connection/RedissonReactiveScriptingCommands.java
@@ -47,7 +47,7 @@ public class RedissonReactiveScriptingCommands extends RedissonBaseReactive impl
     @Override
     public Mono<String> scriptFlush() {
         return executorService.reactive(() -> {
-            RFuture<Void> f = executorService.writeAllAsync(RedisCommands.SCRIPT_FLUSH);
+            RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.SCRIPT_FLUSH);
             return toStringFuture(f);
         });
     }
@@ -60,7 +60,7 @@ public class RedissonReactiveScriptingCommands extends RedissonBaseReactive impl
     @Override
     public Mono<String> scriptLoad(ByteBuffer script) {
         return executorService.reactive(() -> {
-            List<CompletableFuture<String>> futures = executorService.executeAll(RedisCommands.SCRIPT_LOAD, toByteArray(script));
+            List<CompletableFuture<String>> futures = executorService.executeAllAsync(RedisCommands.SCRIPT_LOAD, toByteArray(script));
             CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
             CompletableFuture<String> s = f.thenApply(r -> futures.get(0).getNow(null));
             return new CompletableFutureWrapper<>(s);
@@ -70,7 +70,7 @@ public class RedissonReactiveScriptingCommands extends RedissonBaseReactive impl
     @Override
     public Flux<Boolean> scriptExists(List<String> scriptShas) {
         Mono<List<Boolean>> m = executorService.reactive(() -> {
-            List<CompletableFuture<List<Boolean>>> futures = executorService.executeMasters(RedisCommands.SCRIPT_EXISTS, scriptShas.toArray());
+            List<CompletableFuture<List<Boolean>>> futures = executorService.writeAllAsync(RedisCommands.SCRIPT_EXISTS, scriptShas.toArray());
             CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
             CompletableFuture<List<Boolean>> s = f.thenApply(r -> {
                 List<Boolean> result = futures.get(0).getNow(new ArrayList<>());

--- a/redisson-spring-data/redisson-spring-data-25/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring-data/redisson-spring-data-25/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -16,7 +16,6 @@
 package org.redisson.spring.data.connection;
 
 import org.redisson.Redisson;
-import org.redisson.SlotCallback;
 import org.redisson.api.BatchOptions;
 import org.redisson.api.BatchOptions.ExecutionMode;
 import org.redisson.api.BatchResult;
@@ -54,7 +53,7 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 import static org.redisson.client.protocol.RedisCommands.LRANGE;
 
@@ -234,9 +233,10 @@ public class RedissonConnection extends AbstractRedisConnection {
             return read(null, ByteArrayCodec.INSTANCE, KEYS, pattern);
         }
 
-        RFuture<Collection<byte[]>> f = executorService.readAllAsync(ByteArrayCodec.INSTANCE, KEYS, pattern);
-        CompletableFuture<Set<byte[]>> future = f.thenApply(r -> {
-            return (Set<byte[]>)new HashSet<>(r);
+        List<CompletableFuture<Set<byte[]>>> futures = executorService.readAllAsync(ByteArrayCodec.INSTANCE, KEYS, pattern);
+        CompletableFuture<Void> ff = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+        CompletableFuture<Set<byte[]>> future = ff.thenApply(r -> {
+            return futures.stream().flatMap(f -> f.getNow(new HashSet<>()).stream()).collect(Collectors.toSet());
         }).toCompletableFuture();
         return sync(new CompletableFutureWrapper<>(future));
     }
@@ -1725,20 +1725,12 @@ public class RedissonConnection extends AbstractRedisConnection {
         if (isQueueing()) {
             return read(null, StringCodec.INSTANCE, RedisCommands.DBSIZE);
         }
-        
-        RFuture<Long> f = executorService.readAllAsync(RedisCommands.DBSIZE, new SlotCallback<Long, Long>() {
-            AtomicLong results = new AtomicLong();
-            @Override
-            public void onSlotResult(Long result) {
-                results.addAndGet(result);
-            }
 
-            @Override
-            public Long onFinish() {
-                return results.get();
-            }
-        });
-        return sync(f);
+        List<CompletableFuture<Long>> futures = executorService.readAllAsync(RedisCommands.DBSIZE);
+        CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+        CompletableFuture<Long> s = f.thenApply(r -> futures.stream().mapToLong(v -> v.getNow(0L)).sum());
+        CompletableFutureWrapper<Long> ff = new CompletableFutureWrapper<>(s);
+        return sync(ff);
     }
 
     @Override
@@ -1748,13 +1740,13 @@ public class RedissonConnection extends AbstractRedisConnection {
             return;
         }
         
-        RFuture<Void> f = executorService.writeAllAsync(RedisCommands.FLUSHDB);
+        RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.FLUSHDB);
         sync(f);
     }
 
     @Override
     public void flushAll() {
-        RFuture<Void> f = executorService.writeAllAsync(RedisCommands.FLUSHALL);
+        RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.FLUSHALL);
         sync(f);
     }
 
@@ -1851,7 +1843,7 @@ public class RedissonConnection extends AbstractRedisConnection {
             throw new UnsupportedOperationException();
         }
 
-        RFuture<Void> f = executorService.writeAllAsync(RedisCommands.SCRIPT_FLUSH);
+        RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.SCRIPT_FLUSH);
         sync(f);
     }
 
@@ -1869,7 +1861,7 @@ public class RedissonConnection extends AbstractRedisConnection {
             throw new UnsupportedOperationException();
         }
 
-        List<CompletableFuture<String>> futures = executorService.executeAll(RedisCommands.SCRIPT_LOAD, (Object)script);
+        List<CompletableFuture<String>> futures = executorService.executeAllAsync(RedisCommands.SCRIPT_LOAD, (Object)script);
         CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
         CompletableFuture<String> s = f.thenApply(r -> futures.get(0).getNow(null));
         return sync(new CompletableFutureWrapper<>(s));
@@ -1881,7 +1873,7 @@ public class RedissonConnection extends AbstractRedisConnection {
             throw new UnsupportedOperationException();
         }
 
-        List<CompletableFuture<List<Boolean>>> futures = executorService.executeMasters(RedisCommands.SCRIPT_EXISTS, (Object[]) scriptShas);
+        List<CompletableFuture<List<Boolean>>> futures = executorService.writeAllAsync(RedisCommands.SCRIPT_EXISTS, (Object[]) scriptShas);
         CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
         CompletableFuture<List<Boolean>> s = f.thenApply(r -> {
             List<Boolean> result = futures.get(0).getNow(new ArrayList<>());

--- a/redisson-spring-data/redisson-spring-data-25/src/main/java/org/redisson/spring/data/connection/RedissonReactiveClusterKeyCommands.java
+++ b/redisson-spring-data/redisson-spring-data-25/src/main/java/org/redisson/spring/data/connection/RedissonReactiveClusterKeyCommands.java
@@ -16,16 +16,18 @@
 package org.redisson.spring.data.connection;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import org.reactivestreams.Publisher;
-import org.redisson.api.RFuture;
 import org.redisson.client.codec.ByteArrayCodec;
 import org.redisson.client.codec.StringCodec;
 import org.redisson.client.protocol.RedisCommands;
 import org.redisson.connection.MasterSlaveEntry;
+import org.redisson.misc.CompletableFutureWrapper;
 import org.redisson.reactive.CommandReactiveExecutor;
 import org.springframework.data.redis.connection.ReactiveClusterKeyCommands;
 import org.springframework.data.redis.connection.ReactiveRedisConnection;
@@ -52,7 +54,12 @@ public class RedissonReactiveClusterKeyCommands extends RedissonReactiveKeyComma
     @Override
     public Mono<List<ByteBuffer>> keys(RedisClusterNode node, ByteBuffer pattern) {
         Mono<List<String>> m = executorService.reactive(() -> {
-            return (RFuture<List<String>>)(Object) executorService.readAllAsync(StringCodec.INSTANCE, RedisCommands.KEYS, toByteArray(pattern));
+            List<CompletableFuture<List<String>>> futures = executorService.readAllAsync(StringCodec.INSTANCE, RedisCommands.KEYS, toByteArray(pattern));
+            CompletableFuture<Void> ff = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+            CompletableFuture<List<String>> future = ff.thenApply(r -> {
+                return futures.stream().flatMap(f -> f.getNow(new ArrayList<>()).stream()).collect(Collectors.toList());
+            }).toCompletableFuture();
+            return new CompletableFutureWrapper<>(future);
         });
         return m.map(v -> v.stream().map(t -> ByteBuffer.wrap(t.getBytes(CharsetUtil.UTF_8))).collect(Collectors.toList()));
     }

--- a/redisson-spring-data/redisson-spring-data-25/src/main/java/org/redisson/spring/data/connection/RedissonReactiveScriptingCommands.java
+++ b/redisson-spring-data/redisson-spring-data-25/src/main/java/org/redisson/spring/data/connection/RedissonReactiveScriptingCommands.java
@@ -47,7 +47,7 @@ public class RedissonReactiveScriptingCommands extends RedissonBaseReactive impl
     @Override
     public Mono<String> scriptFlush() {
         return executorService.reactive(() -> {
-            RFuture<Void> f = executorService.writeAllAsync(RedisCommands.SCRIPT_FLUSH);
+            RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.SCRIPT_FLUSH);
             return toStringFuture(f);
         });
     }
@@ -60,7 +60,7 @@ public class RedissonReactiveScriptingCommands extends RedissonBaseReactive impl
     @Override
     public Mono<String> scriptLoad(ByteBuffer script) {
         return executorService.reactive(() -> {
-            List<CompletableFuture<String>> futures = executorService.executeAll(RedisCommands.SCRIPT_LOAD, (Object)toByteArray(script));
+            List<CompletableFuture<String>> futures = executorService.executeAllAsync(RedisCommands.SCRIPT_LOAD, (Object)toByteArray(script));
             CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
             CompletableFuture<String> s = f.thenApply(r -> futures.get(0).getNow(null));
             return new CompletableFutureWrapper<>(s);
@@ -70,7 +70,7 @@ public class RedissonReactiveScriptingCommands extends RedissonBaseReactive impl
     @Override
     public Flux<Boolean> scriptExists(List<String> scriptShas) {
         Mono<List<Boolean>> m = executorService.reactive(() -> {
-            List<CompletableFuture<List<Boolean>>> futures = executorService.executeMasters(RedisCommands.SCRIPT_EXISTS, scriptShas.toArray());
+            List<CompletableFuture<List<Boolean>>> futures = executorService.writeAllAsync(RedisCommands.SCRIPT_EXISTS, scriptShas.toArray());
             CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
             CompletableFuture<List<Boolean>> s = f.thenApply(r -> {
                 List<Boolean> result = futures.get(0).getNow(new ArrayList<>());

--- a/redisson-spring-data/redisson-spring-data-25/src/main/java/org/redisson/spring/data/connection/RedissonReactiveServerCommands.java
+++ b/redisson-spring-data/redisson-spring-data-25/src/main/java/org/redisson/spring/data/connection/RedissonReactiveServerCommands.java
@@ -17,10 +17,9 @@ package org.redisson.spring.data.connection;
 
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
 
-import org.redisson.SlotCallback;
 import org.redisson.api.RFuture;
 import org.redisson.client.codec.LongCodec;
 import org.redisson.client.codec.StringCodec;
@@ -29,6 +28,7 @@ import org.redisson.client.protocol.RedisCommands;
 import org.redisson.client.protocol.RedisStrictCommand;
 import org.redisson.client.protocol.decoder.ObjectDecoder;
 import org.redisson.client.protocol.decoder.TimeLongObjectDecoder;
+import org.redisson.misc.CompletableFutureWrapper;
 import org.redisson.reactive.CommandReactiveExecutor;
 import org.springframework.data.redis.connection.ReactiveServerCommands;
 import org.springframework.data.redis.core.types.RedisClientInfo;
@@ -76,18 +76,10 @@ public class RedissonReactiveServerCommands extends RedissonBaseReactive impleme
     @Override
     public Mono<Long> dbSize() {
         return executorService.reactive(() -> {
-            return executorService.readAllAsync(RedisCommands.DBSIZE, new SlotCallback<Long, Long>() {
-                AtomicLong results = new AtomicLong();
-                @Override
-                public void onSlotResult(Long result) {
-                    results.addAndGet(result);
-                }
-                
-                @Override
-                public Long onFinish() {
-                    return results.get();
-                }
-            });
+            List<CompletableFuture<Long>> futures = executorService.readAllAsync(RedisCommands.DBSIZE);
+            CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+            CompletableFuture<Long> s = f.thenApply(r -> futures.stream().mapToLong(v -> v.getNow(0L)).sum());
+            return new CompletableFutureWrapper<>(s);
         });
     }
     
@@ -96,7 +88,7 @@ public class RedissonReactiveServerCommands extends RedissonBaseReactive impleme
     @Override
     public Mono<String> flushDb() {
         return executorService.reactive(() -> {
-            RFuture<Void> f = executorService.writeAllAsync(FLUSHDB);
+            RFuture<Void> f = executorService.writeAllVoidAsync(FLUSHDB);
             return toStringFuture(f);
         });
     }
@@ -106,7 +98,7 @@ public class RedissonReactiveServerCommands extends RedissonBaseReactive impleme
     @Override
     public Mono<String> flushAll() {
         return executorService.reactive(() -> {
-            RFuture<Void> f = executorService.writeAllAsync(FLUSHALL);
+            RFuture<Void> f = executorService.writeAllVoidAsync(FLUSHALL);
             return toStringFuture(f);
         });
     }

--- a/redisson-spring-data/redisson-spring-data-26/pom.xml
+++ b/redisson-spring-data/redisson-spring-data-26/pom.xml
@@ -30,7 +30,7 @@
                     <archive>  
                         <manifestEntries>
                             <Build-Time>${maven.build.timestamp}</Build-Time>
-                            <Automatic-Module-Name>redisson.spring.data25</Automatic-Module-Name>
+                            <Automatic-Module-Name>redisson.spring.data26</Automatic-Module-Name>
                         </manifestEntries>
                     </archive> 
                 </configuration>

--- a/redisson-spring-data/redisson-spring-data-26/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring-data/redisson-spring-data-26/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -16,7 +16,6 @@
 package org.redisson.spring.data.connection;
 
 import org.redisson.Redisson;
-import org.redisson.SlotCallback;
 import org.redisson.api.BatchOptions;
 import org.redisson.api.BatchOptions.ExecutionMode;
 import org.redisson.api.BatchResult;
@@ -54,7 +53,7 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 import static org.redisson.client.protocol.RedisCommands.LRANGE;
 
@@ -234,9 +233,10 @@ public class RedissonConnection extends AbstractRedisConnection {
             return read(null, ByteArrayCodec.INSTANCE, KEYS, pattern);
         }
 
-        RFuture<Collection<byte[]>> f = executorService.readAllAsync(ByteArrayCodec.INSTANCE, KEYS, pattern);
-        CompletableFuture<Set<byte[]>> future = f.thenApply(r -> {
-            return (Set<byte[]>)new HashSet<>(r);
+        List<CompletableFuture<Set<byte[]>>> futures = executorService.readAllAsync(ByteArrayCodec.INSTANCE, KEYS, pattern);
+        CompletableFuture<Void> ff = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+        CompletableFuture<Set<byte[]>> future = ff.thenApply(r -> {
+            return futures.stream().flatMap(f -> f.getNow(new HashSet<>()).stream()).collect(Collectors.toSet());
         }).toCompletableFuture();
         return sync(new CompletableFutureWrapper<>(future));
     }
@@ -1725,20 +1725,12 @@ public class RedissonConnection extends AbstractRedisConnection {
         if (isQueueing()) {
             return read(null, StringCodec.INSTANCE, RedisCommands.DBSIZE);
         }
-        
-        RFuture<Long> f = executorService.readAllAsync(RedisCommands.DBSIZE, new SlotCallback<Long, Long>() {
-            AtomicLong results = new AtomicLong();
-            @Override
-            public void onSlotResult(Long result) {
-                results.addAndGet(result);
-            }
 
-            @Override
-            public Long onFinish() {
-                return results.get();
-            }
-        });
-        return sync(f);
+        List<CompletableFuture<Long>> futures = executorService.readAllAsync(RedisCommands.DBSIZE);
+        CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+        CompletableFuture<Long> s = f.thenApply(r -> futures.stream().mapToLong(v -> v.getNow(0L)).sum());
+        CompletableFutureWrapper<Long> ff = new CompletableFutureWrapper<>(s);
+        return sync(ff);
     }
 
     @Override
@@ -1748,13 +1740,13 @@ public class RedissonConnection extends AbstractRedisConnection {
             return;
         }
         
-        RFuture<Void> f = executorService.writeAllAsync(RedisCommands.FLUSHDB);
+        RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.FLUSHDB);
         sync(f);
     }
 
     @Override
     public void flushAll() {
-        RFuture<Void> f = executorService.writeAllAsync(RedisCommands.FLUSHALL);
+        RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.FLUSHALL);
         sync(f);
     }
 
@@ -1851,7 +1843,7 @@ public class RedissonConnection extends AbstractRedisConnection {
             throw new UnsupportedOperationException();
         }
 
-        RFuture<Void> f = executorService.writeAllAsync(RedisCommands.SCRIPT_FLUSH);
+        RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.SCRIPT_FLUSH);
         sync(f);
     }
 
@@ -1869,7 +1861,7 @@ public class RedissonConnection extends AbstractRedisConnection {
             throw new UnsupportedOperationException();
         }
 
-        List<CompletableFuture<String>> futures = executorService.executeAll(RedisCommands.SCRIPT_LOAD, (Object)script);
+        List<CompletableFuture<String>> futures = executorService.executeAllAsync(RedisCommands.SCRIPT_LOAD, (Object)script);
         CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
         CompletableFuture<String> s = f.thenApply(r -> futures.get(0).getNow(null));
         return sync(new CompletableFutureWrapper<>(s));
@@ -1881,7 +1873,7 @@ public class RedissonConnection extends AbstractRedisConnection {
             throw new UnsupportedOperationException();
         }
 
-        List<CompletableFuture<List<Boolean>>> futures = executorService.executeMasters(RedisCommands.SCRIPT_EXISTS, (Object[]) scriptShas);
+        List<CompletableFuture<List<Boolean>>> futures = executorService.writeAllAsync(RedisCommands.SCRIPT_EXISTS, (Object[]) scriptShas);
         CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
         CompletableFuture<List<Boolean>> s = f.thenApply(r -> {
             List<Boolean> result = futures.get(0).getNow(new ArrayList<>());

--- a/redisson-spring-data/redisson-spring-data-26/src/main/java/org/redisson/spring/data/connection/RedissonReactiveClusterKeyCommands.java
+++ b/redisson-spring-data/redisson-spring-data-26/src/main/java/org/redisson/spring/data/connection/RedissonReactiveClusterKeyCommands.java
@@ -16,16 +16,18 @@
 package org.redisson.spring.data.connection;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import org.reactivestreams.Publisher;
-import org.redisson.api.RFuture;
 import org.redisson.client.codec.ByteArrayCodec;
 import org.redisson.client.codec.StringCodec;
 import org.redisson.client.protocol.RedisCommands;
 import org.redisson.connection.MasterSlaveEntry;
+import org.redisson.misc.CompletableFutureWrapper;
 import org.redisson.reactive.CommandReactiveExecutor;
 import org.springframework.data.redis.connection.ReactiveClusterKeyCommands;
 import org.springframework.data.redis.connection.ReactiveRedisConnection;
@@ -52,7 +54,12 @@ public class RedissonReactiveClusterKeyCommands extends RedissonReactiveKeyComma
     @Override
     public Mono<List<ByteBuffer>> keys(RedisClusterNode node, ByteBuffer pattern) {
         Mono<List<String>> m = executorService.reactive(() -> {
-            return (RFuture<List<String>>)(Object) executorService.readAllAsync(StringCodec.INSTANCE, RedisCommands.KEYS, toByteArray(pattern));
+            List<CompletableFuture<List<String>>> futures = executorService.readAllAsync(StringCodec.INSTANCE, RedisCommands.KEYS, toByteArray(pattern));
+            CompletableFuture<Void> ff = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+            CompletableFuture<List<String>> future = ff.thenApply(r -> {
+                return futures.stream().flatMap(f -> f.getNow(new ArrayList<>()).stream()).collect(Collectors.toList());
+            }).toCompletableFuture();
+            return new CompletableFutureWrapper<>(future);
         });
         return m.map(v -> v.stream().map(t -> ByteBuffer.wrap(t.getBytes(CharsetUtil.UTF_8))).collect(Collectors.toList()));
     }

--- a/redisson-spring-data/redisson-spring-data-26/src/main/java/org/redisson/spring/data/connection/RedissonReactiveScriptingCommands.java
+++ b/redisson-spring-data/redisson-spring-data-26/src/main/java/org/redisson/spring/data/connection/RedissonReactiveScriptingCommands.java
@@ -47,7 +47,7 @@ public class RedissonReactiveScriptingCommands extends RedissonBaseReactive impl
     @Override
     public Mono<String> scriptFlush() {
         return executorService.reactive(() -> {
-            RFuture<Void> f = executorService.writeAllAsync(RedisCommands.SCRIPT_FLUSH);
+            RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.SCRIPT_FLUSH);
             return toStringFuture(f);
         });
     }
@@ -60,7 +60,7 @@ public class RedissonReactiveScriptingCommands extends RedissonBaseReactive impl
     @Override
     public Mono<String> scriptLoad(ByteBuffer script) {
         return executorService.reactive(() -> {
-            List<CompletableFuture<String>> futures = executorService.executeAll(RedisCommands.SCRIPT_LOAD, (Object)toByteArray(script));
+            List<CompletableFuture<String>> futures = executorService.executeAllAsync(RedisCommands.SCRIPT_LOAD, (Object)toByteArray(script));
             CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
             CompletableFuture<String> s = f.thenApply(r -> futures.get(0).getNow(null));
             return new CompletableFutureWrapper<>(s);
@@ -70,7 +70,7 @@ public class RedissonReactiveScriptingCommands extends RedissonBaseReactive impl
     @Override
     public Flux<Boolean> scriptExists(List<String> scriptShas) {
         Mono<List<Boolean>> m = executorService.reactive(() -> {
-            List<CompletableFuture<List<Boolean>>> futures = executorService.executeMasters(RedisCommands.SCRIPT_EXISTS, scriptShas.toArray());
+            List<CompletableFuture<List<Boolean>>> futures = executorService.writeAllAsync(RedisCommands.SCRIPT_EXISTS, scriptShas.toArray());
             CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
             CompletableFuture<List<Boolean>> s = f.thenApply(r -> {
                 List<Boolean> result = futures.get(0).getNow(new ArrayList<>());

--- a/redisson-spring-data/redisson-spring-data-26/src/main/java/org/redisson/spring/data/connection/RedissonReactiveServerCommands.java
+++ b/redisson-spring-data/redisson-spring-data-26/src/main/java/org/redisson/spring/data/connection/RedissonReactiveServerCommands.java
@@ -17,10 +17,9 @@ package org.redisson.spring.data.connection;
 
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
 
-import org.redisson.SlotCallback;
 import org.redisson.api.RFuture;
 import org.redisson.client.codec.LongCodec;
 import org.redisson.client.codec.StringCodec;
@@ -29,6 +28,7 @@ import org.redisson.client.protocol.RedisCommands;
 import org.redisson.client.protocol.RedisStrictCommand;
 import org.redisson.client.protocol.decoder.ObjectDecoder;
 import org.redisson.client.protocol.decoder.TimeLongObjectDecoder;
+import org.redisson.misc.CompletableFutureWrapper;
 import org.redisson.reactive.CommandReactiveExecutor;
 import org.springframework.data.redis.connection.ReactiveServerCommands;
 import org.springframework.data.redis.core.types.RedisClientInfo;
@@ -76,18 +76,10 @@ public class RedissonReactiveServerCommands extends RedissonBaseReactive impleme
     @Override
     public Mono<Long> dbSize() {
         return executorService.reactive(() -> {
-            return executorService.readAllAsync(RedisCommands.DBSIZE, new SlotCallback<Long, Long>() {
-                AtomicLong results = new AtomicLong();
-                @Override
-                public void onSlotResult(Long result) {
-                    results.addAndGet(result);
-                }
-                
-                @Override
-                public Long onFinish() {
-                    return results.get();
-                }
-            });
+            List<CompletableFuture<Long>> futures = executorService.readAllAsync(RedisCommands.DBSIZE);
+            CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+            CompletableFuture<Long> s = f.thenApply(r -> futures.stream().mapToLong(v -> v.getNow(0L)).sum());
+            return new CompletableFutureWrapper<>(s);
         });
     }
     
@@ -96,7 +88,7 @@ public class RedissonReactiveServerCommands extends RedissonBaseReactive impleme
     @Override
     public Mono<String> flushDb() {
         return executorService.reactive(() -> {
-            RFuture<Void> f = executorService.writeAllAsync(FLUSHDB);
+            RFuture<Void> f = executorService.writeAllVoidAsync(FLUSHDB);
             return toStringFuture(f);
         });
     }
@@ -106,7 +98,7 @@ public class RedissonReactiveServerCommands extends RedissonBaseReactive impleme
     @Override
     public Mono<String> flushAll() {
         return executorService.reactive(() -> {
-            RFuture<Void> f = executorService.writeAllAsync(FLUSHALL);
+            RFuture<Void> f = executorService.writeAllVoidAsync(FLUSHALL);
             return toStringFuture(f);
         });
     }

--- a/redisson-spring-data/redisson-spring-data-27/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring-data/redisson-spring-data-27/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -16,7 +16,6 @@
 package org.redisson.spring.data.connection;
 
 import org.redisson.Redisson;
-import org.redisson.SlotCallback;
 import org.redisson.api.BatchOptions;
 import org.redisson.api.BatchOptions.ExecutionMode;
 import org.redisson.api.BatchResult;
@@ -54,7 +53,7 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 import static org.redisson.client.protocol.RedisCommands.LRANGE;
 
@@ -234,9 +233,10 @@ public class RedissonConnection extends AbstractRedisConnection {
             return read(null, ByteArrayCodec.INSTANCE, KEYS, pattern);
         }
 
-        RFuture<Collection<byte[]>> f = executorService.readAllAsync(ByteArrayCodec.INSTANCE, KEYS, pattern);
-        CompletableFuture<Set<byte[]>> future = f.thenApply(r -> {
-            return (Set<byte[]>)new HashSet<>(r);
+        List<CompletableFuture<Set<byte[]>>> futures = executorService.readAllAsync(ByteArrayCodec.INSTANCE, KEYS, pattern);
+        CompletableFuture<Void> ff = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+        CompletableFuture<Set<byte[]>> future = ff.thenApply(r -> {
+            return futures.stream().flatMap(f -> f.getNow(new HashSet<>()).stream()).collect(Collectors.toSet());
         }).toCompletableFuture();
         return sync(new CompletableFutureWrapper<>(future));
     }
@@ -1725,20 +1725,12 @@ public class RedissonConnection extends AbstractRedisConnection {
         if (isQueueing()) {
             return read(null, StringCodec.INSTANCE, RedisCommands.DBSIZE);
         }
-        
-        RFuture<Long> f = executorService.readAllAsync(RedisCommands.DBSIZE, new SlotCallback<Long, Long>() {
-            AtomicLong results = new AtomicLong();
-            @Override
-            public void onSlotResult(Long result) {
-                results.addAndGet(result);
-            }
 
-            @Override
-            public Long onFinish() {
-                return results.get();
-            }
-        });
-        return sync(f);
+        List<CompletableFuture<Long>> futures = executorService.readAllAsync(RedisCommands.DBSIZE);
+        CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+        CompletableFuture<Long> s = f.thenApply(r -> futures.stream().mapToLong(v -> v.getNow(0L)).sum());
+        CompletableFutureWrapper<Long> ff = new CompletableFutureWrapper<>(s);
+        return sync(ff);
     }
 
     @Override
@@ -1748,13 +1740,13 @@ public class RedissonConnection extends AbstractRedisConnection {
             return;
         }
         
-        RFuture<Void> f = executorService.writeAllAsync(RedisCommands.FLUSHDB);
+        RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.FLUSHDB);
         sync(f);
     }
 
     @Override
     public void flushAll() {
-        RFuture<Void> f = executorService.writeAllAsync(RedisCommands.FLUSHALL);
+        RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.FLUSHALL);
         sync(f);
     }
 
@@ -1851,7 +1843,7 @@ public class RedissonConnection extends AbstractRedisConnection {
             throw new UnsupportedOperationException();
         }
 
-        RFuture<Void> f = executorService.writeAllAsync(RedisCommands.SCRIPT_FLUSH);
+        RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.SCRIPT_FLUSH);
         sync(f);
     }
 
@@ -1869,7 +1861,7 @@ public class RedissonConnection extends AbstractRedisConnection {
             throw new UnsupportedOperationException();
         }
 
-        List<CompletableFuture<String>> futures = executorService.executeAll(RedisCommands.SCRIPT_LOAD, (Object)script);
+        List<CompletableFuture<String>> futures = executorService.executeAllAsync(RedisCommands.SCRIPT_LOAD, (Object)script);
         CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
         CompletableFuture<String> s = f.thenApply(r -> futures.get(0).getNow(null));
         return sync(new CompletableFutureWrapper<>(s));
@@ -1881,7 +1873,7 @@ public class RedissonConnection extends AbstractRedisConnection {
             throw new UnsupportedOperationException();
         }
 
-        List<CompletableFuture<List<Boolean>>> futures = executorService.executeMasters(RedisCommands.SCRIPT_EXISTS, (Object[]) scriptShas);
+        List<CompletableFuture<List<Boolean>>> futures = executorService.writeAllAsync(RedisCommands.SCRIPT_EXISTS, (Object[]) scriptShas);
         CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
         CompletableFuture<List<Boolean>> s = f.thenApply(r -> {
             List<Boolean> result = futures.get(0).getNow(new ArrayList<>());

--- a/redisson-spring-data/redisson-spring-data-27/src/main/java/org/redisson/spring/data/connection/RedissonReactiveClusterKeyCommands.java
+++ b/redisson-spring-data/redisson-spring-data-27/src/main/java/org/redisson/spring/data/connection/RedissonReactiveClusterKeyCommands.java
@@ -16,16 +16,18 @@
 package org.redisson.spring.data.connection;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import org.reactivestreams.Publisher;
-import org.redisson.api.RFuture;
 import org.redisson.client.codec.ByteArrayCodec;
 import org.redisson.client.codec.StringCodec;
 import org.redisson.client.protocol.RedisCommands;
 import org.redisson.connection.MasterSlaveEntry;
+import org.redisson.misc.CompletableFutureWrapper;
 import org.redisson.reactive.CommandReactiveExecutor;
 import org.springframework.data.redis.connection.ReactiveClusterKeyCommands;
 import org.springframework.data.redis.connection.ReactiveRedisConnection;
@@ -52,7 +54,12 @@ public class RedissonReactiveClusterKeyCommands extends RedissonReactiveKeyComma
     @Override
     public Mono<List<ByteBuffer>> keys(RedisClusterNode node, ByteBuffer pattern) {
         Mono<List<String>> m = executorService.reactive(() -> {
-            return (RFuture<List<String>>)(Object) executorService.readAllAsync(StringCodec.INSTANCE, RedisCommands.KEYS, toByteArray(pattern));
+            List<CompletableFuture<List<String>>> futures = executorService.readAllAsync(StringCodec.INSTANCE, RedisCommands.KEYS, toByteArray(pattern));
+            CompletableFuture<Void> ff = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+            CompletableFuture<List<String>> future = ff.thenApply(r -> {
+                return futures.stream().flatMap(f -> f.getNow(new ArrayList<>()).stream()).collect(Collectors.toList());
+            }).toCompletableFuture();
+            return new CompletableFutureWrapper<>(future);
         });
         return m.map(v -> v.stream().map(t -> ByteBuffer.wrap(t.getBytes(CharsetUtil.UTF_8))).collect(Collectors.toList()));
     }

--- a/redisson-spring-data/redisson-spring-data-27/src/main/java/org/redisson/spring/data/connection/RedissonReactiveScriptingCommands.java
+++ b/redisson-spring-data/redisson-spring-data-27/src/main/java/org/redisson/spring/data/connection/RedissonReactiveScriptingCommands.java
@@ -47,7 +47,7 @@ public class RedissonReactiveScriptingCommands extends RedissonBaseReactive impl
     @Override
     public Mono<String> scriptFlush() {
         return executorService.reactive(() -> {
-            RFuture<Void> f = executorService.writeAllAsync(RedisCommands.SCRIPT_FLUSH);
+            RFuture<Void> f = executorService.writeAllVoidAsync(RedisCommands.SCRIPT_FLUSH);
             return toStringFuture(f);
         });
     }
@@ -60,7 +60,7 @@ public class RedissonReactiveScriptingCommands extends RedissonBaseReactive impl
     @Override
     public Mono<String> scriptLoad(ByteBuffer script) {
         return executorService.reactive(() -> {
-            List<CompletableFuture<String>> futures = executorService.executeAll(RedisCommands.SCRIPT_LOAD, (Object)toByteArray(script));
+            List<CompletableFuture<String>> futures = executorService.executeAllAsync(RedisCommands.SCRIPT_LOAD, (Object)toByteArray(script));
             CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
             CompletableFuture<String> s = f.thenApply(r -> futures.get(0).getNow(null));
             return new CompletableFutureWrapper<>(s);
@@ -70,7 +70,7 @@ public class RedissonReactiveScriptingCommands extends RedissonBaseReactive impl
     @Override
     public Flux<Boolean> scriptExists(List<String> scriptShas) {
         Mono<List<Boolean>> m = executorService.reactive(() -> {
-            List<CompletableFuture<List<Boolean>>> futures = executorService.executeMasters(RedisCommands.SCRIPT_EXISTS, scriptShas.toArray());
+            List<CompletableFuture<List<Boolean>>> futures = executorService.writeAllAsync(RedisCommands.SCRIPT_EXISTS, scriptShas.toArray());
             CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
             CompletableFuture<List<Boolean>> s = f.thenApply(r -> {
                 List<Boolean> result = futures.get(0).getNow(new ArrayList<>());

--- a/redisson-spring-data/redisson-spring-data-27/src/main/java/org/redisson/spring/data/connection/RedissonReactiveServerCommands.java
+++ b/redisson-spring-data/redisson-spring-data-27/src/main/java/org/redisson/spring/data/connection/RedissonReactiveServerCommands.java
@@ -17,10 +17,9 @@ package org.redisson.spring.data.connection;
 
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
 
-import org.redisson.SlotCallback;
 import org.redisson.api.RFuture;
 import org.redisson.client.codec.LongCodec;
 import org.redisson.client.codec.StringCodec;
@@ -29,6 +28,7 @@ import org.redisson.client.protocol.RedisCommands;
 import org.redisson.client.protocol.RedisStrictCommand;
 import org.redisson.client.protocol.decoder.ObjectDecoder;
 import org.redisson.client.protocol.decoder.TimeLongObjectDecoder;
+import org.redisson.misc.CompletableFutureWrapper;
 import org.redisson.reactive.CommandReactiveExecutor;
 import org.springframework.data.redis.connection.ReactiveServerCommands;
 import org.springframework.data.redis.connection.RedisServerCommands;
@@ -77,18 +77,10 @@ public class RedissonReactiveServerCommands extends RedissonBaseReactive impleme
     @Override
     public Mono<Long> dbSize() {
         return executorService.reactive(() -> {
-            return executorService.readAllAsync(RedisCommands.DBSIZE, new SlotCallback<Long, Long>() {
-                AtomicLong results = new AtomicLong();
-                @Override
-                public void onSlotResult(Long result) {
-                    results.addAndGet(result);
-                }
-                
-                @Override
-                public Long onFinish() {
-                    return results.get();
-                }
-            });
+            List<CompletableFuture<Long>> futures = executorService.readAllAsync(RedisCommands.DBSIZE);
+            CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+            CompletableFuture<Long> s = f.thenApply(r -> futures.stream().mapToLong(v -> v.getNow(0L)).sum());
+            return new CompletableFutureWrapper<>(s);
         });
     }
     
@@ -97,7 +89,7 @@ public class RedissonReactiveServerCommands extends RedissonBaseReactive impleme
     @Override
     public Mono<String> flushDb() {
         return executorService.reactive(() -> {
-            RFuture<Void> f = executorService.writeAllAsync(FLUSHDB);
+            RFuture<Void> f = executorService.writeAllVoidAsync(FLUSHDB);
             return toStringFuture(f);
         });
     }
@@ -107,7 +99,7 @@ public class RedissonReactiveServerCommands extends RedissonBaseReactive impleme
     @Override
     public Mono<String> flushAll() {
         return executorService.reactive(() -> {
-            RFuture<Void> f = executorService.writeAllAsync(FLUSHALL);
+            RFuture<Void> f = executorService.writeAllVoidAsync(FLUSHALL);
             return toStringFuture(f);
         });
     }
@@ -116,7 +108,7 @@ public class RedissonReactiveServerCommands extends RedissonBaseReactive impleme
     public Mono<String> flushDb(RedisServerCommands.FlushOption option) {
         if (option == RedisServerCommands.FlushOption.ASYNC) {
             return executorService.reactive(() -> {
-                RFuture<Void> f = executorService.writeAllAsync(FLUSHDB, option.toString());
+                RFuture<Void> f = executorService.writeAllVoidAsync(FLUSHDB, option.toString());
                 return toStringFuture(f);
             });
         }
@@ -127,7 +119,7 @@ public class RedissonReactiveServerCommands extends RedissonBaseReactive impleme
     public Mono<String> flushAll(RedisServerCommands.FlushOption option) {
         if (option == RedisServerCommands.FlushOption.ASYNC) {
             return executorService.reactive(() -> {
-                RFuture<Void> f = executorService.writeAllAsync(FLUSHALL, option.toString());
+                RFuture<Void> f = executorService.writeAllVoidAsync(FLUSHALL, option.toString());
                 return toStringFuture(f);
             });
         }

--- a/redisson/src/main/java/org/redisson/Redisson.java
+++ b/redisson/src/main/java/org/redisson/Redisson.java
@@ -471,6 +471,16 @@ public class Redisson implements RedissonClient {
     }
 
     @Override
+    public RShardedTopic getShardedTopic(String name) {
+        return new RedissonShardedTopic(commandExecutor, name);
+    }
+
+    @Override
+    public RShardedTopic getShardedTopic(String name, Codec codec) {
+        return new RedissonShardedTopic(codec, commandExecutor, name);
+    }
+
+    @Override
     public RTopic getTopic(String name) {
         return new RedissonTopic(commandExecutor, name);
     }

--- a/redisson/src/main/java/org/redisson/RedissonFuction.java
+++ b/redisson/src/main/java/org/redisson/RedissonFuction.java
@@ -53,9 +53,7 @@ public class RedissonFuction implements RFunction {
 
     @Override
     public RFuture<Void> deleteAsync(String libraryName) {
-        List<CompletableFuture<Void>> futures = commandExecutor.executeMasters(RedisCommands.FUNCTION_DELETE, libraryName);
-        CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
-        return new CompletableFutureWrapper<>(f);
+        return commandExecutor.writeAllVoidAsync(RedisCommands.FUNCTION_DELETE, libraryName);
     }
 
     @Override
@@ -75,9 +73,7 @@ public class RedissonFuction implements RFunction {
 
     @Override
     public RFuture<Void> flushAsync() {
-        List<CompletableFuture<Void>> futures = commandExecutor.executeMasters(RedisCommands.FUNCTION_FLUSH);
-        CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
-        return new CompletableFutureWrapper<>(f);
+        return commandExecutor.writeAllVoidAsync(RedisCommands.FUNCTION_FLUSH);
     }
 
     @Override
@@ -87,7 +83,7 @@ public class RedissonFuction implements RFunction {
 
     @Override
     public RFuture<Void> killAsync() {
-        List<CompletableFuture<Void>> futures = commandExecutor.executeAll(RedisCommands.FUNCTION_KILL);
+        List<CompletableFuture<Void>> futures = commandExecutor.executeAllAsync(RedisCommands.FUNCTION_KILL);
         CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
         return new CompletableFutureWrapper<>(f);
     }
@@ -120,9 +116,7 @@ public class RedissonFuction implements RFunction {
 
     @Override
     public RFuture<Void> loadAsync(String libraryName, String code) {
-        List<CompletableFuture<Void>> futures = commandExecutor.executeMasters(RedisCommands.FUNCTION_LOAD, "Lua", libraryName, code);
-        CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
-        return new CompletableFutureWrapper<>(f);
+        return commandExecutor.writeAllVoidAsync(RedisCommands.FUNCTION_LOAD, "Lua", libraryName, code);
     }
 
     @Override
@@ -132,10 +126,8 @@ public class RedissonFuction implements RFunction {
 
     @Override
     public RFuture<Void> loadAndReplaceAsync(String libraryName, String code) {
-        List<CompletableFuture<Void>> futures = commandExecutor.executeMasters(RedisCommands.FUNCTION_LOAD,
+        return commandExecutor.writeAllVoidAsync(RedisCommands.FUNCTION_LOAD,
                                                 "Lua", libraryName, "REPLACE", code);
-        CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
-        return new CompletableFutureWrapper<>(f);
     }
 
     @Override
@@ -145,9 +137,7 @@ public class RedissonFuction implements RFunction {
 
     @Override
     public RFuture<Void> restoreAsync(byte[] payload) {
-        List<CompletableFuture<Void>> futures = commandExecutor.executeMasters(RedisCommands.FUNCTION_RESTORE, payload);
-        CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
-        return new CompletableFutureWrapper<>(f);
+        return commandExecutor.writeAllVoidAsync(RedisCommands.FUNCTION_RESTORE, payload);
     }
 
     @Override
@@ -157,9 +147,7 @@ public class RedissonFuction implements RFunction {
 
     @Override
     public RFuture<Void> restoreAndReplaceAsync(byte[] payload) {
-        List<CompletableFuture<Void>> futures = commandExecutor.executeMasters(RedisCommands.FUNCTION_RESTORE, payload, "REPLACE");
-        CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
-        return new CompletableFutureWrapper<>(f);
+        return commandExecutor.writeAllVoidAsync(RedisCommands.FUNCTION_RESTORE, payload, "REPLACE");
     }
 
     @Override
@@ -169,9 +157,7 @@ public class RedissonFuction implements RFunction {
 
     @Override
     public RFuture<Void> restoreAfterFlushAsync(byte[] payload) {
-        List<CompletableFuture<Void>> futures = commandExecutor.executeMasters(RedisCommands.FUNCTION_RESTORE, payload, "FLUSH");
-        CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
-        return new CompletableFutureWrapper<>(f);
+        return commandExecutor.writeAllVoidAsync(RedisCommands.FUNCTION_RESTORE, payload, "FLUSH");
     }
 
     private List<Object> encode(Collection<?> values, Codec codec) {

--- a/redisson/src/main/java/org/redisson/RedissonPatternTopic.java
+++ b/redisson/src/main/java/org/redisson/RedissonPatternTopic.java
@@ -120,19 +120,13 @@ public class RedissonPatternTopic implements RPatternTopic {
     
     @Override
     public void removeAllListeners() {
-        AsyncSemaphore semaphore = subscribeService.getSemaphore(channelName);
-        acquire(semaphore);
-        
-        PubSubConnectionEntry entry = subscribeService.getPubSubEntry(channelName);
-        if (entry == null) {
-            semaphore.release();
-            return;
-        }
+        commandExecutor.get(removeAllListenersAsync());
+    }
 
-        if (entry.hasListeners(channelName)) {
-            subscribeService.unsubscribe(PubSubType.PUNSUBSCRIBE, channelName).toCompletableFuture().join();
-        }
-        semaphore.release();
+    @Override
+    public RFuture<Void> removeAllListenersAsync() {
+        CompletableFuture<Void> f = subscribeService.removeAllListenersAsync(PubSubType.PUNSUBSCRIBE, channelName);
+        return new CompletableFutureWrapper<>(f);
     }
 
     @Override

--- a/redisson/src/main/java/org/redisson/RedissonReactive.java
+++ b/redisson/src/main/java/org/redisson/RedissonReactive.java
@@ -354,6 +354,20 @@ public class RedissonReactive implements RedissonReactiveClient {
     }
 
     @Override
+    public RShardedTopicReactive getShardedTopic(String name) {
+        RedissonShardedTopic topic = new RedissonShardedTopic(commandExecutor, name);
+        return ReactiveProxyBuilder.create(commandExecutor, topic,
+                new RedissonTopicReactive(topic), RShardedTopicReactive.class);
+    }
+
+    @Override
+    public RShardedTopicReactive getShardedTopic(String name, Codec codec) {
+        RedissonShardedTopic topic = new RedissonShardedTopic(codec, commandExecutor, name);
+        return ReactiveProxyBuilder.create(commandExecutor, topic,
+                new RedissonTopicReactive(topic), RShardedTopicReactive.class);
+    }
+
+    @Override
     public RTopicReactive getTopic(String name) {
         RedissonTopic topic = new RedissonTopic(commandExecutor, name);
         return ReactiveProxyBuilder.create(commandExecutor, topic,

--- a/redisson/src/main/java/org/redisson/RedissonRx.java
+++ b/redisson/src/main/java/org/redisson/RedissonRx.java
@@ -339,6 +339,18 @@ public class RedissonRx implements RedissonRxClient {
     }
 
     @Override
+    public RShardedTopicRx getShardedTopic(String name) {
+        RShardedTopic topic = new RedissonShardedTopic(commandExecutor, name);
+        return RxProxyBuilder.create(commandExecutor, topic, new RedissonTopicRx(topic), RShardedTopicRx.class);
+    }
+
+    @Override
+    public RShardedTopicRx getShardedTopic(String name, Codec codec) {
+        RShardedTopic topic = new RedissonShardedTopic(codec, commandExecutor, name);
+        return RxProxyBuilder.create(commandExecutor, topic, new RedissonTopicRx(topic), RShardedTopicRx.class);
+    }
+
+    @Override
     public RTopicRx getTopic(String name) {
         RTopic topic = new RedissonTopic(commandExecutor, name);
         return RxProxyBuilder.create(commandExecutor, topic, new RedissonTopicRx(topic), RTopicRx.class);

--- a/redisson/src/main/java/org/redisson/RedissonScript.java
+++ b/redisson/src/main/java/org/redisson/RedissonScript.java
@@ -58,7 +58,7 @@ public class RedissonScript implements RScript {
 
     @Override
     public RFuture<String> scriptLoadAsync(String luaScript) {
-        List<CompletableFuture<String>> futures = commandExecutor.executeAll(RedisCommands.SCRIPT_LOAD, luaScript);
+        List<CompletableFuture<String>> futures = commandExecutor.executeAllAsync(RedisCommands.SCRIPT_LOAD, luaScript);
         CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
         CompletableFuture<String> s = f.thenApply(r -> futures.get(0).getNow(null));
         return new CompletableFutureWrapper<>(s);
@@ -123,7 +123,7 @@ public class RedissonScript implements RScript {
 
     @Override
     public RFuture<Void> scriptKillAsync() {
-        return commandExecutor.writeAllAsync(RedisCommands.SCRIPT_KILL);
+        return commandExecutor.writeAllVoidAsync(RedisCommands.SCRIPT_KILL);
     }
 
     public RFuture<Void> scriptKillAsync(String key) {
@@ -137,7 +137,7 @@ public class RedissonScript implements RScript {
 
     @Override
     public RFuture<List<Boolean>> scriptExistsAsync(String... shaDigests) {
-        List<CompletableFuture<List<Boolean>>> futures = commandExecutor.executeAll(RedisCommands.SCRIPT_EXISTS, (Object[]) shaDigests);
+        List<CompletableFuture<List<Boolean>>> futures = commandExecutor.executeAllAsync(RedisCommands.SCRIPT_EXISTS, (Object[]) shaDigests);
         CompletableFuture<Void> f = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
         CompletableFuture<List<Boolean>> s = f.thenApply(r -> {
             List<Boolean> result = futures.get(0).getNow(new ArrayList<>());
@@ -171,7 +171,7 @@ public class RedissonScript implements RScript {
 
     @Override
     public RFuture<Void> scriptFlushAsync() {
-        return commandExecutor.writeAllAsync(RedisCommands.SCRIPT_FLUSH);
+        return commandExecutor.writeAllVoidAsync(RedisCommands.SCRIPT_FLUSH);
     }
 
     public RFuture<Void> scriptFlushAsync(String key) {

--- a/redisson/src/main/java/org/redisson/RedissonShardedTopic.java
+++ b/redisson/src/main/java/org/redisson/RedissonShardedTopic.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2013-2021 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson;
+
+import org.redisson.api.NameMapper;
+import org.redisson.api.RFuture;
+import org.redisson.api.RShardedTopic;
+import org.redisson.api.listener.MessageListener;
+import org.redisson.client.RedisPubSubListener;
+import org.redisson.client.codec.Codec;
+import org.redisson.client.codec.StringCodec;
+import org.redisson.client.protocol.RedisCommands;
+import org.redisson.client.protocol.pubsub.PubSubType;
+import org.redisson.command.CommandAsyncExecutor;
+import org.redisson.misc.CompletableFutureWrapper;
+import org.redisson.pubsub.PubSubConnectionEntry;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Sharded Topic for Redis Cluster. Messages are delivered to message listeners connected to the same Topic.
+ *
+ * @author Nikita Koksharov
+ *
+ */
+public class RedissonShardedTopic extends RedissonTopic implements RShardedTopic {
+
+    public RedissonShardedTopic(CommandAsyncExecutor commandExecutor, String name) {
+        super(commandExecutor, name);
+    }
+
+    public RedissonShardedTopic(Codec codec, CommandAsyncExecutor commandExecutor, String name) {
+        super(codec, commandExecutor, name);
+    }
+
+    public RedissonShardedTopic(Codec codec, CommandAsyncExecutor commandExecutor, NameMapper nameMapper, String name) {
+        super(codec, commandExecutor, nameMapper, name);
+    }
+
+    @Override
+    protected RFuture<Integer> addListenerAsync(RedisPubSubListener<?> pubSubListener) {
+        CompletableFuture<PubSubConnectionEntry> future = subscribeService.ssubscribe(codec, channelName, pubSubListener);
+        CompletableFuture<Integer> f = future.thenApply(res -> {
+            return System.identityHashCode(pubSubListener);
+        });
+        return new CompletableFutureWrapper<>(f);
+    }
+
+    @Override
+    public RFuture<Long> publishAsync(Object message) {
+        String name = getName(message);
+        return commandExecutor.writeAsync(name, StringCodec.INSTANCE, RedisCommands.SPUBLISH, name, commandExecutor.encode(codec, message));
+    }
+
+    @Override
+    public RFuture<Void> removeListenerAsync(MessageListener<?> listener) {
+        CompletableFuture<Void> f = subscribeService.removeListenerAsync(PubSubType.SUNSUBSCRIBE, channelName, listener);
+        return new CompletableFutureWrapper<>(f);
+    }
+
+    @Override
+    public RFuture<Void> removeListenerAsync(Integer... listenerIds) {
+        CompletableFuture<Void> f = subscribeService.removeListenerAsync(PubSubType.SUNSUBSCRIBE, channelName, listenerIds);
+        return new CompletableFutureWrapper<>(f);
+    }
+
+    public RFuture<Void> removeAllListenersAsync() {
+        CompletableFuture<Void> f = subscribeService.removeAllListenersAsync(PubSubType.SUNSUBSCRIBE, channelName);
+        return new CompletableFutureWrapper<>(f);
+    }
+
+    @Override
+    public RFuture<Long> countSubscribersAsync() {
+        throw new UnsupportedOperationException("Sharded PUBSUB doesn't support this operation");
+    }
+}

--- a/redisson/src/main/java/org/redisson/RedissonTopic.java
+++ b/redisson/src/main/java/org/redisson/RedissonTopic.java
@@ -46,7 +46,7 @@ public class RedissonTopic implements RTopic {
 
     final PublishSubscribeService subscribeService;
     final CommandAsyncExecutor commandExecutor;
-    private final String name;
+    final String name;
     final ChannelName channelName;
     final Codec codec;
 

--- a/redisson/src/main/java/org/redisson/api/RPatternTopic.java
+++ b/redisson/src/main/java/org/redisson/api/RPatternTopic.java
@@ -75,6 +75,13 @@ public interface RPatternTopic {
      * Removes all listeners from this topic
      */
     void removeAllListeners();
+
+    /**
+     * Removes all listeners from this topic
+     *
+     * @return void
+     */
+    RFuture<Void> removeAllListenersAsync();
     
     RFuture<Integer> addListenerAsync(PatternStatusListener listener);
     

--- a/redisson/src/main/java/org/redisson/api/RShardedTopic.java
+++ b/redisson/src/main/java/org/redisson/api/RShardedTopic.java
@@ -13,20 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.redisson.client.protocol.pubsub;
+package org.redisson.api;
 
 /**
- * 
+ * Sharded Topic for Redis Cluster. Messages are delivered to message listeners connected to the same Topic.
+ *
  * @author Nikita Koksharov
  *
  */
-public enum PubSubType {
-
-    SUBSCRIBE,
-    PSUBSCRIBE,
-    SSUBSCRIBE,
-    PUNSUBSCRIBE,
-    UNSUBSCRIBE,
-    SUNSUBSCRIBE
-
+public interface RShardedTopic extends RTopic, RShardedTopicAsync {
 }

--- a/redisson/src/main/java/org/redisson/api/RShardedTopicAsync.java
+++ b/redisson/src/main/java/org/redisson/api/RShardedTopicAsync.java
@@ -13,20 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.redisson.client.protocol.pubsub;
+package org.redisson.api;
 
 /**
- * 
+ * Sharded Topic for Redis Cluster. Messages are delivered to message listeners connected to the same Topic.
+ *
  * @author Nikita Koksharov
  *
  */
-public enum PubSubType {
-
-    SUBSCRIBE,
-    PSUBSCRIBE,
-    SSUBSCRIBE,
-    PUNSUBSCRIBE,
-    UNSUBSCRIBE,
-    SUNSUBSCRIBE
-
+public interface RShardedTopicAsync extends RTopicAsync {
 }

--- a/redisson/src/main/java/org/redisson/api/RShardedTopicReactive.java
+++ b/redisson/src/main/java/org/redisson/api/RShardedTopicReactive.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2013-2021 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.api;
+
+import org.redisson.api.listener.MessageListener;
+import org.redisson.api.listener.StatusListener;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+/**
+ * Reactive interface for Sharded Topic. Messages are delivered to message listeners connected to the same Topic.
+ *
+ * @author Nikita Koksharov
+ *
+ */
+public interface RShardedTopicReactive {
+
+    /**
+     * Get topic channel names
+     *
+     * @return channel names
+     */
+    List<String> getChannelNames();
+
+    /**
+     * Publish the message to all subscribers of this topic asynchronously
+     *
+     * @param message to send
+     * @return the <code>Future</code> object with number of clients that received the message
+     */
+    Mono<Long> publish(Object message);
+
+    /**
+     * Subscribes to status changes of this topic
+     *
+     * @param listener for messages
+     * @return listener id
+     * @see org.redisson.api.listener.StatusListener
+     */
+    Mono<Integer> addListener(StatusListener listener);
+
+    /**
+     * Subscribes to this topic.
+     * <code>MessageListener.onMessage</code> is called when any message
+     * is published on this topic.
+     *
+     * @param <M> type of message
+     * @param type - type of message
+     * @param listener for messages
+     * @return locally unique listener id
+     * @see org.redisson.api.listener.MessageListener
+     */
+    <M> Mono<Integer> addListener(Class<M> type, MessageListener<M> listener);
+
+    /**
+     * Removes the listener by <code>id</code> for listening this topic
+     *
+     * @param listenerIds - message listener ids
+     * @return void
+     */
+    Mono<Void> removeListener(Integer... listenerIds);
+
+    /**
+     * Removes the listener by <code>instance</code> for listening this topic
+     *
+     * @param listener - message listener
+     * @return void
+     */
+    Mono<Void> removeListener(MessageListener<?> listener);
+
+    /**
+     * Returns continues stream of published messages.
+     *
+     * @param <M> type of message
+     * @param type - type of message to listen
+     * @return stream of messages
+     */
+    <M> Flux<M> getMessages(Class<M> type);
+
+    /**
+     * Removes all listeners from this topic
+     *
+     * @return void
+     */
+    Mono<Void> removeAllListeners();
+
+}

--- a/redisson/src/main/java/org/redisson/api/RShardedTopicRx.java
+++ b/redisson/src/main/java/org/redisson/api/RShardedTopicRx.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2013-2021 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.api;
+
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Single;
+import org.redisson.api.listener.MessageListener;
+import org.redisson.api.listener.StatusListener;
+
+import java.util.List;
+
+/**
+ * RxJava3 interface for Sharded Topic. Messages are delivered to message listeners connected to the same Topic.
+ *
+ * @author Nikita Koksharov
+ *
+ */
+public interface RShardedTopicRx {
+
+    /**
+     * Get topic channel names
+     *
+     * @return channel names
+     */
+    List<String> getChannelNames();
+
+    /**
+     * Publish the message to all subscribers of this topic asynchronously
+     *
+     * @param message to send
+     * @return the <code>Future</code> object with number of clients that received the message
+     */
+    Single<Long> publish(Object message);
+
+    /**
+     * Subscribes to status changes of this topic
+     *
+     * @param listener for messages
+     * @return listener id
+     * @see org.redisson.api.listener.StatusListener
+     */
+    Single<Integer> addListener(StatusListener listener);
+
+    /**
+     * Subscribes to this topic.
+     * <code>MessageListener.onMessage</code> is called when any message
+     * is published on this topic.
+     *
+     * @param <M> - type of message
+     * @param type - type of message
+     * @param listener for messages
+     * @return locally unique listener id
+     * @see org.redisson.api.listener.MessageListener
+     */
+    <M> Single<Integer> addListener(Class<M> type, MessageListener<M> listener);
+
+    /**
+     * Removes the listener by <code>id</code> for listening this topic
+     *
+     * @param listenerIds - message listener ids
+     * @return void
+     */
+    Completable removeListener(Integer... listenerIds);
+
+    /**
+     * Removes the listener by <code>instance</code> for listening this topic
+     *
+     * @param listener - message listener
+     * @return void
+     */
+    Completable removeListener(MessageListener<?> listener);
+
+    /**
+     * Returns continues stream of published messages.
+     *
+     * @param <M> - type of message
+     * @param type - type of message to listen
+     * @return stream of messages
+     */
+    <M> Flowable<M> getMessages(Class<M> type);
+
+    /**
+     * Returns amount of subscribers to this topic across all Redisson instances.
+     * Each subscriber may have multiple listeners.
+     *
+     * @return amount of subscribers
+     */
+    Single<Long> countSubscribers();
+
+    /**
+     * Removes all listeners from this topic
+     *
+     * @return void
+     */
+    Completable removeAllListeners();
+
+}

--- a/redisson/src/main/java/org/redisson/api/RedissonClient.java
+++ b/redisson/src/main/java/org/redisson/api/RedissonClient.java
@@ -610,9 +610,32 @@ public interface RedissonClient {
     RLexSortedSet getLexSortedSet(String name);
 
     /**
+     * Returns Sharded Topic instance by name.
+     * <p>
+     * Messages are delivered to message listeners connected to the same Topic.
+     * <p>
+     *
+     * @param name - name of object
+     * @return Topic object
+     */
+    RShardedTopic getShardedTopic(String name);
+
+    /**
+     * Returns Sharded Topic instance by name using provided codec for messages.
+     * <p>
+     * Messages are delivered to message listeners connected to the same Topic.
+     * <p>
+     *
+     * @param name - name of object
+     * @param codec - codec for message
+     * @return Topic object
+     */
+    RShardedTopic getShardedTopic(String name, Codec codec);
+
+    /**
      * Returns topic instance by name.
      * <p>
-     * Messages are delivered to all listeners attached to the same Redis setup.
+     * Messages are delivered to message listeners connected to the same Topic.
      * <p>
      *
      * @param name - name of object
@@ -624,7 +647,7 @@ public interface RedissonClient {
      * Returns topic instance by name
      * using provided codec for messages.
      * <p>
-     * Messages are delivered to all listeners attached to the same Redis setup.
+     * Messages are delivered to message listeners connected to the same Topic.
      * <p>
      *
      * @param name - name of object

--- a/redisson/src/main/java/org/redisson/api/RedissonReactiveClient.java
+++ b/redisson/src/main/java/org/redisson/api/RedissonReactiveClient.java
@@ -586,6 +586,29 @@ public interface RedissonReactiveClient {
     RLexSortedSetReactive getLexSortedSet(String name);
 
     /**
+     * Returns Sharded Topic instance by name.
+     * <p>
+     * Messages are delivered to message listeners connected to the same Topic.
+     * <p>
+     *
+     * @param name - name of object
+     * @return Topic object
+     */
+    RShardedTopicReactive getShardedTopic(String name);
+
+    /**
+     * Returns Sharded Topic instance by name using provided codec for messages.
+     * <p>
+     * Messages are delivered to message listeners connected to the same Topic.
+     * <p>
+     *
+     * @param name - name of object
+     * @param codec - codec for message
+     * @return Topic object
+     */
+    RShardedTopicReactive getShardedTopic(String name, Codec codec);
+
+    /**
      * Returns topic instance by name.
      *
      * @param name - name of object

--- a/redisson/src/main/java/org/redisson/api/RedissonRxClient.java
+++ b/redisson/src/main/java/org/redisson/api/RedissonRxClient.java
@@ -576,6 +576,29 @@ public interface RedissonRxClient {
     RLexSortedSetRx getLexSortedSet(String name);
 
     /**
+     * Returns Sharded Topic instance by name.
+     * <p>
+     * Messages are delivered to message listeners connected to the same Topic.
+     * <p>
+     *
+     * @param name - name of object
+     * @return Topic object
+     */
+    RShardedTopicRx getShardedTopic(String name);
+
+    /**
+     * Returns Sharded Topic instance by name using provided codec for messages.
+     * <p>
+     * Messages are delivered to message listeners connected to the same Topic.
+     * <p>
+     *
+     * @param name - name of object
+     * @param codec - codec for message
+     * @return Topic object
+     */
+    RShardedTopicRx getShardedTopic(String name, Codec codec);
+
+    /**
      * Returns topic instance by name.
      *
      * @param name - name of object

--- a/redisson/src/main/java/org/redisson/cache/LocalCacheListener.java
+++ b/redisson/src/main/java/org/redisson/cache/LocalCacheListener.java
@@ -247,6 +247,10 @@ public abstract class LocalCacheListener {
     
     public RFuture<Void> clearLocalCacheAsync() {
         cache.clear();
+        if (syncListenerId == 0) {
+            return new CompletableFutureWrapper<>((Void) null);
+        }
+
         byte[] id = generateId();
         RFuture<Long> future = invalidationTopic.publishAsync(new LocalCachedMapClear(instanceId, id, true));
         CompletionStage<Void> f = future.thenCompose(res -> {

--- a/redisson/src/main/java/org/redisson/client/protocol/RedisCommands.java
+++ b/redisson/src/main/java/org/redisson/client/protocol/RedisCommands.java
@@ -597,16 +597,21 @@ public interface RedisCommands {
     RedisStrictCommand<Void> QUIT = new RedisStrictCommand<Void>("QUIT", new VoidReplayConvertor());
 
     RedisStrictCommand<Long> PUBLISH = new RedisStrictCommand<Long>("PUBLISH");
+
+    RedisStrictCommand<Long> SPUBLISH = new RedisStrictCommand<Long>("SPUBLISH");
     RedisCommand<Long> PUBSUB_NUMSUB = new RedisCommand<Long>("PUBSUB", "NUMSUB", new ListObjectDecoder<Long>(1));
     RedisCommand<List<String>> PUBSUB_CHANNELS = new RedisStrictCommand<>("PUBSUB", "CHANNELS", new StringListReplayDecoder());
 
+    RedisCommand<Object> SSUBSCRIBE = new RedisCommand<Object>("SSUBSCRIBE", new PubSubStatusDecoder());
     RedisCommand<Object> SUBSCRIBE = new RedisCommand<Object>("SUBSCRIBE", new PubSubStatusDecoder());
     RedisCommand<Object> UNSUBSCRIBE = new RedisCommand<Object>("UNSUBSCRIBE", new PubSubStatusDecoder());
+    RedisCommand<Object> SUNSUBSCRIBE = new RedisCommand<Object>("SUNSUBSCRIBE", new PubSubStatusDecoder());
     RedisCommand<Object> PSUBSCRIBE = new RedisCommand<Object>("PSUBSCRIBE", new PubSubStatusDecoder());
     RedisCommand<Object> PUNSUBSCRIBE = new RedisCommand<Object>("PUNSUBSCRIBE", new PubSubStatusDecoder());
 
     Set<String> PUBSUB_COMMANDS = new HashSet<String>(
-            Arrays.asList(PSUBSCRIBE.getName(), SUBSCRIBE.getName(), PUNSUBSCRIBE.getName(), UNSUBSCRIBE.getName()));
+            Arrays.asList(PSUBSCRIBE.getName(), SUBSCRIBE.getName(), PUNSUBSCRIBE.getName(),
+                            UNSUBSCRIBE.getName(), SSUBSCRIBE.getName(), SUNSUBSCRIBE.getName()));
 
     Set<String> SCAN_COMMANDS = new HashSet<String>(
             Arrays.asList(HSCAN.getName(), SCAN.getName(), ZSCAN.getName(), SSCAN.getName()));

--- a/redisson/src/main/java/org/redisson/command/CommandAsyncExecutor.java
+++ b/redisson/src/main/java/org/redisson/command/CommandAsyncExecutor.java
@@ -27,7 +27,6 @@ import org.redisson.connection.MasterSlaveEntry;
 import org.redisson.connection.NodeSource;
 import org.redisson.liveobject.core.RedissonObjectBuilder;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -71,17 +70,13 @@ public interface CommandAsyncExecutor {
     
     <T, R> RFuture<R> readAsync(RedisClient client, Codec codec, RedisCommand<T> command, Object... params);
 
-    <R> List<CompletableFuture<R>> executeAll(RedisCommand<?> command, Object... params);
+    <R> List<CompletableFuture<R>> executeAllAsync(RedisCommand<?> command, Object... params);
 
-    <R> List<CompletableFuture<R>> executeMasters(RedisCommand<?> command, Object... params);
+    <R> List<CompletableFuture<R>> writeAllAsync(RedisCommand<?> command, Object... params);
 
-    <R> List<CompletableFuture<R>> executeRead(Codec codec, RedisCommand<?> command, Object... params);
+    <R> List<CompletableFuture<R>> readAllAsync(Codec codec, RedisCommand<?> command, Object... params);
 
-    <R> List<CompletableFuture<R>> executeRead(RedisCommand<?> command, Object... params);
-
-    <T, R> RFuture<Collection<R>> readAllAsync(Codec codec, RedisCommand<T> command, Object... params);
-    
-    <R, T> RFuture<R> readAllAsync(RedisCommand<T> command, SlotCallback<T, R> callback, Object... params);
+    <R> List<CompletableFuture<R>> readAllAsync(RedisCommand<?> command, Object... params);
 
     <T, R> RFuture<R> evalReadAsync(RedisClient client, String name, Codec codec, RedisCommand<T> evalCommandType, String script, List<Object> keys, Object... params);
 
@@ -101,7 +96,7 @@ public interface CommandAsyncExecutor {
 
     <T, R> RFuture<R> writeAsync(String key, Codec codec, RedisCommand<T> command, Object... params);
 
-    <T> RFuture<Void> writeAllAsync(RedisCommand<T> command, Object... params);
+    <T> RFuture<Void> writeAllVoidAsync(RedisCommand<T> command, Object... params);
 
     <T, R> RFuture<R> writeAsync(String key, RedisCommand<T> command, Object... params);
 

--- a/redisson/src/main/java/org/redisson/command/CommandAsyncExecutor.java
+++ b/redisson/src/main/java/org/redisson/command/CommandAsyncExecutor.java
@@ -75,6 +75,10 @@ public interface CommandAsyncExecutor {
 
     <R> List<CompletableFuture<R>> executeMasters(RedisCommand<?> command, Object... params);
 
+    <R> List<CompletableFuture<R>> executeRead(Codec codec, RedisCommand<?> command, Object... params);
+
+    <R> List<CompletableFuture<R>> executeRead(RedisCommand<?> command, Object... params);
+
     <T, R> RFuture<Collection<R>> readAllAsync(Codec codec, RedisCommand<T> command, Object... params);
     
     <R, T> RFuture<R> readAllAsync(RedisCommand<T> command, SlotCallback<T, R> callback, Object... params);

--- a/redisson/src/main/java/org/redisson/command/CommandAsyncService.java
+++ b/redisson/src/main/java/org/redisson/command/CommandAsyncService.java
@@ -594,13 +594,14 @@ public class CommandAsyncService implements CommandAsyncExecutor {
         }
 
         CompletableFuture<Void> future = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
-        CompletableFuture<R> result = future.whenComplete((res, e) -> {
+        CompletableFuture<R> result = future.thenApply(r -> {
             futures.forEach(f -> {
                 if (!f.isCompletedExceptionally() && f.getNow(null) != null) {
                     callback.onSlotResult((T) f.getNow(null));
                 }
             });
-        }).thenApply(r -> callback.onFinish());
+            return callback.onFinish();
+        });
 
         return new CompletableFutureWrapper<>(result);
     }

--- a/redisson/src/main/java/org/redisson/command/CommandBatchService.java
+++ b/redisson/src/main/java/org/redisson/command/CommandBatchService.java
@@ -184,7 +184,7 @@ public class CommandBatchService extends CommandAsyncService {
 
         executed.set(true);
         if (isRedisBasedQueue()) {
-            return writeAllAsync(RedisCommands.DISCARD);
+            return writeAllVoidAsync(RedisCommands.DISCARD);
         }
 
         commands.values().stream()

--- a/redisson/src/main/java/org/redisson/connection/SentinelConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/SentinelConnectionManager.java
@@ -63,6 +63,15 @@ public class SentinelConnectionManager extends MasterSlaveConnectionManager {
     private String scheme;
     private final SentinelServersConfig cfg;
 
+    /**
+     * save all ips resolved from hostnames.
+     */
+    private Map<String,List<RedisURI>> urisFromDNS = new ConcurrentHashMap<>();
+    /**
+     * Mark if all redis Sentinels are dead. 0 indicates alive.
+     */
+    private int sentinelFlag = 0;
+
     public SentinelConnectionManager(SentinelServersConfig cfg, Config config, UUID id) {
         super(config, id);
         
@@ -294,10 +303,31 @@ public class SentinelConnectionManager extends MasterSlaveConnectionManager {
                     return;
                 }
 
-                future.getNow().stream()
-                        .map(addr -> toURI(addr))
-                        .filter(uri -> !sentinels.containsKey(uri))
-                        .forEach(uri -> registerSentinel(uri, getConfig(), host.getHost()));
+                // get all uris
+                List<RedisURI> urisFromAddr = future.getNow().stream()
+                        .map(this::toURI)
+                        .collect(Collectors.toList());
+
+                // If the hostname is not already in urisFromDNS, add the hostname and IP address.
+                // If the hostname already exists, the old IP of the hostname is obtained as 'oldUris'.
+                List<RedisURI> oldUris = urisFromDNS.putIfAbsent(host.toString(), urisFromAddr);
+
+                // If ordUris is not null, compare the old and new IPs. If they are inconsistent, replace the old one with the new one and call registerSentinel.
+                if (oldUris != null && !oldUris.equals(urisFromAddr)) {
+                    urisFromDNS.replace(host.toString(), urisFromAddr);
+                    urisFromAddr.forEach(uri -> registerSentinel(uri, getConfig(), host.getHost()));
+                    log.info("change ips of hostname, the new ips are " + urisFromAddr.toString());
+                }
+
+                // With K8S, it's possible that all redis Sentinels' pods are dead, but the Service is still alive,
+                // and Redisson needs to be able to sense when the sentinels' pods are pulled up by k8s.
+                // So when sentinelFlag==1 (all the sentinels' pods are dead), the hostname should be constantly resolved to add the proxy IP to the 'sentinels',
+                // and look for other restart sentinels based on this IP.
+                if(sentinelFlag==1){
+                    urisFromAddr.forEach(uri -> registerSentinel(uri, getConfig(), host.getHost()));
+                    sentinelFlag = 0;
+                    log.info("All of redis sentinels have been down. Redisson is waiting for resurgence of redis sentinels");
+                }
             });
             if (commonListener != null) {
                 allNodes.addListener(commonListener);
@@ -327,6 +357,7 @@ public class SentinelConnectionManager extends MasterSlaveConnectionManager {
             if (lastException.get() != null) {
                 log.error("Can't update cluster state", lastException.get());
             }
+            sentinelFlag = 1;
             performSentinelDNSCheck(null);
             scheduleChangeCheck(cfg, null);
             return;

--- a/redisson/src/main/java/org/redisson/misc/RedisURI.java
+++ b/redisson/src/main/java/org/redisson/misc/RedisURI.java
@@ -32,6 +32,8 @@ public class RedisURI {
     private final boolean ssl;
     private final String host;
     private final int port;
+    private String username;
+    private String password;
 
     public RedisURI(String scheme, String host, int port) {
         this.ssl = "rediss".equals(scheme);
@@ -56,6 +58,15 @@ public class RedisURI {
 
         try {
             URL url = new URL(urlHost);
+            if (url.getUserInfo() != null) {
+                String[] details = url.getUserInfo().split(":", 2);
+                if (details.length == 2) {
+                    if (!details[0].isEmpty()) {
+                        username = details[0];
+                    }
+                    password = details[1];
+                }
+            }
             host = url.getHost();
             port = url.getPort();
             ssl = uri.startsWith("rediss://");
@@ -70,7 +81,15 @@ public class RedisURI {
         }
         return "redis";
     }
-    
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
     public boolean isSsl() {
         return ssl;
     }

--- a/redisson/src/main/java/org/redisson/misc/RedisURI.java
+++ b/redisson/src/main/java/org/redisson/misc/RedisURI.java
@@ -20,6 +20,7 @@ import io.netty.util.NetUtil;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Objects;
 
 /**
  * 
@@ -103,35 +104,16 @@ public class RedisURI {
     }
 
     @Override
-    @SuppressWarnings("AvoidInlineConditionals")
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((host == null) ? 0 : host.hashCode());
-        result = prime * result + port;
-        result = prime * result + (ssl ? 1231 : 1237);
-        return result;
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RedisURI redisURI = (RedisURI) o;
+        return ssl == redisURI.ssl && port == redisURI.port && Objects.equals(host, redisURI.host);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        RedisURI other = (RedisURI) obj;
-        if (host == null) {
-            if (other.host != null)
-                return false;
-        } else if (!host.equals(other.host))
-            return false;
-        if (port != other.port)
-            return false;
-        if (ssl != other.ssl)
-            return false;
-        return true;
+    public int hashCode() {
+        return Objects.hash(ssl, host, port);
     }
 
     @Override

--- a/redisson/src/main/java/org/redisson/pubsub/PubSubConnectionEntry.java
+++ b/redisson/src/main/java/org/redisson/pubsub/PubSubConnectionEntry.java
@@ -158,10 +158,12 @@ public class PubSubConnectionEntry {
 
     public void subscribe(Codec codec, PubSubType type, ChannelName channelName, CompletableFuture<Void> subscribeFuture) {
         ChannelFuture future;
-        if (PubSubType.PSUBSCRIBE == type) {
-            future = conn.psubscribe(codec, channelName);
-        } else {
+        if (PubSubType.SUBSCRIBE == type) {
             future = conn.subscribe(codec, channelName);
+        } else if (PubSubType.SSUBSCRIBE == type) {
+            future = conn.ssubscribe(codec, channelName);
+        } else {
+            future = conn.psubscribe(codec, channelName);
         }
 
         future.addListener((ChannelFutureListener) future1 -> {

--- a/redisson/src/main/java/org/redisson/pubsub/PublishSubscribeService.java
+++ b/redisson/src/main/java/org/redisson/pubsub/PublishSubscribeService.java
@@ -309,7 +309,7 @@ public class PublishSubscribeService {
             CompletableFuture<Void> subscribeFuture = addListeners(channelName, promise, type, lock, freeEntry, listeners);
             freeEntry.subscribe(codec, type, channelName, subscribeFuture);
             subscribeFuture.whenComplete((r, e) -> {
-                if (e instanceof RedisTimeoutException) {
+                if (e != null) {
                     unsubscribe(channelName, type);
                 }
             });
@@ -410,6 +410,11 @@ public class PublishSubscribeService {
 
                 CompletableFuture<Void> subscribeFuture = addListeners(channelName, promise, type, lock, entry, listeners);
                 entry.subscribe(codec, type, channelName, subscribeFuture);
+                subscribeFuture.whenComplete((r, e) -> {
+                    if (e != null) {
+                        unsubscribe(channelName, type);
+                    }
+                });
             });
         });
         return connFuture;

--- a/redisson/src/test/java/org/redisson/RedissonBlockingQueueTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonBlockingQueueTest.java
@@ -228,9 +228,6 @@ public class RedissonBlockingQueueTest extends RedissonQueueTest {
             } catch (ExecutionException | TimeoutException e) {
                 // skip
             }
-            if (f.cause() != null) {
-                f.cause().printStackTrace();
-            }
             Integer result = f.toCompletableFuture().getNow(null);
             assertThat(result).isEqualTo(i*100);
         }

--- a/redisson/src/test/java/org/redisson/RedissonShardedTopicTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonShardedTopicTest.java
@@ -1,0 +1,66 @@
+package org.redisson;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.redisson.api.HostPortNatMapper;
+import org.redisson.api.RTopic;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.redisson.connection.balancer.RandomLoadBalancer;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RedissonShardedTopicTest {
+
+    @Test
+    public void testClusterSharding() {
+        Config config = new Config();
+        HostPortNatMapper m = new HostPortNatMapper();
+        Map<String, String> mm = new HashMap<>();
+        mm.put("172.17.0.2:6380", "127.0.0.1:5001");
+        mm.put("172.17.0.2:6382", "127.0.0.1:5003");
+        mm.put("172.17.0.2:6379", "127.0.0.1:5000");
+        mm.put("172.17.0.2:6383", "127.0.0.1:5004");
+        mm.put("172.17.0.2:6384", "127.0.0.1:5005");
+        mm.put("172.17.0.2:6381", "127.0.0.1:5002");
+        m.setHostsPortMap(mm);
+        config.useClusterServers()
+                .setPingConnectionInterval(0)
+                .setNatMapper(m)
+                .setLoadBalancer(new RandomLoadBalancer())
+                .addNodeAddress("redis://127.0.0.1:5000");
+        RedissonClient redisson = Redisson.create(config);
+
+        AtomicInteger counter = new AtomicInteger();
+        for (int i = 0; i < 10; i++) {
+            int j = i;
+            RTopic topic = redisson.getShardedTopic("test" + i);
+            topic.addListener(Integer.class, (c, v) -> {
+                assertThat(v).isEqualTo(j);
+                counter.incrementAndGet();
+            });
+        }
+
+        for (int i = 0; i < 10; i++) {
+            RTopic topic = redisson.getShardedTopic("test" + i);
+            long s = topic.publish(i);
+            assertThat(s).isEqualTo(1);
+        }
+
+        Awaitility.await().atMost(Duration.ofSeconds(5)).until(() -> counter.get() == 10);
+
+        for (int i = 0; i < 10; i++) {
+            RTopic topic = redisson.getShardedTopic("test" + i);
+            topic.removeAllListeners();
+        }
+
+        redisson.shutdown();
+    }
+
+
+}

--- a/redisson/src/test/java/org/redisson/RedissonTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonTest.java
@@ -803,6 +803,26 @@ public class RedissonTest extends BaseTest {
     }
 
     @Test
+    public void testURIPassword() throws InterruptedException, IOException {
+        RedisProcess runner = new RedisRunner()
+                .nosave()
+                .randomDir()
+                .randomPort()
+                .requirepass("1234")
+                .run();
+
+        Config config = new Config();
+        config.useSingleServer()
+              .setAddress("redis://:1234@" + runner.getRedisServerBindAddress() + ":" + runner.getRedisServerPort());
+        RedissonClient redisson = Redisson.create(config);
+        RBucket<String> b = redisson.getBucket("test");
+        b.set("123");
+
+        redisson.shutdown();
+        runner.stop();
+    }
+
+    @Test
     public void testSentinelStartupWithPassword() throws Exception {
         RedisRunner.RedisProcess master = new RedisRunner()
                 .nosave()

--- a/redisson/src/test/java/org/redisson/RedissonTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonTest.java
@@ -422,22 +422,20 @@ public class RedissonTest extends BaseTest {
         for (RFuture<?> rFuture : futures) {
             try {
                 rFuture.toCompletableFuture().join();
-            } catch (Exception e) {
-                // skip
-            }
-            if (!rFuture.isSuccess()) {
-                if (rFuture.cause().getMessage().contains("READONLY You can't write against")) {
+                success++;
+            } catch (CompletionException e) {
+                if (e.getCause().getMessage().contains("READONLY You can't write against")) {
                     readonlyErrors++;
                 }
                 errors++;
-            } else {
-                success++;
+                // skip
             }
         }
         
         System.out.println("errors " + errors + " success " + success + " readonly " + readonlyErrors);
 
-        assertThat(futures.get(futures.size() - 1).isSuccess()).isTrue();
+        assertThat(futures.get(futures.size() - 1).isDone()).isTrue();
+        assertThat(futures.get(futures.size() - 1).toCompletableFuture().isCompletedExceptionally()).isFalse();
         assertThat(errors).isLessThan(820);
         assertThat(readonlyErrors).isZero();
         
@@ -556,9 +554,6 @@ public class RedissonTest extends BaseTest {
             try {
                 rFuture.toCompletableFuture().join();
             } catch (Exception e) {
-                // skip
-            }
-            if (!rFuture.isSuccess()) {
                 Assertions.fail();
             }
         }
@@ -659,13 +654,9 @@ public class RedissonTest extends BaseTest {
         for (RFuture<?> rFuture : futures) {
             try {
                 rFuture.toCompletableFuture().join();
-            } catch (Exception e) {
-                // skip
-            }
-            if (!rFuture.isSuccess()) {
-                errors++;
-            } else {
                 success++;
+            } catch (Exception e) {
+                errors++;
             }
         }
         
@@ -737,14 +728,11 @@ public class RedissonTest extends BaseTest {
         for (RFuture<?> rFuture : futures) {
             try {
                 rFuture.toCompletableFuture().join();
-            } catch (Exception e) {
-                // skip
-            }
-            if (!rFuture.isSuccess()) {
-                rFuture.cause().printStackTrace();
-                errors++;
-            } else {
                 success++;
+            } catch (Exception e) {
+                e.printStackTrace();
+                errors++;
+                // skip
             }
         }
 
@@ -754,7 +742,8 @@ public class RedissonTest extends BaseTest {
         assertThat(readonlyErrors).isZero();
         assertThat(errors).isLessThan(200);
         assertThat(success).isGreaterThan(600 - 200);
-        assertThat(futures.get(futures.size() - 1).isSuccess()).isTrue();
+        assertThat(futures.get(futures.size() - 1).isDone()).isTrue();
+        assertThat(futures.get(futures.size() - 1).toCompletableFuture().isCompletedExceptionally()).isFalse();
     }
 
 

--- a/redisson/src/test/java/org/redisson/jcache/JCacheTest.java
+++ b/redisson/src/test/java/org/redisson/jcache/JCacheTest.java
@@ -352,7 +352,30 @@ public class JCacheTest extends BaseTest {
         cache.close();
         runner.stop();
     }
-    
+
+    @Test
+    public void testScriptCache() throws IOException, InterruptedException {
+        RedisProcess runner = new RedisRunner()
+                .nosave()
+                .randomDir()
+                .port(6311)
+                .run();
+
+        URL configUrl = getClass().getResource("redisson-jcache.yaml");
+        Config cfg = Config.fromYAML(configUrl);
+        cfg.setUseScriptCache(true);
+
+        Configuration<String, String> config = RedissonConfiguration.fromConfig(cfg);
+        Cache<String, String> cache = Caching.getCachingProvider().getCacheManager()
+                .createCache("test", config);
+
+        cache.put("1", "2");
+        Assertions.assertEquals("2", cache.get("1"));
+
+        cache.close();
+        runner.stop();
+    }
+
     @Test
     public void testRedissonInstance() throws IllegalArgumentException {
         Configuration<String, String> config = RedissonConfiguration.fromInstance(redisson);


### PR DESCRIPTION
Let's consider the following case. Redis is deployed on the K8S in sentinel mode, and the sentinels' pods are deployment, using a service to load balance these multiple sentinels' pods.

Suppose the name of this service is sentinel-SVC. In projects using Redisson, the address in the configuration file is:
`sentinelServersConfig:
  sentinelAddresses:
    - "redis://sentinel-svc:26379"`

After the project is started, a large number of logs will be generated, as following, where "xxx" is the VIP corresponding to "sentinel-svc":
sentinel: redis://xxx.xxx.xxx.xxx:26379 is down
sentinel: redis://xxx.xxx.xxx.xxx:26379 is added
sentinel: redis://xxx.xxx.xxx.xxx:26379 is down
sentinel: redis://xxx.xxx.xxx.xxx:26379 is added
......

Without k8s, you can also reproduce the problem using an Nginx as the proxy of several sentinels. The ip of Nginx's hostname will be added and down all the time.

![picture](https://user-images.githubusercontent.com/47973010/169647589-9d8fd765-0429-49dd-841c-79ec4f20e1a7.png)
.

I try to fix it by updating the function "performSentinelDNSCheck" in class SentinelConnectionManager.