### PR TITLE
fix(sec): upgrade org.hibernate:hibernate-core to 5.4.24.Final

### DIFF
--- a/redisson-hibernate/redisson-hibernate-4/pom.xml
+++ b/redisson-hibernate/redisson-hibernate-4/pom.xml
@@ -17,7 +17,7 @@
        <dependency>
          <groupId>org.hibernate</groupId>
          <artifactId>hibernate-core</artifactId>
-         <version>4.3.11.Final</version>
+         <version>5.4.24.Final</version>
          <optional>true</optional>
        </dependency>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.hibernate:hibernate-core 4.3.11.Final
- [CVE-2020-25638](https://www.oscs1024.com/hd/CVE-2020-25638)


### What did I do？
Upgrade org.hibernate:hibernate-core from 4.3.11.Final to 5.4.24.Final for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS