### PR TITLE
Fixed - RedissonPriorityBlockingQueue should return null if negative …

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonPriorityBlockingQueue.java
+++ b/redisson/src/main/java/org/redisson/RedissonPriorityBlockingQueue.java
@@ -115,6 +115,9 @@ public class RedissonPriorityBlockingQueue<V> extends RedissonPriorityQueue<V> i
     }
 
     public RFuture<V> pollAsync(long timeout, TimeUnit unit) {
+        if (timeout < 0) {
+            return new CompletableFutureWrapper<>((V) null);
+        }
         CompletableFuture<V> result = new CompletableFuture<V>();
         takeAsync(result, 0, unit.toMicros(timeout), RedisCommands.LPOP, getRawName());
         return new CompletableFutureWrapper<>(result);
@@ -152,6 +155,9 @@ public class RedissonPriorityBlockingQueue<V> extends RedissonPriorityQueue<V> i
 
     @Override
     public RFuture<V> pollLastAndOfferFirstToAsync(String queueName, long timeout, TimeUnit unit) {
+        if (timeout < 0) {
+            return new CompletableFutureWrapper<>((V) null);
+        }
         CompletableFuture<V> result = new CompletableFuture<V>();
         takeAsync(result, 0, unit.toMicros(timeout), RedisCommands.RPOPLPUSH, getRawName(), queueName);
         return new CompletableFutureWrapper<>(result);

--- a/redisson/src/test/java/org/redisson/RedissonPriorityBlockingQueueTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonPriorityBlockingQueueTest.java
@@ -144,6 +144,19 @@ public class RedissonPriorityBlockingQueueTest extends RedissonBlockingQueueTest
         queue1.drainTo(dst, 2);
         assertThat(dst).containsExactly(3);
     }
-    
+
+    @Test
+    public void testPollWithNegativeTimeout() throws Exception {
+        RBlockingQueue<Integer> queue1 = getQueue();
+        queue1.put(1);
+        queue1.put(2);
+        queue1.put(3);
+
+        Integer first = queue1.poll(1, TimeUnit.SECONDS);
+        Assertions.assertEquals(1, first);
+
+        Integer second = queue1.poll(-1, TimeUnit.SECONDS);
+        Assertions.assertNull(second);
+    }
     
 }


### PR DESCRIPTION
Is the RedissonPriorityBlockingQueue should return null if timeout is negative ? the same logic

#4652 