### PR TITLE
Add tracking and setters for max permits

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonPermitExpirableSemaphore.java
+++ b/redisson/src/main/java/org/redisson/RedissonPermitExpirableSemaphore.java
@@ -711,12 +711,12 @@ public class RedissonPermitExpirableSemaphore extends RedissonExpirable implemen
                 "if (available == false) then " +
                     "redis.call('set', KEYS[1], ARGV[1]); " +
                     "redis.call('publish', KEYS[2], ARGV[1]); " +
-                    "return ARGV[1];" +
+                    "return;" +
                 "end;" +
                 "local claimed = redis.call('zcount', KEYS[3], 0, '+inf'); " +
                 "local maximum = (claimed == false and 0 or claimed) + tonumber(available); " +
                 "if (maximum == ARGV[1]) then " +
-                    "return 0;" +
+                    "return;" +
                 "end;" +
                 "redis.call('incrby', KEYS[1], tonumber(ARGV[1]) - maximum); " +
                 "redis.call('publish', KEYS[2], ARGV[1]);",

--- a/redisson/src/main/java/org/redisson/RedissonPermitExpirableSemaphore.java
+++ b/redisson/src/main/java/org/redisson/RedissonPermitExpirableSemaphore.java
@@ -666,7 +666,7 @@ public class RedissonPermitExpirableSemaphore extends RedissonExpirable implemen
                     "return tonumber(available) " +
                 "end;" +
                 "return tonumber(available) + acquired;",
-                Arrays.<Object>asList(getRawName(), timeoutName, getChannelName()), System.currentTimeMillis());
+                Arrays.<Object>asList(getRawName(), timeoutName, channelName), System.currentTimeMillis());
     }
 
     @Override
@@ -682,7 +682,7 @@ public class RedissonPermitExpirableSemaphore extends RedissonExpirable implemen
                 "end; " +
                 "local acquired = redis.call('zcount', KEYS[2], 0, '+inf'); " +
                 "return acquired == false and 0 or acquired;",
-                Arrays.<Object>asList(getRawName(), timeoutName, getChannelName()), System.currentTimeMillis());
+                Arrays.<Object>asList(getRawName(), timeoutName, channelName), System.currentTimeMillis());
     }
 
     @Override
@@ -711,7 +711,7 @@ public class RedissonPermitExpirableSemaphore extends RedissonExpirable implemen
                 "end;" +
                 "redis.call('incrby', KEYS[1], tonumber(ARGV[1]) - maximum); " +
                 "redis.call('publish', KEYS[2], ARGV[1]);",
-                Arrays.<Object>asList(getRawName(), getChannelName(), timeoutName), permits);
+                Arrays.<Object>asList(getRawName(), channelName, timeoutName), permits);
     }
 
     @Override

--- a/redisson/src/main/java/org/redisson/RedissonPermitExpirableSemaphore.java
+++ b/redisson/src/main/java/org/redisson/RedissonPermitExpirableSemaphore.java
@@ -695,17 +695,17 @@ public class RedissonPermitExpirableSemaphore extends RedissonExpirable implemen
     }
 
     @Override
-    public boolean trySetPermits(int maxPermits) {
-        return get(trySetPermitsAsync(maxPermits));
+    public boolean trySetPermits(int permits) {
+        return get(trySetPermitsAsync(permits));
     }
 
     @Override
-    public int setPermits(int maxPermits) {
-        return get(setPermitsAsync(maxPermits));
+    public int setPermits(int permits) {
+        return get(setPermitsAsync(permits));
     }
 
     @Override
-    public RFuture<Integer> setPermitsAsync(int maxPermits) {
+    public RFuture<Integer> setPermitsAsync(int permits) {
         return commandExecutor.evalWriteAsync(getRawName(), LongCodec.INSTANCE, RedisCommands.EVAL_INTEGER,
                 "local available = redis.call('get', KEYS[1]); " +
                 "if (available == false) then " +
@@ -725,7 +725,7 @@ public class RedissonPermitExpirableSemaphore extends RedissonExpirable implemen
                 "redis.call('incrby', KEYS[1], delta); " +
                 "redis.call('publish', KEYS[2], ARGV[1]); " +
                 "return delta;",
-                Arrays.<Object>asList(getRawName(), getChannelName(), timeoutName), maxPermits);
+                Arrays.<Object>asList(getRawName(), getChannelName(), timeoutName), permits);
     }
 
     @Override

--- a/redisson/src/main/java/org/redisson/RedissonPermitExpirableSemaphore.java
+++ b/redisson/src/main/java/org/redisson/RedissonPermitExpirableSemaphore.java
@@ -719,9 +719,6 @@ public class RedissonPermitExpirableSemaphore extends RedissonExpirable implemen
                     "return 0;" +
                 "end;" +
                 "local delta = tonumber(ARGV[1]) - maximum; " +
-                "if (delta == 0) then " +
-                    "return 0;" +
-                "end;" +
                 "redis.call('incrby', KEYS[1], delta); " +
                 "redis.call('publish', KEYS[2], ARGV[1]); " +
                 "return delta;",

--- a/redisson/src/main/java/org/redisson/RedissonPermitExpirableSemaphore.java
+++ b/redisson/src/main/java/org/redisson/RedissonPermitExpirableSemaphore.java
@@ -667,10 +667,10 @@ public class RedissonPermitExpirableSemaphore extends RedissonExpirable implemen
                     "end;" +
                 "end; " +
                 "local available = redis.call('get', KEYS[1]); " +
-                "local claimed = redis.call('zcount', KEYS[2], 0, '+inf'); " +
                 "if available == false then " +
                     "return 0 " +
                 "end;" +
+                "local claimed = redis.call('zcount', KEYS[2], 0, '+inf'); " +
                 "if claimed == false then " +
                     "return tonumber(available) " +
                 "end;" +
@@ -755,7 +755,7 @@ public class RedissonPermitExpirableSemaphore extends RedissonExpirable implemen
               + "end;"
               + "redis.call('set', KEYS[1], tonumber(value) + tonumber(ARGV[1])); "
               + "if tonumber(ARGV[1]) > 0 then "
-                  + "redis.call('publish', KEYS[2], tonumber(value) + tonumber(ARGV[1])); "
+                  + "redis.call('publish', KEYS[2], ARGV[1]); "
               + "end;",
                 Arrays.<Object>asList(getRawName(), getChannelName()), permits);
     }

--- a/redisson/src/main/java/org/redisson/api/RPermitExpirableSemaphore.java
+++ b/redisson/src/main/java/org/redisson/api/RPermitExpirableSemaphore.java
@@ -109,16 +109,16 @@ public interface RPermitExpirableSemaphore extends RExpirable, RPermitExpirableS
     int availablePermits();
 
     /**
-     * Returns the maximum number of permits.
+     * Returns the number of permits.
      *
-     * @return maximum number of permits
+     * @return number of permits
      */
