### PR TITLE
Added testing redis binary path for  Mac OS 

### DIFF
--- a/redisson/src/test/java/org/redisson/RedissonRuntimeEnvironment.java
+++ b/redisson/src/test/java/org/redisson/RedissonRuntimeEnvironment.java
@@ -9,13 +9,22 @@ import java.util.Locale;
 public class RedissonRuntimeEnvironment {
 
     public static final boolean isTravis = "true".equalsIgnoreCase(System.getProperty("travisEnv"));
-    public static final String redisBinaryPath = System.getProperty("redisBinary", "C:\\redis\\redis-server.exe");
+    public static final String redisBinaryPath = System.getProperty("redisBinary", installPathByOS());
     public static final String tempDir = System.getProperty("java.io.tmpdir");
     public static final String OS;
     public static final boolean isWindows;
+    private static final String MAC_PATH = "/usr/local/opt/redis/bin/redis-server";
+    private static final String WINDOW_PATH = "C:\\redis\\redis-server.exe";
 
     static {
         OS = System.getProperty("os.name", "generic");
         isWindows = OS.toLowerCase(Locale.ENGLISH).contains("win");
+    }
+
+    private static String installPathByOS(){
+        final String OS = System.getProperty("os.name", "generic");
+        final boolean isMacOS = OS.toLowerCase(Locale.ENGLISH).contains("mac");
+
+        return isMacOS ? MAC_PATH : WINDOW_PATH;
     }
 }


### PR DESCRIPTION
I faced a pah problem testing the [org.redisson.RedissonAtomicLongReactiveTest.java].
When I checked this problem, only Windows OS Path was set in RedissonRuntimeEnvironment. So I sent a PR by adding the Mac OS Path.

[problem]
<img width="2038" alt="Screenshot at Nov 06 22-11-52" src="https://user-images.githubusercontent.com/76584547/200173561-77ad6ed7-352e-4eb4-b2dd-ab0fae03ca1f.png">

[solved]
<img width="2032" alt="Screenshot at Nov 06 22-13-56" src="https://user-images.githubusercontent.com/76584547/200173632-4bb3524f-ae14-4e47-aefa-916f5dd3a571.png">
