### PR TITLE
Fix - the description of the return for the RLiveObjectService interface

### DIFF
--- a/redisson/src/main/java/org/redisson/api/RLiveObjectService.java
+++ b/redisson/src/main/java/org/redisson/api/RLiveObjectService.java
@@ -190,7 +190,7 @@ public interface RLiveObjectService {
      *
      * @param <T> Entity type
      * @param attachedObject - proxied object
-     * @return proxied object
+     * @return detachedObject object - not proxied object
      */
     <T> T detach(T attachedObject);
 


### PR DESCRIPTION
The description of the return value is incorrect.
The return value of detach method of the RLiveObjectService interface is not proxied object.