### PR TITLE
Bugfix - RedissonFunction doesn't pass keys to Redis correctly

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonFuction.java
+++ b/redisson/src/main/java/org/redisson/RedissonFuction.java
@@ -199,7 +199,7 @@ public class RedissonFuction implements RFunction {
         args.add(name);
         args.add(keys.size());
         if (keys.size() > 0) {
-            args.add(keys);
+            args.addAll(keys);
         }
         args.addAll(encode(Arrays.asList(values), codec));
         if (mode == FunctionMode.READ) {

--- a/redisson/src/test/java/org/redisson/RedissonFunctionTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonFunctionTest.java
@@ -68,6 +68,20 @@ public class RedissonFunctionTest extends BaseTest {
     }
 
     @Test
+    public void testKeysLoadAsExpected() {
+	RFunction f = redisson.getFunction();
+	f.flush();
+	f.load("lib", "redis.register_function('myfun', function(keys, args) return keys[1] end)" +
+					"redis.register_function('myfun2', function(keys, args) return args[1] end");
+	String s = f.call(FunctionMode.READ, "myfun", FunctionResult.VALUE, List.of("testKey"), "arg1");
+	assertThat(s).isEqualTo("testKey");
+
+	RFunction f2 = redisson.getFunction(StringCodec.INSTANCE);
+	String s2 = f2.call(FunctionMode.READ, "myfun2", FunctionResult.STRING, List.of("testKey1", "testKey2"), "arg1");
+	assertThat(s2).isEqualTo("arg1");
+    }
+
+    @Test
     public void testList() {
         RFunction f = redisson.getFunction();
         f.flush();


### PR DESCRIPTION
This changes the way keys are passed to Redis in `RedissonFunction`. Currently, the `keys` list is added to `args`, rather than the contents of `keys`. This stringifies the list when it's passed to Redis, making the entire list a single key. If more than one key is passed, Redis starts to use args for keys, since it expects *n* keys. I have added a unit test covering both these cases.

See #4729 for more details.