### PR TITLE
refactor : early return to ternary operator

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonObject.java
+++ b/redisson/src/main/java/org/redisson/RedissonObject.java
@@ -60,17 +60,15 @@ public abstract class RedissonObject implements RObject {
     }
 
     public static String prefixName(String prefix, String name) {
-        if (name.contains("{")) {
-            return prefix + ":" + name;
-        }
-        return prefix + ":{" + name + "}";
+        return name.contains("{")
+                ? prefix + ":" + name
+                : prefix + ":{" + name + "}";
     }
     
     public static String suffixName(String name, String suffix) {
-        if (name.contains("{")) {
-            return name + ":" + suffix;
-        }
-        return "{" + name + "}:" + suffix;
+        return name.contains("{")
+                ? name + ":" + suffix
+                : "{" + name + "}:" + suffix;
     }
 
     protected final <T> Stream<T> toStream(Iterator<T> iterator) {

--- a/redisson/src/main/java/org/redisson/api/MapOptions.java
+++ b/redisson/src/main/java/org/redisson/api/MapOptions.java
@@ -174,6 +174,12 @@ public class MapOptions<K, V> {
         return loader;
     }
 
+    /**
+     * Sets {@link MapLoaderAsync} object.
+     *
+     * @param loaderAsync object
+     * @return MapOptions instance
+     */
     public MapOptions<K, V> loaderAsync(MapLoaderAsync<K, V> loaderAsync) {
         this.loaderAsync = loaderAsync;
         return this;


### PR DESCRIPTION
Hello.
While reading the RedissonObject code, the functions of prefixName() and suffixName() are currently using early return, but have changed to a trinomial operator with better readability.