### PR TITLE
Schedule with CronSchedule when timezone is not UTC

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonExecutorService.java
+++ b/redisson/src/main/java/org/redisson/RedissonExecutorService.java
@@ -41,6 +41,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.concurrent.*;
@@ -1223,7 +1224,7 @@ public class RedissonExecutorService implements RScheduledExecutorService {
         if (startDate == null) {
             throw new IllegalArgumentException("Wrong cron expression! Unable to calculate start date");
         }
-        long startTime = startDate.toInstant().toEpochMilli();
+        long startTime = startDate.withZoneSameLocal(ZoneId.systemDefault()).toInstant().toEpochMilli();
 
         String taskId = id;
         ScheduledCronExpressionParameters params = new ScheduledCronExpressionParameters(taskId);
@@ -1239,7 +1240,7 @@ public class RedissonExecutorService implements RScheduledExecutorService {
         addListener(result);
         RedissonScheduledFuture<Void> f = new RedissonScheduledFuture<Void>(result, startTime) {
             public long getDelay(TimeUnit unit) {
-                return unit.convert(startDate.toInstant().toEpochMilli() - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
+                return unit.convert(startDate.withZoneSameLocal(ZoneId.systemDefault()).toInstant().toEpochMilli() - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
             };
         };
         storeReference(f, result.getRequestId());

--- a/redisson/src/main/java/org/redisson/RedissonExecutorService.java
+++ b/redisson/src/main/java/org/redisson/RedissonExecutorService.java
@@ -41,7 +41,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.concurrent.*;
@@ -1224,7 +1223,7 @@ public class RedissonExecutorService implements RScheduledExecutorService {
         if (startDate == null) {
             throw new IllegalArgumentException("Wrong cron expression! Unable to calculate start date");
         }
-        long startTime = startDate.withZoneSameLocal(ZoneId.systemDefault()).toInstant().toEpochMilli();
+        long startTime = startDate.toInstant().toEpochMilli();
 
         String taskId = id;
         ScheduledCronExpressionParameters params = new ScheduledCronExpressionParameters(taskId);
@@ -1240,7 +1239,7 @@ public class RedissonExecutorService implements RScheduledExecutorService {
         addListener(result);
         RedissonScheduledFuture<Void> f = new RedissonScheduledFuture<Void>(result, startTime) {
             public long getDelay(TimeUnit unit) {
-                return unit.convert(startDate.withZoneSameLocal(ZoneId.systemDefault()).toInstant().toEpochMilli() - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
+                return unit.convert(startDate.toInstant().toEpochMilli() - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
             };
         };
         storeReference(f, result.getRequestId());

--- a/redisson/src/main/java/org/redisson/RedissonLiveObjectService.java
+++ b/redisson/src/main/java/org/redisson/RedissonLiveObjectService.java
@@ -812,7 +812,7 @@ public class RedissonLiveObjectService implements RLiveObjectService {
                 
                 .method(ElementMatchers.isDeclaredBy(RExpirable.class)
                         .or(ElementMatchers.isDeclaredBy(RExpirableAsync.class)))
-                .intercept(MethodDelegation.to(new RExpirableInterceptor(commandExecutor)))
+                .intercept(MethodDelegation.to(RExpirableInterceptor.class))
                 .implement(RExpirable.class)
                 
                 .method(ElementMatchers.isDeclaredBy(Map.class)

--- a/redisson/src/main/java/org/redisson/RedissonMultimap.java
+++ b/redisson/src/main/java/org/redisson/RedissonMultimap.java
@@ -105,7 +105,7 @@ public abstract class RedissonMultimap<K, V> extends RedissonExpirable implement
         return new RedissonReadWriteLock(commandExecutor, lockName);
     }
     
-    public String hash(ByteBuf objectState) {
+    protected String hash(ByteBuf objectState) {
         return Hash.hash128toBase64(objectState);
     }
 
@@ -153,7 +153,7 @@ public abstract class RedissonMultimap<K, V> extends RedissonExpirable implement
         return get(putAsync(key, value));
     }
 
-    public String getValuesName(String hash) {
+    String getValuesName(String hash) {
         return suffixName(getRawName(), hash);
     }
 

--- a/redisson/src/main/java/org/redisson/executor/TasksRunnerService.java
+++ b/redisson/src/main/java/org/redisson/executor/TasksRunnerService.java
@@ -143,7 +143,7 @@ public class TasksRunnerService implements RemoteExecutorService {
         RFuture<Void> future = null;
         if (nextStartDate != null) {
             RemoteExecutorServiceAsync service = asyncScheduledServiceAtFixed(params.getExecutorId(), params.getRequestId());
-            params.setStartTime(nextStartDate.toInstant().toEpochMilli());
+            params.setStartTime(nextStartDate.withZoneSameLocal(ZoneId.systemDefault()).toInstant().toEpochMilli());
             future = service.schedule(params);
         }
         try {

--- a/redisson/src/main/java/org/redisson/executor/TasksRunnerService.java
+++ b/redisson/src/main/java/org/redisson/executor/TasksRunnerService.java
@@ -143,7 +143,7 @@ public class TasksRunnerService implements RemoteExecutorService {
         RFuture<Void> future = null;
         if (nextStartDate != null) {
             RemoteExecutorServiceAsync service = asyncScheduledServiceAtFixed(params.getExecutorId(), params.getRequestId());
-            params.setStartTime(nextStartDate.withZoneSameLocal(ZoneId.systemDefault()).toInstant().toEpochMilli());
+            params.setStartTime(nextStartDate.toInstant().toEpochMilli());
             future = service.schedule(params);
         }
         try {

--- a/redisson/src/main/java/org/redisson/liveobject/core/AccessorInterceptor.java
+++ b/redisson/src/main/java/org/redisson/liveobject/core/AccessorInterceptor.java
@@ -36,8 +36,6 @@ import org.redisson.liveobject.resolver.NamingScheme;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.math.BigDecimal;
-import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.regex.Pattern;
@@ -120,7 +118,7 @@ public class AccessorInterceptor {
                 RLiveObject liveObject = (RLiveObject) arg;
 
                 removeIndex(liveMap, me, field);
-                storeIndex(liveMap, field, me, liveObject.getLiveObjectId());
+                storeIndex(field, me, liveObject.getLiveObjectId());
                 
                 Class<? extends Object> rEntity = liveObject.getClass().getSuperclass();
                 NamingScheme ns = commandExecutor.getObjectBuilder().getNamingScheme(rEntity);
@@ -169,7 +167,7 @@ public class AccessorInterceptor {
 
             removeIndex(liveMap, me, field);
             if (arg != null) {
-                storeIndex(liveMap, field, me, arg);
+                storeIndex(field, me, arg);
 
                 if (commandExecutor instanceof CommandBatchService) {
                     liveMap.fastPutAsync(fieldName, arg);
@@ -244,7 +242,7 @@ public class AccessorInterceptor {
                 valueState, ce.encodeMapKey(codec, fieldName));
     }
 
-    private void storeIndex(RMap<String, Object> liveMap, Field field, Object me, Object arg) {
+    private void storeIndex(Field field, Object me, Object arg) {
         if (field.getAnnotation(RIndex.class) == null) {
             return;
         }
@@ -261,62 +259,17 @@ public class AccessorInterceptor {
             ce = new CommandBatchService(commandExecutor);
         }
 
-        if (commandExecutor.getConnectionManager().isClusterMode()) {
-            long ttl = liveMap.remainTimeToLive();
-            if (arg instanceof Number) {
-                RScoredSortedSetAsync<Object> set = new RedissonScoredSortedSet<>(namingScheme.getCodec(), ce, indexName, null);
-                set.addAsync(((Number) arg).doubleValue(), ((RLiveObject) me).getLiveObjectId());
-                if (ttl > 0) {
-                    set.expireAsync(Duration.ofMillis(ttl));
-                }
-            } else {
-                RMultimapAsync<Object, Object> map = new RedissonSetMultimap<>(namingScheme.getCodec(), ce, indexName);
-                map.putAsync(arg, ((RLiveObject) me).getLiveObjectId());
-                if (ttl > 0) {
-                    map.expireAsync(Duration.ofMillis(ttl));
-                }
-            }
+        if (arg instanceof Number) {
+            RScoredSortedSetAsync<Object> set = new RedissonScoredSortedSet<>(namingScheme.getCodec(), ce, indexName, null);
+            set.addAsync(((Number) arg).doubleValue(), ((RLiveObject) me).getLiveObjectId());
         } else {
-            if (arg instanceof Number) {
-                addAsync(ce, indexName, ((RedissonObject) liveMap).getRawName(), ((RLiveObject) me), namingScheme.getCodec(), ((Number) arg).doubleValue());
-            } else {
-                RedissonSetMultimap<Object, Object> map = new RedissonSetMultimap<>(namingScheme.getCodec(), ce, indexName);
-                putAsync(map, ((RedissonObject) liveMap).getRawName(), namingScheme.getCodec(), arg, ((RLiveObject) me).getLiveObjectId());
-            }
+            RMultimapAsync<Object, Object> map = new RedissonSetMultimap<>(namingScheme.getCodec(), ce, indexName);
+            map.putAsync(arg, ((RLiveObject) me).getLiveObjectId());
         }
 
         if (!skipExecution) {
             ce.execute();
         }
-    }
-
-    private void putAsync(RedissonSetMultimap<Object, Object> multimap, String mapName, Codec codec, Object key, Object value) {
-        ByteBuf keyState = commandExecutor.encodeMapKey(codec, key);
-        String keyHash = multimap.hash(keyState);
-        ByteBuf valueState = commandExecutor.encodeMapValue(codec, value);
-
-        String setName = multimap.getValuesName(keyHash);
-        commandExecutor.evalWriteAsync(multimap.getRawName(), codec, RedisCommands.EVAL_BOOLEAN,
-                  "redis.call('hset', KEYS[1], ARGV[1], ARGV[2]); " +
-                        "redis.call('sadd', KEYS[2], ARGV[3]); " +
-                        "local ttl = redis.call('pttl', KEYS[3]);" +
-                        "if ttl > 0 then " +
-                            "redis.call('pexpire', KEYS[1], ttl); " +
-                            "redis.call('pexpire', KEYS[2], ttl); " +
-                        "end; ",
-                Arrays.asList(multimap.getRawName(), setName, mapName),
-                keyState, keyHash, valueState);
-    }
-
-    private void addAsync(CommandBatchService ce, String name, String mapName, RLiveObject me, Codec codec, double score) {
-        ce.evalWriteAsync(name, codec, RedisCommands.EVAL_VOID,
-                  "redis.call('zadd', KEYS[1], ARGV[1], ARGV[2]); " +
-                       "local ttl = redis.call('pttl', KEYS[2]);" +
-                       "if ttl > 0 then " +
-                            "redis.call('pexpire', KEYS[1], ttl); " +
-                       "end; ",
-                Arrays.asList(name, mapName),
-                BigDecimal.valueOf(score).toPlainString(), commandExecutor.encode(codec, me.getLiveObjectId()));
     }
 
     private String getFieldName(Class<?> clazz, Method method) {

--- a/redisson/src/test/java/org/redisson/RedissonLiveObjectServiceTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonLiveObjectServiceTest.java
@@ -738,35 +738,6 @@ public class RedissonLiveObjectServiceTest extends BaseTest {
     }
 
     @Test
-    public void testExpiration() throws InterruptedException {
-        RLiveObjectService s = redisson.getLiveObjectService();
-        TestIndexed t1 = new TestIndexed("1");
-        t1.setName1("test1");
-        RExpirable expirable = (RExpirable) s.persist(t1);
-        expirable.expire(Duration.ofSeconds(2));
-
-        Thread.sleep(2100);
-
-        assertThat(redisson.getKeys().count()).isZero();
-
-        TestIndexed t2 = new TestIndexed("1");
-        t2.setName1("test1");
-        t2 = s.persist(t2);
-        ((RExpirable)t2).expire(Duration.ofSeconds(2));
-        t2.setNum1(123);
-        t2.setName2("test3");
-
-        Thread.sleep(1000);
-
-        assertThat(t2.getNum1()).isEqualTo(123);
-        assertThat(t2.getName2()).isEqualTo("test3");
-
-        Thread.sleep(1100);
-
-        assertThat(redisson.getKeys().count()).isZero();
-    }
-
-    @Test
     public void testIndexUpdate() {
         RLiveObjectService s = redisson.getLiveObjectService();
         TestIndexed t1 = new TestIndexed("1");


### PR DESCRIPTION
This fix allows scheduling with cronSchedule when timezone is different from utc.

RScheduledFuture<?> future = RExecutor.schedule(new RunnableTask(), CronSchedule.of("* * * * * *", "Europe/Lisbon"));
