### PR TITLE
Fix - the description of the return for the RLiveObjectService class

### DIFF
--- a/redisson/src/main/java/org/redisson/api/RLiveObjectService.java
+++ b/redisson/src/main/java/org/redisson/api/RLiveObjectService.java
@@ -190,7 +190,7 @@ public interface RLiveObjectService {
      *
      * @param <T> Entity type
      * @param attachedObject - proxied object
-     * @return proxied object
+     * @return detachedObject - not proxied object
      */
     <T> T detach(T attachedObject);
 


### PR DESCRIPTION
The description of the return object was wrong, so I fixed it.
The detach method returns not proxied object.

/**
     * Returns unproxied detached object for the attached object.
     *
     * @param <T> Entity type
     * @param attachedObject - proxied object
     * @return proxied object **_detachedObject - not proxied object_**
     */
<T> T detach(T attachedObject);