-    int maximumPermits();
+    int getPermits();
 
     /**
      * Returns the number of claimed permits.
      *
-     * @return number of permits claimed
+     * @return number of claimed permits
      */
     int claimedPermits();
 
@@ -131,14 +131,14 @@ public interface RPermitExpirableSemaphore extends RExpirable, RPermitExpirableS
     boolean trySetPermits(int permits);
 
     /**
-     * Sets the avaiable number of permits such that the number of claimed
-     * permits and the number of available permits is equal to the provided max value.
-     * If the number of permits has not been set yet, it will be set to the max value.
+     * Sets the number of permits such that the number of claimed
+     * permits plus the number of available permits is equal to the provided value.
+     * If the number of permits has not been set yet, it will be set to the provided value.
      *
      * @param permits - number of permits to use as the maximum
      * @return the number of permits that were added
      */
-    int setMaximumPermits(int maxPermits);
+    int setPermits(int maxPermits);
 
     /**
      * Increases or decreases the number of available permits by defined value. 

--- a/redisson/src/main/java/org/redisson/api/RPermitExpirableSemaphore.java
+++ b/redisson/src/main/java/org/redisson/api/RPermitExpirableSemaphore.java
@@ -123,7 +123,7 @@ public interface RPermitExpirableSemaphore extends RExpirable, RPermitExpirableS
     int claimedPermits();
 
     /**
-     * Tries to set number of permits.
+     * Tries to set the initial number of available permits.
      *
      * @param permits - number of permits
      * @return <code>true</code> if permits has been set successfully, otherwise <code>false</code>.  
@@ -131,12 +131,14 @@ public interface RPermitExpirableSemaphore extends RExpirable, RPermitExpirableS
     boolean trySetPermits(int permits);
 
     /**
-     * Tries to set the maximum number of permits.
+     * Sets the avaiable number of permits such that the number of claimed
+     * permits and the number of available permits is equal to the provided max value.
+     * If the number of permits has not been set yet, it will be set to the max value.
      *
      * @param permits - number of permits to use as the maximum
-     * @return <code>true</code> if permits has been set successfully, otherwise <code>false</code>.
+     * @return the number of permits that were added
      */
-    boolean trySetMaximumPermits(int permits);
+    int setMaximumPermits(int maxPermits);
 
     /**
      * Increases or decreases the number of available permits by defined value. 

--- a/redisson/src/main/java/org/redisson/api/RPermitExpirableSemaphore.java
+++ b/redisson/src/main/java/org/redisson/api/RPermitExpirableSemaphore.java
@@ -102,11 +102,25 @@ public interface RPermitExpirableSemaphore extends RExpirable, RPermitExpirableS
     void release(String permitId);
     
     /**
-     * Returns amount of available permits.
+     * Returns number of available permits.
      *
-     * @return number of permits
+     * @return number of available permits
      */
     int availablePermits();
+
+    /**
+     * Returns the maximum number of permits.
+     *
+     * @return maximum number of permits
+     */
+    int maximumPermits();
+
+    /**
+     * Returns the number of claimed permits.
+     *
+     * @return number of permits claimed
+     */
+    int claimedPermits();
 
     /**
      * Tries to set number of permits.
@@ -115,7 +129,15 @@ public interface RPermitExpirableSemaphore extends RExpirable, RPermitExpirableS
      * @return <code>true</code> if permits has been set successfully, otherwise <code>false</code>.  
      */
     boolean trySetPermits(int permits);
-    
+
+    /**
+     * Tries to set the maximum number of permits.
+     *
+     * @param permits - number of permits to use as the maximum
+     * @return <code>true</code> if permits has been set successfully, otherwise <code>false</code>.
+     */
+    boolean trySetMaximumPermits(int permits);
+
     /**
      * Increases or decreases the number of available permits by defined value. 
      *

--- a/redisson/src/main/java/org/redisson/api/RPermitExpirableSemaphore.java
+++ b/redisson/src/main/java/org/redisson/api/RPermitExpirableSemaphore.java
@@ -116,11 +116,11 @@ public interface RPermitExpirableSemaphore extends RExpirable, RPermitExpirableS
     int getPermits();
 
     /**
-     * Returns the number of claimed permits.
+     * Returns the number of acquired permits.
      *
-     * @return number of claimed permits
+     * @return number of acquired permits
      */
-    int claimedPermits();
+    int acquiredPermits();
 
     /**
      * Tries to set the initial number of available permits.

--- a/redisson/src/main/java/org/redisson/api/RPermitExpirableSemaphore.java
+++ b/redisson/src/main/java/org/redisson/api/RPermitExpirableSemaphore.java
@@ -131,12 +131,12 @@ public interface RPermitExpirableSemaphore extends RExpirable, RPermitExpirableS
     boolean trySetPermits(int permits);
 
     /**
-     * Sets the number of permits such that the number of claimed
-     * permits plus the number of available permits is equal to the provided value.
-     * If the number of permits has not been set yet, it will be set to the provided value.
+     * Sets the number of permits to the provided value and returns the number of permits added.
+     * Calculates the <code>delta</code> between the given <code>permits</code> value and the
+     * current number of permits, then increases the number of available permits by <code>delta</code>.
      *
-     * @param permits - number of permits to use as the maximum
-     * @return the number of permits that were added
+     * @param permits - number of permits
+     * @return delta - number of permits that were added, will be negative if permits were removed
      */
     int setPermits(int permits);
 

--- a/redisson/src/main/java/org/redisson/api/RPermitExpirableSemaphore.java
+++ b/redisson/src/main/java/org/redisson/api/RPermitExpirableSemaphore.java
@@ -131,14 +131,13 @@ public interface RPermitExpirableSemaphore extends RExpirable, RPermitExpirableS
     boolean trySetPermits(int permits);
 
     /**
-     * Sets the number of permits to the provided value and returns the number of permits added.
+     * Sets the number of permits to the provided value.
      * Calculates the <code>delta</code> between the given <code>permits</code> value and the
      * current number of permits, then increases the number of available permits by <code>delta</code>.
      *
      * @param permits - number of permits
-     * @return delta - number of permits that were added, will be negative if permits were removed
      */
-    int setPermits(int permits);
+    void setPermits(int permits);
 
     /**
      * Increases or decreases the number of available permits by defined value. 

--- a/redisson/src/main/java/org/redisson/api/RPermitExpirableSemaphore.java
+++ b/redisson/src/main/java/org/redisson/api/RPermitExpirableSemaphore.java
@@ -138,7 +138,7 @@ public interface RPermitExpirableSemaphore extends RExpirable, RPermitExpirableS
      * @param permits - number of permits to use as the maximum
      * @return the number of permits that were added
      */
