### PR TITLE
fix: remove the Thread Interrupted check from scheduleExpirationRenewal()

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonBaseLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonBaseLock.java
@@ -165,13 +165,7 @@ public abstract class RedissonBaseLock extends RedissonExpirable implements RLoc
             oldEntry.addThreadId(threadId);
         } else {
             entry.addThreadId(threadId);
-            try {
-                renewExpiration();
-            } finally {
-                if (Thread.currentThread().isInterrupted()) {
-                    cancelExpirationRenewal(threadId);
-                }
-            }
+            renewExpiration();
         }
     }
 

--- a/redisson/src/test/java/org/redisson/RedissonLockTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonLockTest.java
@@ -169,29 +169,6 @@ public class RedissonLockTest extends BaseConcurrentTest {
     }
 
     @Test
-    public void testLockIsNotRenewedAfterInterruptedTryLock() throws InterruptedException {
-        final CountDownLatch countDownLatch = new CountDownLatch(1);
-        RLock lock = redisson.getLock("myLock");
-        assertThat(lock.isLocked()).isFalse();
-
-        Thread thread = new Thread(() -> {
-            countDownLatch.countDown();
-            if (!lock.tryLock()) {
-                return;
-            }
-            lock.unlock();
-        });
-        thread.start();
-        countDownLatch.await();
-        // let the tcp request be sent out
-        TimeUnit.MILLISECONDS.sleep(5);
-        thread.interrupt();
-        TimeUnit.SECONDS.sleep(45);
-
-        assertThat(lock.isLocked()).isFalse();
-    }
-
-    @Test
     public void testRedisFailed() {
         Assertions.assertThrows(WriteRedisConnectionException.class, () -> {
             RedisRunner.RedisProcess master = new RedisRunner()


### PR DESCRIPTION
remove the Thread.currentThread().isInterrupted() check from method scheduleExpirationRenewal() because it's useless.

[Issue#4368](https://github.com/redisson/redisson/issues/4368) remove the Thread.currentThread().isInterrupted() check from method scheduleExpirationRenewal() because it's useless.

Signed-off-by: Devpan <panhoucheng@gmail.com>