### PR TITLE
compatibility for spring boot 3

### DIFF
--- a/redisson-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/redisson-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.redisson.spring.starter.RedissonAutoConfiguration


### PR DESCRIPTION
Spring Boot 3.0 changes the way AutoConfiguration are loaded. This PR just adds the file `org.springframework.boot.autoconfigure.AutoConfiguration.imports` to support SB 3.0 _and_ SB 2.x.
No module redisson-spring-data-30 is added as the 2.7 version seems to be compatible...

#4328 