-    int setPermits(int maxPermits);
+    int setPermits(int permits);
 
     /**
      * Increases or decreases the number of available permits by defined value. 

--- a/redisson/src/main/java/org/redisson/api/RPermitExpirableSemaphoreAsync.java
+++ b/redisson/src/main/java/org/redisson/api/RPermitExpirableSemaphoreAsync.java
@@ -135,7 +135,7 @@ public interface RPermitExpirableSemaphoreAsync extends RExpirableAsync {
      * @param permits - number of permits to use as the maximum
      * @return the number of permits that were added
      */
-    RFuture<Integer> setPermitsAsync(int maxPermits);
+    RFuture<Integer> setPermitsAsync(int permits);
 
     /**
      * Increases or decreases the number of available permits by defined value. 

--- a/redisson/src/main/java/org/redisson/api/RPermitExpirableSemaphoreAsync.java
+++ b/redisson/src/main/java/org/redisson/api/RPermitExpirableSemaphoreAsync.java
@@ -106,16 +106,16 @@ public interface RPermitExpirableSemaphoreAsync extends RExpirableAsync {
     RFuture<Integer> availablePermitsAsync();
 
     /**
-     * Returns the maximum number of permits.
+     * Returns the number of permits.
      *
-     * @return maximum number of permits
+     * @return number of permits
      */
-    RFuture<Integer> maximumPermitsAsync();
+    RFuture<Integer> getPermitsAsync();
 
     /**
      * Returns the number of claimed permits.
      *
-     * @return number of permits claimed
+     * @return number of claimed permits
      */
     RFuture<Integer> claimedPermitsAsync();
 
