### PR TITLE
Bump jackson-bom to 2.13.4.20221013 (upgrade to jackson-databind 2.13.4.2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>2.13.4</version>
+                <version>2.13.4.20221013</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
There is [CVE-2022-42003](https://nvd.nist.gov/vuln/detail/CVE-2022-42003) for `jackson-databind` `2.13.4`, which is fixed in the next point release `2.13.4.1`.

I didn't check if redisson is actually vulnerable. But bumping the dependency to an unaffected version will at least silence any vulnerability scanners when redisson is used.