### PR TITLE
Remove includes for full configuration

### DIFF
--- a/redisson-micronaut/redisson-micronaut-20/src/main/java/org/redisson/micronaut/RedissonConfiguration.java
+++ b/redisson-micronaut/redisson-micronaut-20/src/main/java/org/redisson/micronaut/RedissonConfiguration.java
@@ -56,7 +56,7 @@ public class RedissonConfiguration extends Config {
     }
 
     @Override
-    @ConfigurationBuilder(value = "clusterServersConfig", includes = {"nodeAddresses"})
+    @ConfigurationBuilder("clusterServersConfig")
     protected void setClusterServersConfig(ClusterServersConfig clusterServersConfig) {
         super.setClusterServersConfig(clusterServersConfig);
     }
@@ -78,7 +78,7 @@ public class RedissonConfiguration extends Config {
     }
 
     @Override
-    @ConfigurationBuilder(value = "replicatedServersConfig", includes = {"nodeAddresses"})
+    @ConfigurationBuilder("replicatedServersConfig")
     protected void setReplicatedServersConfig(ReplicatedServersConfig replicatedServersConfig) {
         super.setReplicatedServersConfig(replicatedServersConfig);
     }
@@ -92,7 +92,7 @@ public class RedissonConfiguration extends Config {
     }
 
     @Override
-    @ConfigurationBuilder(value = "sentinelServersConfig", includes = {"sentinelAddresses"})
+    @ConfigurationBuilder("sentinelServersConfig")
     protected void setSentinelServersConfig(SentinelServersConfig sentinelConnectionConfig) {
         super.setSentinelServersConfig(sentinelConnectionConfig);
     }
@@ -106,7 +106,7 @@ public class RedissonConfiguration extends Config {
     }
 
     @Override
-    @ConfigurationBuilder(value = "masterSlaveServersConfig", includes = {"slaveAddresses"})
+    @ConfigurationBuilder("masterSlaveServersConfig")
     protected void setMasterSlaveServersConfig(MasterSlaveServersConfig masterSlaveConnectionConfig) {
         super.setMasterSlaveServersConfig(masterSlaveConnectionConfig);
     }

--- a/redisson-micronaut/redisson-micronaut-30/src/main/java/org/redisson/micronaut/RedissonConfiguration.java
+++ b/redisson-micronaut/redisson-micronaut-30/src/main/java/org/redisson/micronaut/RedissonConfiguration.java
@@ -56,7 +56,7 @@ public class RedissonConfiguration extends Config {
     }
 
     @Override
-    @ConfigurationBuilder(value = "clusterServersConfig", includes = {"nodeAddresses"})
+    @ConfigurationBuilder("clusterServersConfig")
     protected void setClusterServersConfig(ClusterServersConfig clusterServersConfig) {
         super.setClusterServersConfig(clusterServersConfig);
     }
@@ -78,7 +78,7 @@ public class RedissonConfiguration extends Config {
     }
 
     @Override
-    @ConfigurationBuilder(value = "replicatedServersConfig", includes = {"nodeAddresses"})
+    @ConfigurationBuilder("replicatedServersConfig")
     protected void setReplicatedServersConfig(ReplicatedServersConfig replicatedServersConfig) {
         super.setReplicatedServersConfig(replicatedServersConfig);
     }
@@ -92,7 +92,7 @@ public class RedissonConfiguration extends Config {
     }
 
     @Override
-    @ConfigurationBuilder(value = "sentinelServersConfig", includes = {"sentinelAddresses"})
+    @ConfigurationBuilder("sentinelServersConfig")
     protected void setSentinelServersConfig(SentinelServersConfig sentinelConnectionConfig) {
         super.setSentinelServersConfig(sentinelConnectionConfig);
     }
@@ -106,7 +106,7 @@ public class RedissonConfiguration extends Config {
     }
 
     @Override
-    @ConfigurationBuilder(value = "masterSlaveServersConfig", includes = {"slaveAddresses"})
+    @ConfigurationBuilder("masterSlaveServersConfig")
     protected void setMasterSlaveServersConfig(MasterSlaveServersConfig masterSlaveConnectionConfig) {
         super.setMasterSlaveServersConfig(masterSlaveConnectionConfig);
     }


### PR DESCRIPTION
current ConfigurationBuilder includes option don't allow full redis configuration with micronaut application.yml, and just allow properties in includes option.