@@ -135,7 +135,7 @@ public interface RPermitExpirableSemaphoreAsync extends RExpirableAsync {
      * @param permits - number of permits to use as the maximum
      * @return the number of permits that were added
      */
-    RFuture<Integer> setMaximumPermitsAsync(int maxPermits);
+    RFuture<Integer> setPermitsAsync(int maxPermits);
 
     /**
      * Increases or decreases the number of available permits by defined value. 

--- a/redisson/src/main/java/org/redisson/api/RPermitExpirableSemaphoreAsync.java
+++ b/redisson/src/main/java/org/redisson/api/RPermitExpirableSemaphoreAsync.java
@@ -128,12 +128,12 @@ public interface RPermitExpirableSemaphoreAsync extends RExpirableAsync {
     RFuture<Boolean> trySetPermitsAsync(int permits);
 
     /**
-     * Sets the avaiable number of permits such that the number of claimed
-     * permits and the number of available permits is equal to the provided max value.
-     * If the number of permits has not been set yet, it will be set to the max value.
+     * Sets the number of permits to the provided value and returns the number of permits added.
+     * Calculates the <code>delta</code> between the given <code>permits</code> vaue and the
+     * current number of permits, then increases the number of available permits by <code>delta</code>.
      *
-     * @param permits - number of permits to use as the maximum
-     * @return the number of permits that were added
+     * @param permits - number of permits
+     * @return delta - number of permits that were added, will be negative if permits were removed
      */
     RFuture<Integer> setPermitsAsync(int permits);
 

--- a/redisson/src/main/java/org/redisson/api/RPermitExpirableSemaphoreAsync.java
+++ b/redisson/src/main/java/org/redisson/api/RPermitExpirableSemaphoreAsync.java
@@ -128,14 +128,13 @@ public interface RPermitExpirableSemaphoreAsync extends RExpirableAsync {
     RFuture<Boolean> trySetPermitsAsync(int permits);
 
     /**
-     * Sets the number of permits to the provided value and returns the number of permits added.
-     * Calculates the <code>delta</code> between the given <code>permits</code> vaue and the
+     * Sets the number of permits to the provided value.
+     * Calculates the <code>delta</code> between the given <code>permits</code> value and the
      * current number of permits, then increases the number of available permits by <code>delta</code>.
      *
      * @param permits - number of permits
-     * @return delta - number of permits that were added, will be negative if permits were removed
      */
-    RFuture<Integer> setPermitsAsync(int permits);
+    RFuture<Void> setPermitsAsync(int permits);
 
     /**
      * Increases or decreases the number of available permits by defined value. 

--- a/redisson/src/main/java/org/redisson/api/RPermitExpirableSemaphoreAsync.java
+++ b/redisson/src/main/java/org/redisson/api/RPermitExpirableSemaphoreAsync.java
@@ -120,7 +120,7 @@ public interface RPermitExpirableSemaphoreAsync extends RExpirableAsync {
     RFuture<Integer> claimedPermitsAsync();
 
     /**
-     * Tries to set number of permits.
+     * Tries to set number of available permits.
      *
      * @param permits - number of permits
      * @return <code>true</code> if permits has been set successfully, otherwise <code>false</code>.  
@@ -128,12 +128,14 @@ public interface RPermitExpirableSemaphoreAsync extends RExpirableAsync {
     RFuture<Boolean> trySetPermitsAsync(int permits);
 
     /**
-     * Tries to set the maximum number of permits.
+     * Sets the avaiable number of permits such that the number of claimed
+     * permits and the number of available permits is equal to the provided max value.
+     * If the number of permits has not been set yet, it will be set to the max value.
      *
      * @param permits - number of permits to use as the maximum
-     * @return <code>true</code> if permits has been set successfully, otherwise <code>false</code>.
+     * @return the number of permits that were added
      */
-    RFuture<Boolean> trySetMaximumPermitsAsync(int permits);
+    RFuture<Integer> setMaximumPermitsAsync(int maxPermits);
 
     /**
      * Increases or decreases the number of available permits by defined value. 

--- a/redisson/src/main/java/org/redisson/api/RPermitExpirableSemaphoreAsync.java
+++ b/redisson/src/main/java/org/redisson/api/RPermitExpirableSemaphoreAsync.java
@@ -113,11 +113,11 @@ public interface RPermitExpirableSemaphoreAsync extends RExpirableAsync {
     RFuture<Integer> getPermitsAsync();
 
     /**
-     * Returns the number of claimed permits.
+     * Returns the number of acquired permits.
      *
-     * @return number of claimed permits
+     * @return number of acquired permits
      */
-    RFuture<Integer> claimedPermitsAsync();
+    RFuture<Integer> acquiredPermitsAsync();
 
     /**
      * Tries to set number of available permits.

--- a/redisson/src/main/java/org/redisson/api/RPermitExpirableSemaphoreAsync.java
+++ b/redisson/src/main/java/org/redisson/api/RPermitExpirableSemaphoreAsync.java
@@ -99,11 +99,25 @@ public interface RPermitExpirableSemaphoreAsync extends RExpirableAsync {
     RFuture<Void> releaseAsync(String permitId);
 
     /**
-     * Returns amount of available permits.
+     * Returns number of available permits.
      *
      * @return number of permits
      */
     RFuture<Integer> availablePermitsAsync();
+
+    /**
+     * Returns the maximum number of permits.
+     *
+     * @return maximum number of permits
+     */
+    RFuture<Integer> maximumPermitsAsync();
+
+    /**
+     * Returns the number of claimed permits.
+     *
+     * @return number of permits claimed
+     */
+    RFuture<Integer> claimedPermitsAsync();
 
     /**
      * Tries to set number of permits.
@@ -112,6 +126,14 @@ public interface RPermitExpirableSemaphoreAsync extends RExpirableAsync {
      * @return <code>true</code> if permits has been set successfully, otherwise <code>false</code>.  
      */
     RFuture<Boolean> trySetPermitsAsync(int permits);
+
+    /**
+     * Tries to set the maximum number of permits.
+     *
+     * @param permits - number of permits to use as the maximum
+     * @return <code>true</code> if permits has been set successfully, otherwise <code>false</code>.
+     */
+    RFuture<Boolean> trySetMaximumPermitsAsync(int permits);
 
     /**
      * Increases or decreases the number of available permits by defined value. 

--- a/redisson/src/main/java/org/redisson/api/RPermitExpirableSemaphoreReactive.java
+++ b/redisson/src/main/java/org/redisson/api/RPermitExpirableSemaphoreReactive.java
@@ -108,12 +108,35 @@ public interface RPermitExpirableSemaphoreReactive extends RExpirableReactive {
     Mono<Integer> availablePermits();
 
     /**
+     * Returns the number of permits.
+     *
+     * @return number of permits
+     */
+    Mono<Integer> getPermits();
+
+    /**
+     * Returns the number of acquired permits.
+     *
+     * @return number of acquired permits
+     */
+    Mono<Integer> acquiredPermits();
+
+    /**
      * Tries to set number of permits.
      *
      * @param permits - number of permits
      * @return <code>true</code> if permits has been set successfully, otherwise <code>false</code>.  
      */
     Mono<Boolean> trySetPermits(int permits);
+
+    /**
+     * Sets the number of permits to the provided value.
+     * Calculates the <code>delta</code> between the given <code>permits</code> value and the
+     * current number of permits, then increases the number of available permits by <code>delta</code>.
+     *
+     * @param permits - number of permits
+     */
+    Mono<Void> setPermits(int permits);
 
     /**
      * Increases or decreases the number of available permits by defined value. 

--- a/redisson/src/main/java/org/redisson/api/RPermitExpirableSemaphoreRx.java
+++ b/redisson/src/main/java/org/redisson/api/RPermitExpirableSemaphoreRx.java
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
+import reactor.core.publisher.Mono;
 
 /**
  * RxJava2 interface for Semaphore object with lease time parameter support for each acquired permit.
@@ -208,12 +209,35 @@ public interface RPermitExpirableSemaphoreRx extends RExpirableRx {
     Single<Integer> availablePermits();
 
     /**
+     * Returns the number of permits.
+     *
+     * @return number of permits
+     */
+    Single<Integer> getPermits();
+
+    /**
+     * Returns the number of acquired permits.
+     *
+     * @return number of acquired permits
+     */
+    Single<Integer> acquiredPermits();
+
+    /**
      * Sets number of permits.
      *
      * @param permits - number of permits
      * @return <code>true</code> if permits has been set successfully, otherwise <code>false</code>.  
      */
     Single<Boolean> trySetPermits(int permits);
+
+    /**
+     * Sets the number of permits to the provided value.
+     * Calculates the <code>delta</code> between the given <code>permits</code> value and the
+     * current number of permits, then increases the number of available permits by <code>delta</code>.
+     *
+     * @param permits - number of permits
+     */
+    Single<Void> setPermits(int permits);
 
     /**
      * Increases or decreases the number of available permits by defined value. 

--- a/redisson/src/main/java/org/redisson/api/RPermitExpirableSemaphoreRx.java
+++ b/redisson/src/main/java/org/redisson/api/RPermitExpirableSemaphoreRx.java
@@ -20,7 +20,6 @@ import java.util.concurrent.TimeUnit;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
-import reactor.core.publisher.Mono;
 
 /**
  * RxJava2 interface for Semaphore object with lease time parameter support for each acquired permit.

--- a/redisson/src/test/java/org/redisson/RedissonPermitExpirableSemaphoreTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonPermitExpirableSemaphoreTest.java
@@ -182,9 +182,9 @@ public class RedissonPermitExpirableSemaphoreTest extends BaseConcurrentTest {
     }
 
     @Test
-    public void testTrySetMaximumPermits() throws InterruptedException {
+    public void testSetMaximumPermits() throws InterruptedException {
         RPermitExpirableSemaphore s = redisson.getPermitExpirableSemaphore("test");
-        assertThat(s.trySetMaximumPermits(10)).isTrue();
+        assertThat(s.setMaximumPermits(10)).isEqualTo(10);
         assertThat(s.maximumPermits()).isEqualTo(10);
         assertThat(s.availablePermits()).isEqualTo(10);
         assertThat(s.claimedPermits()).isEqualTo(0);
@@ -196,19 +196,19 @@ public class RedissonPermitExpirableSemaphoreTest extends BaseConcurrentTest {
         assertThat(s.claimedPermits()).isEqualTo(0);
 
         // attempts to set max permits succeeds
-        assertThat(s.trySetMaximumPermits(15)).isTrue();
+        assertThat(s.setMaximumPermits(15)).isEqualTo(5);
         assertThat(s.maximumPermits()).isEqualTo(15);
         assertThat(s.availablePermits()).isEqualTo(15);
         assertThat(s.claimedPermits()).isEqualTo(0);
 
         // setting to existing value succeeds
-        assertThat(s.trySetMaximumPermits(15)).isTrue();
+        assertThat(s.setMaximumPermits(15)).isEqualTo(0);
         assertThat(s.maximumPermits()).isEqualTo(15);
         assertThat(s.availablePermits()).isEqualTo(15);
         assertThat(s.claimedPermits()).isEqualTo(0);
 
         // decreasing max permits succeeds
-        assertThat(s.trySetMaximumPermits(5)).isTrue();
+        assertThat(s.setMaximumPermits(5)).isEqualTo(-10);
         assertThat(s.maximumPermits()).isEqualTo(5);
         assertThat(s.availablePermits()).isEqualTo(5);
         assertThat(s.claimedPermits()).isEqualTo(0);
@@ -226,14 +226,14 @@ public class RedissonPermitExpirableSemaphoreTest extends BaseConcurrentTest {
         assertThat(s.claimedPermits()).isEqualTo(3);
 
         // decreasing the max to the number of claimed permits is allowed
-        assertThat(s.trySetMaximumPermits(3)).isTrue();
+        assertThat(s.setMaximumPermits(3)).isEqualTo(-2);
         assertThat(s.maximumPermits()).isEqualTo(3);
         assertThat(s.availablePermits()).isEqualTo(0);
         assertThat(s.claimedPermits()).isEqualTo(3);
 
         // decreasing the max to below the number of claimed permits is allowed
         // and results in a negative number of available permits
-        assertThat(s.trySetMaximumPermits(2)).isTrue();
+        assertThat(s.setMaximumPermits(2)).isEqualTo(-1);
         assertThat(s.maximumPermits()).isEqualTo(2);
         assertThat(s.availablePermits()).isEqualTo(-1);
         assertThat(s.claimedPermits()).isEqualTo(3);

--- a/redisson/src/test/java/org/redisson/RedissonPermitExpirableSemaphoreTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonPermitExpirableSemaphoreTest.java
@@ -16,23 +16,23 @@ import org.redisson.client.RedisException;
 
 public class RedissonPermitExpirableSemaphoreTest extends BaseConcurrentTest {
 
-//    @Test
-//    public void testUpdateLeaseTime() throws InterruptedException {
-//        RPermitExpirableSemaphore semaphore = redisson.getPermitExpirableSemaphore("test");
-//        semaphore.trySetPermits(1);
-//        assertThat(semaphore.updateLeaseTime("1234", 1, TimeUnit.SECONDS)).isFalse();
-//        String id = semaphore.acquire();
-//        assertThat(semaphore.updateLeaseTime(id, 1, TimeUnit.SECONDS)).isTrue();
-//        Thread.sleep(1200);
-//        assertThat(semaphore.updateLeaseTime(id, 1, TimeUnit.SECONDS)).isFalse();
-//        String id2 = semaphore.tryAcquire(1, 1, TimeUnit.SECONDS);
-//        assertThat(semaphore.updateLeaseTime(id2, 3, TimeUnit.SECONDS)).isTrue();
-//        Thread.sleep(2800);
-//        assertThat(semaphore.availablePermits()).isZero();
-//        Thread.sleep(500);
-//        assertThat(semaphore.availablePermits()).isOne();
-//        assertThat(semaphore.updateLeaseTime(id2, 2, TimeUnit.SECONDS)).isFalse();
-//    }
+    @Test
+    public void testUpdateLeaseTime() throws InterruptedException {
+        RPermitExpirableSemaphore semaphore = redisson.getPermitExpirableSemaphore("test");
+        semaphore.trySetPermits(1);
+        assertThat(semaphore.updateLeaseTime("1234", 1, TimeUnit.SECONDS)).isFalse();
+        String id = semaphore.acquire();
+        assertThat(semaphore.updateLeaseTime(id, 1, TimeUnit.SECONDS)).isTrue();
+        Thread.sleep(1200);
+        assertThat(semaphore.updateLeaseTime(id, 1, TimeUnit.SECONDS)).isFalse();
+        String id2 = semaphore.tryAcquire(1, 1, TimeUnit.SECONDS);
+        assertThat(semaphore.updateLeaseTime(id2, 3, TimeUnit.SECONDS)).isTrue();
+        Thread.sleep(2800);
+        assertThat(semaphore.availablePermits()).isZero();
+        Thread.sleep(500);
+        assertThat(semaphore.availablePermits()).isOne();
+        assertThat(semaphore.updateLeaseTime(id2, 2, TimeUnit.SECONDS)).isFalse();
+    }
     
     @Test
     public void testNotExistent() {
@@ -40,24 +40,24 @@ public class RedissonPermitExpirableSemaphoreTest extends BaseConcurrentTest {
         Assertions.assertEquals(0, semaphore.availablePermits());
     }
     
-//    @Test
-//    public void testAvailablePermits() throws InterruptedException {
-//        RPermitExpirableSemaphore semaphore = redisson.getPermitExpirableSemaphore("test-semaphore");
-//        assertThat(semaphore.trySetPermits(2)).isTrue();
-//        Assertions.assertEquals(2, semaphore.availablePermits());
-//        String acquire1 = semaphore.tryAcquire(200, 1000, TimeUnit.MILLISECONDS);
-//        assertThat(acquire1).isNotNull();
-//        String acquire2 = semaphore.tryAcquire(200, 1000, TimeUnit.MILLISECONDS);
-//        assertThat(acquire2).isNotNull();
-//        String acquire3 = semaphore.tryAcquire(200, 1000, TimeUnit.MILLISECONDS);
-//        assertThat(acquire3).isNull();
-//        Assertions.assertEquals(0, semaphore.availablePermits());
-//        Thread.sleep(1100);
-//        String acquire4 = semaphore.tryAcquire(200, 1000, TimeUnit.MILLISECONDS);
-//        assertThat(acquire4).isNotNull();
-//        Thread.sleep(1100);
-//        Assertions.assertEquals(2, semaphore.availablePermits());
-//    }
+    @Test
+    public void testAvailablePermits() throws InterruptedException {
+        RPermitExpirableSemaphore semaphore = redisson.getPermitExpirableSemaphore("test-semaphore");
+        assertThat(semaphore.trySetPermits(2)).isTrue();
+        Assertions.assertEquals(2, semaphore.availablePermits());
+        String acquire1 = semaphore.tryAcquire(200, 1000, TimeUnit.MILLISECONDS);
+        assertThat(acquire1).isNotNull();
+        String acquire2 = semaphore.tryAcquire(200, 1000, TimeUnit.MILLISECONDS);
+        assertThat(acquire2).isNotNull();
+        String acquire3 = semaphore.tryAcquire(200, 1000, TimeUnit.MILLISECONDS);
+        assertThat(acquire3).isNull();
+        Assertions.assertEquals(0, semaphore.availablePermits());
+        Thread.sleep(1100);
+        String acquire4 = semaphore.tryAcquire(200, 1000, TimeUnit.MILLISECONDS);
+        assertThat(acquire4).isNotNull();
+        Thread.sleep(1100);
+        Assertions.assertEquals(2, semaphore.availablePermits());
+    }
 
     @Test
     public void testClaimedPermits() throws InterruptedException {
@@ -98,78 +98,78 @@ public class RedissonPermitExpirableSemaphoreTest extends BaseConcurrentTest {
         Assertions.assertEquals(2, semaphore.maximumPermits());
     }
 
-//
-//    @Test
-//    public void testExpiration() throws InterruptedException {
-//        RPermitExpirableSemaphore semaphore = redisson.getPermitExpirableSemaphore("some-key");
-//        semaphore.trySetPermits(1);
-//        semaphore.expire(Duration.ofSeconds(3));
-//        semaphore.tryAcquire(1, 1, TimeUnit.SECONDS);
-//        Thread.sleep(4100);
-//        assertThat(redisson.getKeys().count()).isZero();
-//    }
-//
-//    @Test
-//    public void testExpire() throws InterruptedException {
-//        RPermitExpirableSemaphore s = redisson.getPermitExpirableSemaphore("test");
-//        s.trySetPermits(1);
-//        String permitId = s.acquire(2, TimeUnit.SECONDS);
-//
-//        final long startTime = System.currentTimeMillis();
-//        AtomicBoolean bool = new AtomicBoolean();
-//        Thread t = new Thread() {
-//            public void run() {
-//                RPermitExpirableSemaphore s = redisson.getPermitExpirableSemaphore("test");
-//                try {
-//                    String permitId = s.acquire();
-//                    long spendTime = System.currentTimeMillis() - startTime;
-//                    assertThat(spendTime).isBetween(1900L, 2100L);
-//                    s.release(permitId);
-//                    bool.set(true);
-//                } catch (InterruptedException e) {
-//                    // TODO Auto-generated catch block
-//                    e.printStackTrace();
-//                }
-//            };
-//        };
-//
-//        t.start();
-//        t.join();
-//
-//        assertThat(s.tryRelease(permitId)).isFalse();
-//        assertThat(bool.get()).isTrue();
-//    }
-//
-//    @Test
-//    public void testExpireTryAcquire() throws InterruptedException {
-//        RPermitExpirableSemaphore s = redisson.getPermitExpirableSemaphore("test");
-//        s.trySetPermits(1);
-//        String permitId = s.tryAcquire(100, 2, TimeUnit.SECONDS);
-//
-//        final long startTime = System.currentTimeMillis();
-//        AtomicBoolean bool = new AtomicBoolean();
-//        Thread t = new Thread() {
-//            public void run() {
-//                RPermitExpirableSemaphore s = redisson.getPermitExpirableSemaphore("test");
-//                try {
-//                    String permitId = s.acquire();
-//                    long spendTime = System.currentTimeMillis() - startTime;
-//                    assertThat(spendTime).isBetween(1900L, 2100L);
-//                    s.release(permitId);
-//                    bool.set(true);
-//                } catch (InterruptedException e) {
-//                    // TODO Auto-generated catch block
-//                    e.printStackTrace();
-//                }
-//            };
-//        };
-//
-//        t.start();
-//        t.join();
-//
-//        assertThat(s.tryRelease(permitId)).isFalse();
-//        assertThat(bool.get()).isTrue();
-//    }
+
+    @Test
+    public void testExpiration() throws InterruptedException {
+        RPermitExpirableSemaphore semaphore = redisson.getPermitExpirableSemaphore("some-key");
+        semaphore.trySetPermits(1);
+        semaphore.expire(Duration.ofSeconds(3));
+        semaphore.tryAcquire(1, 1, TimeUnit.SECONDS);
+        Thread.sleep(4100);
+        assertThat(redisson.getKeys().count()).isZero();
+    }
+
+    @Test
+    public void testExpire() throws InterruptedException {
+        RPermitExpirableSemaphore s = redisson.getPermitExpirableSemaphore("test");
+        s.trySetPermits(1);
+        String permitId = s.acquire(2, TimeUnit.SECONDS);
+
+        final long startTime = System.currentTimeMillis();
+        AtomicBoolean bool = new AtomicBoolean();
+        Thread t = new Thread() {
+            public void run() {
+                RPermitExpirableSemaphore s = redisson.getPermitExpirableSemaphore("test");
+                try {
+                    String permitId = s.acquire();
+                    long spendTime = System.currentTimeMillis() - startTime;
+                    assertThat(spendTime).isBetween(1900L, 2100L);
+                    s.release(permitId);
+                    bool.set(true);
+                } catch (InterruptedException e) {
+                    // TODO Auto-generated catch block
+                    e.printStackTrace();
+                }
+            };
+        };
+
+        t.start();
+        t.join();
+
+        assertThat(s.tryRelease(permitId)).isFalse();
+        assertThat(bool.get()).isTrue();
+    }
+
+    @Test
+    public void testExpireTryAcquire() throws InterruptedException {
+        RPermitExpirableSemaphore s = redisson.getPermitExpirableSemaphore("test");
+        s.trySetPermits(1);
+        String permitId = s.tryAcquire(100, 2, TimeUnit.SECONDS);
+
+        final long startTime = System.currentTimeMillis();
+        AtomicBoolean bool = new AtomicBoolean();
+        Thread t = new Thread() {
+            public void run() {
+                RPermitExpirableSemaphore s = redisson.getPermitExpirableSemaphore("test");
+                try {
+                    String permitId = s.acquire();
+                    long spendTime = System.currentTimeMillis() - startTime;
+                    assertThat(spendTime).isBetween(1900L, 2100L);
+                    s.release(permitId);
+                    bool.set(true);
+                } catch (InterruptedException e) {
+                    // TODO Auto-generated catch block
+                    e.printStackTrace();
+                }
+            };
+        };
+
+        t.start();
+        t.join();
+
+        assertThat(s.tryRelease(permitId)).isFalse();
+        assertThat(bool.get()).isTrue();
+    }
 
     
     @Test

--- a/redisson/src/test/java/org/redisson/RedissonPermitExpirableSemaphoreTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonPermitExpirableSemaphoreTest.java
@@ -80,24 +80,23 @@ public class RedissonPermitExpirableSemaphoreTest extends BaseConcurrentTest {
     }
 
     @Test
-    public void testMaximumPermits() throws InterruptedException {
+    public void testGetPermits() throws InterruptedException {
         RPermitExpirableSemaphore semaphore = redisson.getPermitExpirableSemaphore("test-semaphore");
         assertThat(semaphore.trySetPermits(2)).isTrue();
-        Assertions.assertEquals(2, semaphore.maximumPermits());
+        Assertions.assertEquals(2, semaphore.getPermits());
         String acquire1 = semaphore.tryAcquire(200, 1000, TimeUnit.MILLISECONDS);
         assertThat(acquire1).isNotNull();
         String acquire2 = semaphore.tryAcquire(200, 1000, TimeUnit.MILLISECONDS);
         assertThat(acquire2).isNotNull();
         String acquire3 = semaphore.tryAcquire(200, 1000, TimeUnit.MILLISECONDS);
         assertThat(acquire3).isNull();
-        Assertions.assertEquals(2, semaphore.maximumPermits());
+        Assertions.assertEquals(2, semaphore.getPermits());
         Thread.sleep(1100);
         String acquire4 = semaphore.tryAcquire(200, 1000, TimeUnit.MILLISECONDS);
         assertThat(acquire4).isNotNull();
         Thread.sleep(1100);
-        Assertions.assertEquals(2, semaphore.maximumPermits());
+        Assertions.assertEquals(2, semaphore.getPermits());
     }
-
 
     @Test
     public void testExpiration() throws InterruptedException {
@@ -182,34 +181,34 @@ public class RedissonPermitExpirableSemaphoreTest extends BaseConcurrentTest {
     }
 
     @Test
-    public void testSetMaximumPermits() throws InterruptedException {
+    public void testSetPermits() throws InterruptedException {
         RPermitExpirableSemaphore s = redisson.getPermitExpirableSemaphore("test");
-        assertThat(s.setMaximumPermits(10)).isEqualTo(10);
-        assertThat(s.maximumPermits()).isEqualTo(10);
+        assertThat(s.setPermits(10)).isEqualTo(10);
+        assertThat(s.getPermits()).isEqualTo(10);
         assertThat(s.availablePermits()).isEqualTo(10);
         assertThat(s.claimedPermits()).isEqualTo(0);
 
         // attempts to set available permits fail
         assertThat(s.trySetPermits(15)).isFalse();
-        assertThat(s.maximumPermits()).isEqualTo(10);
+        assertThat(s.getPermits()).isEqualTo(10);
         assertThat(s.availablePermits()).isEqualTo(10);
         assertThat(s.claimedPermits()).isEqualTo(0);
 
         // attempts to set max permits succeeds
-        assertThat(s.setMaximumPermits(15)).isEqualTo(5);
-        assertThat(s.maximumPermits()).isEqualTo(15);
+        assertThat(s.setPermits(15)).isEqualTo(5);
+        assertThat(s.getPermits()).isEqualTo(15);
         assertThat(s.availablePermits()).isEqualTo(15);
         assertThat(s.claimedPermits()).isEqualTo(0);
 
         // setting to existing value succeeds
-        assertThat(s.setMaximumPermits(15)).isEqualTo(0);
-        assertThat(s.maximumPermits()).isEqualTo(15);
+        assertThat(s.setPermits(15)).isEqualTo(0);
+        assertThat(s.getPermits()).isEqualTo(15);
         assertThat(s.availablePermits()).isEqualTo(15);
         assertThat(s.claimedPermits()).isEqualTo(0);
 
         // decreasing max permits succeeds
-        assertThat(s.setMaximumPermits(5)).isEqualTo(-10);
-        assertThat(s.maximumPermits()).isEqualTo(5);
+        assertThat(s.setPermits(5)).isEqualTo(-10);
+        assertThat(s.getPermits()).isEqualTo(5);
         assertThat(s.availablePermits()).isEqualTo(5);
         assertThat(s.claimedPermits()).isEqualTo(0);
 
@@ -221,20 +220,20 @@ public class RedissonPermitExpirableSemaphoreTest extends BaseConcurrentTest {
         String acquire3 = s.tryAcquire(200, 1000, TimeUnit.MILLISECONDS);
         assertThat(acquire3).isNotNull();
 
-        assertThat(s.maximumPermits()).isEqualTo(5);
+        assertThat(s.getPermits()).isEqualTo(5);
         assertThat(s.availablePermits()).isEqualTo(2);
         assertThat(s.claimedPermits()).isEqualTo(3);
 
         // decreasing the max to the number of claimed permits is allowed
-        assertThat(s.setMaximumPermits(3)).isEqualTo(-2);
-        assertThat(s.maximumPermits()).isEqualTo(3);
+        assertThat(s.setPermits(3)).isEqualTo(-2);
+        assertThat(s.getPermits()).isEqualTo(3);
         assertThat(s.availablePermits()).isEqualTo(0);
         assertThat(s.claimedPermits()).isEqualTo(3);
 
         // decreasing the max to below the number of claimed permits is allowed
         // and results in a negative number of available permits
-        assertThat(s.setMaximumPermits(2)).isEqualTo(-1);
-        assertThat(s.maximumPermits()).isEqualTo(2);
+        assertThat(s.setPermits(2)).isEqualTo(-1);
+        assertThat(s.getPermits()).isEqualTo(2);
         assertThat(s.availablePermits()).isEqualTo(-1);
         assertThat(s.claimedPermits()).isEqualTo(3);
     }

--- a/redisson/src/test/java/org/redisson/RedissonPermitExpirableSemaphoreTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonPermitExpirableSemaphoreTest.java
@@ -60,23 +60,23 @@ public class RedissonPermitExpirableSemaphoreTest extends BaseConcurrentTest {
     }
 
     @Test
-    public void testClaimedPermits() throws InterruptedException {
+    public void testAcquiredPermits() throws InterruptedException {
         RPermitExpirableSemaphore semaphore = redisson.getPermitExpirableSemaphore("test-semaphore");
         assertThat(semaphore.trySetPermits(2)).isTrue();
-        Assertions.assertEquals(0, semaphore.claimedPermits());
+        Assertions.assertEquals(0, semaphore.acquiredPermits());
         String acquire1 = semaphore.tryAcquire(200, 1000, TimeUnit.MILLISECONDS);
         assertThat(acquire1).isNotNull();
-        Assertions.assertEquals(1, semaphore.claimedPermits());
+        Assertions.assertEquals(1, semaphore.acquiredPermits());
         String acquire2 = semaphore.tryAcquire(200, 1000, TimeUnit.MILLISECONDS);
         assertThat(acquire2).isNotNull();
         String acquire3 = semaphore.tryAcquire(200, 1000, TimeUnit.MILLISECONDS);
         assertThat(acquire3).isNull();
-        Assertions.assertEquals(2, semaphore.claimedPermits());
+        Assertions.assertEquals(2, semaphore.acquiredPermits());
         Thread.sleep(1100);
         String acquire4 = semaphore.tryAcquire(200, 1000, TimeUnit.MILLISECONDS);
         assertThat(acquire4).isNotNull();
         Thread.sleep(1100);
-        Assertions.assertEquals(0, semaphore.claimedPermits());
+        Assertions.assertEquals(0, semaphore.acquiredPermits());
     }
 
     @Test
@@ -186,31 +186,31 @@ public class RedissonPermitExpirableSemaphoreTest extends BaseConcurrentTest {
         s.setPermits(10);
         assertThat(s.getPermits()).isEqualTo(10);
         assertThat(s.availablePermits()).isEqualTo(10);
-        assertThat(s.claimedPermits()).isEqualTo(0);
+        assertThat(s.acquiredPermits()).isEqualTo(0);
 
         // attempts to set available permits fail
         assertThat(s.trySetPermits(15)).isFalse();
         assertThat(s.getPermits()).isEqualTo(10);
         assertThat(s.availablePermits()).isEqualTo(10);
-        assertThat(s.claimedPermits()).isEqualTo(0);
+        assertThat(s.acquiredPermits()).isEqualTo(0);
 
         // attempts to set max permits succeeds
         s.setPermits(15);
         assertThat(s.getPermits()).isEqualTo(15);
         assertThat(s.availablePermits()).isEqualTo(15);
-        assertThat(s.claimedPermits()).isEqualTo(0);
+        assertThat(s.acquiredPermits()).isEqualTo(0);
 
         // setting to existing value succeeds
         s.setPermits(15);
         assertThat(s.getPermits()).isEqualTo(15);
         assertThat(s.availablePermits()).isEqualTo(15);
-        assertThat(s.claimedPermits()).isEqualTo(0);
+        assertThat(s.acquiredPermits()).isEqualTo(0);
 
         // decreasing max permits succeeds
         s.setPermits(5);
         assertThat(s.getPermits()).isEqualTo(5);
         assertThat(s.availablePermits()).isEqualTo(5);
-        assertThat(s.claimedPermits()).isEqualTo(0);
+        assertThat(s.acquiredPermits()).isEqualTo(0);
 
         // changing the max after acquiring permits succeeds
         String acquire1 = s.tryAcquire(200, 1000, TimeUnit.MILLISECONDS);
@@ -222,20 +222,20 @@ public class RedissonPermitExpirableSemaphoreTest extends BaseConcurrentTest {
 
         assertThat(s.getPermits()).isEqualTo(5);
         assertThat(s.availablePermits()).isEqualTo(2);
-        assertThat(s.claimedPermits()).isEqualTo(3);
+        assertThat(s.acquiredPermits()).isEqualTo(3);
 
         // decreasing the max to the number of claimed permits is allowed
         s.setPermits(3);
         assertThat(s.getPermits()).isEqualTo(3);
         assertThat(s.availablePermits()).isEqualTo(0);
-        assertThat(s.claimedPermits()).isEqualTo(3);
+        assertThat(s.acquiredPermits()).isEqualTo(3);
 
         // decreasing the max to below the number of claimed permits is allowed
         // and results in a negative number of available permits
         s.setPermits(2);
         assertThat(s.getPermits()).isEqualTo(2);
         assertThat(s.availablePermits()).isEqualTo(-1);
-        assertThat(s.claimedPermits()).isEqualTo(3);
+        assertThat(s.acquiredPermits()).isEqualTo(3);
     }
 
     @Test

--- a/redisson/src/test/java/org/redisson/RedissonPermitExpirableSemaphoreTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonPermitExpirableSemaphoreTest.java
@@ -183,7 +183,7 @@ public class RedissonPermitExpirableSemaphoreTest extends BaseConcurrentTest {
     @Test
     public void testSetPermits() throws InterruptedException {
         RPermitExpirableSemaphore s = redisson.getPermitExpirableSemaphore("test");
-        assertThat(s.setPermits(10)).isEqualTo(10);
+        s.setPermits(10);
         assertThat(s.getPermits()).isEqualTo(10);
         assertThat(s.availablePermits()).isEqualTo(10);
         assertThat(s.claimedPermits()).isEqualTo(0);
@@ -195,19 +195,19 @@ public class RedissonPermitExpirableSemaphoreTest extends BaseConcurrentTest {
         assertThat(s.claimedPermits()).isEqualTo(0);
 
         // attempts to set max permits succeeds
-        assertThat(s.setPermits(15)).isEqualTo(5);
+        s.setPermits(15);
         assertThat(s.getPermits()).isEqualTo(15);
         assertThat(s.availablePermits()).isEqualTo(15);
         assertThat(s.claimedPermits()).isEqualTo(0);
 
         // setting to existing value succeeds
-        assertThat(s.setPermits(15)).isEqualTo(0);
+        s.setPermits(15);
         assertThat(s.getPermits()).isEqualTo(15);
         assertThat(s.availablePermits()).isEqualTo(15);
         assertThat(s.claimedPermits()).isEqualTo(0);
 
         // decreasing max permits succeeds
-        assertThat(s.setPermits(5)).isEqualTo(-10);
+        s.setPermits(5);
         assertThat(s.getPermits()).isEqualTo(5);
         assertThat(s.availablePermits()).isEqualTo(5);
         assertThat(s.claimedPermits()).isEqualTo(0);
@@ -225,14 +225,14 @@ public class RedissonPermitExpirableSemaphoreTest extends BaseConcurrentTest {
         assertThat(s.claimedPermits()).isEqualTo(3);
 
         // decreasing the max to the number of claimed permits is allowed
-        assertThat(s.setPermits(3)).isEqualTo(-2);
+        s.setPermits(3);
         assertThat(s.getPermits()).isEqualTo(3);
         assertThat(s.availablePermits()).isEqualTo(0);
         assertThat(s.claimedPermits()).isEqualTo(3);
 
         // decreasing the max to below the number of claimed permits is allowed
         // and results in a negative number of available permits
-        assertThat(s.setPermits(2)).isEqualTo(-1);
+        s.setPermits(2);
         assertThat(s.getPermits()).isEqualTo(2);
         assertThat(s.availablePermits()).isEqualTo(-1);
         assertThat(s.claimedPermits()).isEqualTo(3);

--- a/redisson/src/test/java/org/redisson/RedissonPermitExpirableSemaphoreTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonPermitExpirableSemaphoreTest.java
@@ -247,6 +247,8 @@ public class RedissonPermitExpirableSemaphoreTest extends BaseConcurrentTest {
         assertThat(s.availablePermits()).isEqualTo(15);
         s.addPermits(-10);
         assertThat(s.availablePermits()).isEqualTo(5);
+        s.addPermits(-10);
+        assertThat(s.availablePermits()).isEqualTo(-5);
     }
     
     @Test


### PR DESCRIPTION
This PR implements tracking and management setting for the maximum number of permits possible for the RedissonPermitExpirableSemaphore.

The added functionality is contained in the following functions

`int maximumPermits()`: returns the maximum number of permits which could ever be available

`int claimedPermits()`: returns the number of permits which are currently claimed by clients

`boolean trySetMaximumPermits(int maximumPermits)`: increases/decreases the number of available permits such that the maximum number of permits is the provided value