### PR TITLE
Move away from spring.factories for auto-configurations

### DIFF
--- a/redisson-spring-boot-starter/src/main/java/org/redisson/spring/starter/RedissonAutoConfiguration.java
+++ b/redisson-spring-boot-starter/src/main/java/org/redisson/spring/starter/RedissonAutoConfiguration.java
@@ -29,7 +29,7 @@ import org.redisson.api.RedissonRxClient;
 import org.redisson.config.Config;
 import org.redisson.spring.data.connection.RedissonConnectionFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
@@ -38,7 +38,6 @@ import org.springframework.boot.autoconfigure.data.redis.RedisProperties.Sentine
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.core.io.Resource;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -54,9 +53,10 @@ import org.springframework.util.ReflectionUtils;
  * @author AnJia (https://anjia0532.github.io/)
  *
  */
-@Configuration
+@AutoConfiguration(
+        before = {RedisAutoConfiguration.class,}
+)
 @ConditionalOnClass({Redisson.class, RedisOperations.class})
-@AutoConfigureBefore(RedisAutoConfiguration.class)
 @EnableConfigurationProperties({RedissonProperties.class, RedisProperties.class})
 public class RedissonAutoConfiguration {
 

--- a/redisson-spring-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/redisson-spring-boot-starter/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-org.redisson.spring.starter.RedissonAutoConfiguration

--- a/redisson-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/redisson-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.redisson.spring.starter.RedissonAutoConfiguration


### PR DESCRIPTION
&emsp;&emsp;In the [Spring Boot 2.7 Release Notes](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes#changes-to-auto-configuration), Changes to autoconfiguration.
1. a new file named `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`
2. A new `@AutoConfiguration` Annotation

For backwards compatibility, The original configuration is still supported.
> [stop using `spring.factories` for auto-configuration in 3.0.](https://github.com/spring-projects/spring-boot/issues/29872)

Attention: it would make mandatory the use of Spring Boot 2.7 (or above), This can break existing project that can't use these Spring versions.