### PR TITLE
Fix incorrectly reset jackson type factory

### DIFF
--- a/redisson/src/main/java/org/redisson/codec/JsonJacksonCodec.java
+++ b/redisson/src/main/java/org/redisson/codec/JsonJacksonCodec.java
@@ -130,7 +130,7 @@ public class JsonJacksonCodec extends BaseCodec {
     }
 
     protected static ObjectMapper createObjectMapper(ClassLoader classLoader, ObjectMapper om) {
-        TypeFactory tf = TypeFactory.defaultInstance().withClassLoader(classLoader);
+        TypeFactory tf = om.getTypeFactory().withClassLoader(classLoader);
         om.setTypeFactory(tf);
         return om;
     }


### PR DESCRIPTION
By overriding the objectMapper’s TypeFactory to use the default type factory, you are blowing away any type factory configuration that may have been done on the mapper eg in Jdk8Module it sets up Jdk8Types. As a result this can result in the inability to deserialize desired types that the mapper had been configured for.

This is what happened with ticket #2010

To fix this, while still using the desired ClassLoader you can just get the TypeFactory from the object mapper and then call withClassLoader on it.
