### PR TITLE
Use slf4j late-binding when logging instead of string concat

### DIFF
--- a/redisson/src/main/java/org/redisson/MapWriteBehindTask.java
+++ b/redisson/src/main/java/org/redisson/MapWriteBehindTask.java
@@ -93,7 +93,7 @@ public class MapWriteBehindTask {
                 deletedKeys.clear();
             }
         } catch (Exception exception) {
-            log.error("Unable to delete keys: " + deletedKeys, exception);
+            log.error("Unable to delete keys: {}", deletedKeys, exception);
         }
         try {
             if (!addedMap.isEmpty()) {
@@ -105,7 +105,7 @@ public class MapWriteBehindTask {
                 addedMap.clear();
             }
         } catch (Exception exception) {
-            log.error("Unable to add keys: " + addedMap, exception);
+            log.error("Unable to add keys: {}", addedMap, exception);
         }
     }
 
@@ -124,7 +124,7 @@ public class MapWriteBehindTask {
 
                     }
                 } catch (Exception exception) {
-                    log.error("Unable to delete keys: " + deletedKeys, exception);
+                    log.error("Unable to delete keys: {}", deletedKeys, exception);
                 }
             }
         } else {
@@ -140,7 +140,7 @@ public class MapWriteBehindTask {
                         addedMap.clear();
                     }
                 } catch (Exception exception) {
-                    log.error("Unable to add keys: " + addedMap, exception);
+                    log.error("Unable to add keys: {}", addedMap, exception);
                 }
             }
         }

--- a/redisson/src/main/java/org/redisson/RedissonBaseLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonBaseLock.java
@@ -140,7 +140,7 @@ public abstract class RedissonBaseLock extends RedissonExpirable implements RLoc
                 CompletionStage<Boolean> future = renewExpirationAsync(threadId);
                 future.whenComplete((res, e) -> {
                     if (e != null) {
-                        log.error("Can't update lock " + getRawName() + " expiration", e);
+                        log.error("Can't update lock {} expiration", getRawName(), e);
                         EXPIRATION_RENEWAL_MAP.remove(getEntryName());
                         return;
                     }

--- a/redisson/src/main/java/org/redisson/RedissonMap.java
+++ b/redisson/src/main/java/org/redisson/RedissonMap.java
@@ -1723,7 +1723,7 @@ public class RedissonMap<K, V> extends RedissonExpirable implements RMap<K, V> {
                             return;
                         }
                     } catch (Exception e) {
-                        log.error("Unable to load value by key " + key + " for map " + getRawName(), e);
+                        log.error("Unable to load value by key {} for map {}", key, getRawName(), e);
                         lock.unlockAsync(threadId)
                                 .whenComplete((r, ex) -> {
                                     if (ex != null) {
@@ -1765,7 +1765,7 @@ public class RedissonMap<K, V> extends RedissonExpirable implements RMap<K, V> {
                 return lock.unlockAsync(threadId);
             }
             if (ex != null) {
-                log.error("Unable to load value by key " + key + " for map " + getRawName(), ex);
+                log.error("Unable to load value by key {} for map {}", key, getRawName(), ex);
                 return lock.unlockAsync(threadId);
             }
 
@@ -1776,7 +1776,7 @@ public class RedissonMap<K, V> extends RedissonExpirable implements RMap<K, V> {
                 return (CompletionStage<V>) putOperationAsync(key, (V) value).handle((r, ex) -> {
                     RFuture<Void> f = lock.unlockAsync(threadId);
                     if (ex != null) {
-                        log.error("Unable to store value by key " + key + " for map " + getRawName(), ex);
+                        log.error("Unable to store value by key {} for map {}", key, getRawName(), ex);
                         return f;
                     }
                     return f.thenApply(res -> value);

--- a/redisson/src/main/java/org/redisson/RedissonNode.java
+++ b/redisson/src/main/java/org/redisson/RedissonNode.java
@@ -94,7 +94,7 @@ public final class RedissonNode {
             try {
                 config = RedissonNodeFileConfig.fromYAML(new File(configPath));
             } catch (IOException e1) {
-                log.error("Can't parse json config " + configPath, e);
+                log.error("Can't parse json config {}", configPath, e);
                 throw new IllegalArgumentException("Can't parse yaml config " + configPath, e1);
             }
         }

--- a/redisson/src/main/java/org/redisson/RedissonReliableTopic.java
+++ b/redisson/src/main/java/org/redisson/RedissonReliableTopic.java
@@ -335,7 +335,7 @@ public class RedissonReliableTopic extends RedissonExpirable implements RReliabl
                 System.currentTimeMillis() + commandExecutor.getConnectionManager().getCfg().getReliableTopicWatchdogTimeout(), subscriberId.get());
             future.whenComplete((res, e) -> {
                 if (e != null) {
-                    log.error("Can't update reliable topic " + getRawName() + " expiration time", e);
+                    log.error("Can't update reliable topic {} expiration time", getRawName(), e);
                     return;
                 }
 

--- a/redisson/src/main/java/org/redisson/RedissonRemoteService.java
+++ b/redisson/src/main/java/org/redisson/RedissonRemoteService.java
@@ -280,7 +280,7 @@ public class RedissonRemoteService extends BaseRemoteService implements RRemoteS
                         if (exc instanceof RedissonShutdownException) {
                             return;
                         }
-                        log.error("Can't process the remote service request with id " + requestId, exc);
+                        log.error("Can't process the remote service request with id {}", requestId, exc);
                             
                         // re-subscribe after a failed takeAsync
                         resubscribe(remoteInterface, requestQueue, executor, bean);
@@ -330,7 +330,7 @@ public class RedissonRemoteService extends BaseRemoteService implements RRemoteS
                                         if (ex instanceof RedissonShutdownException) {
                                             return;
                                         }
-                                        log.error("Can't send ack for request: " + request, ex);
+                                        log.error("Can't send ack for request: {}", request, ex);
 
                                         // re-subscribe after a failed send (ack)
                                         resubscribe(remoteInterface, requestQueue, executor, bean);
@@ -350,7 +350,7 @@ public class RedissonRemoteService extends BaseRemoteService implements RRemoteS
                                             if (exce instanceof RedissonShutdownException) {
                                                 return;
                                             }
-                                            log.error("Can't send ack for request: " + request, exce);
+                                            log.error("Can't send ack for request: {}", request, exce);
 
                                             // re-subscribe after a failed send (ack)
                                             resubscribe(remoteInterface, requestQueue, executor, bean);
@@ -413,13 +413,13 @@ public class RedissonRemoteService extends BaseRemoteService implements RRemoteS
                             if (exc instanceof RedissonShutdownException) {
                                 return;
                             }
-                            log.error("Can't send response: " + response + " for request: " + request, exc);
+                            log.error("Can't send response: {} for request: {}", response, request, exc);
                         }
 
                         resubscribe(remoteInterface, requestQueue, executor, method.getBean());
                     });
                 } catch (Exception ex) {
-                    log.error("Can't send response: " + result + " for request: " + request, ex);
+                    log.error("Can't send response: {} for request: {}", result, request, ex);
                 }
             } else {
                 resubscribe(remoteInterface, requestQueue, executor, method.getBean());
@@ -465,7 +465,7 @@ public class RedissonRemoteService extends BaseRemoteService implements RRemoteS
         } catch (Exception e) {
             RemoteServiceResponse response = new RemoteServiceResponse(request.getId(), e.getCause());
             responsePromise.complete(response);
-            log.error("Can't execute: " + request, e);
+            log.error("Can't execute: {}", request, e);
         }
 
         if (cancelRequestFuture != null) {

--- a/redisson/src/main/java/org/redisson/Version.java
+++ b/redisson/src/main/java/org/redisson/Version.java
@@ -38,7 +38,7 @@ public class Version {
                     }
                     String name = attrs.getValue("Bundle-Name");
                     if ("Redisson".equals(name)) {
-                        log.info("Redisson " + attrs.getValue("Bundle-Version"));
+                        log.info("Redisson {}", attrs.getValue("Bundle-Version"));
                         break;
                     }
             }

--- a/redisson/src/main/java/org/redisson/client/RedisConnection.java
+++ b/redisson/src/main/java/org/redisson/client/RedisConnection.java
@@ -69,7 +69,7 @@ public class RedisConnection implements RedisCommands {
         updateChannel(channel);
         lastUsageTime = System.nanoTime();
 
-        LOG.debug("Connection created " + redisClient);
+        LOG.debug("Connection created {}", redisClient);
     }
     
     protected RedisConnection(RedisClient redisClient) {

--- a/redisson/src/main/java/org/redisson/client/handler/CommandDecoder.java
+++ b/redisson/src/main/java/org/redisson/client/handler/CommandDecoder.java
@@ -205,7 +205,7 @@ public class CommandDecoder extends ReplayingDecoder<State> {
                 decode(in, cmd, null, channel, false, null);
                 sendNext(channel, data);
             } catch (Exception e) {
-                log.error("Unable to decode data. channel: " + channel + ", reply: " + LogHelper.toString(in) + ", command: " + LogHelper.toString(data), e);
+                log.error("Unable to decode data. channel: {}, reply: {}, command: {}", channel, LogHelper.toString(in), LogHelper.toString(data), e);
                 in.readerIndex(endIndex);
                 sendNext(channel);
                 cmd.tryFailure(e);
@@ -228,7 +228,7 @@ public class CommandDecoder extends ReplayingDecoder<State> {
                 }
                 sendNext(channel);
             } catch (Exception e) {
-                log.error("Unable to decode data. channel: " + channel + ", reply: " + LogHelper.toString(in), e);
+                log.error("Unable to decode data. channel: {}, reply: {}", channel, LogHelper.toString(in), e);
                 sendNext(channel);
                 throw e;
             }

--- a/redisson/src/main/java/org/redisson/client/handler/CommandPubSubDecoder.java
+++ b/redisson/src/main/java/org/redisson/client/handler/CommandPubSubDecoder.java
@@ -87,7 +87,7 @@ public class CommandPubSubDecoder extends CommandDecoder {
                 }
                 sendNext(channel);
             } catch (Exception e) {
-                log.error("Unable to decode data. channel: " + channel + ", reply: " + LogHelper.toString(in), e);
+                log.error("Unable to decode data. channel: {}, reply: {}", channel, LogHelper.toString(in), e);
                 sendNext(channel);
                 throw e;
             }
@@ -99,7 +99,7 @@ public class CommandPubSubDecoder extends CommandDecoder {
                 }
                 sendNext(channel, data);
             } catch (Exception e) {
-                log.error("Unable to decode data. channel: " + channel + ", reply: " + LogHelper.toString(in), e);
+                log.error("Unable to decode data. channel: {}, reply: {}", channel, LogHelper.toString(in), e);
                 cmd.tryFailure(e);
                 sendNext(channel);
                 throw e;

--- a/redisson/src/main/java/org/redisson/client/handler/ErrorsLoggingHandler.java
+++ b/redisson/src/main/java/org/redisson/client/handler/ErrorsLoggingHandler.java
@@ -44,7 +44,7 @@ public class ErrorsLoggingHandler extends ChannelDuplexHandler {
             }
         }
 
-        log.error("Exception occured. Channel: " + ctx.channel(), cause);
+        log.error("Exception occured. Channel: {}", ctx.channel(), cause);
     }
 
 }

--- a/redisson/src/main/java/org/redisson/client/handler/PingConnectionHandler.java
+++ b/redisson/src/main/java/org/redisson/client/handler/PingConnectionHandler.java
@@ -89,7 +89,7 @@ public class PingConnectionHandler extends ChannelInboundHandlerAdapter {
                             || cause instanceof RedisClusterDownException
                                 || cause instanceof RedisBusyException)) {
                     if (!future.isCancelled()) {
-                        log.error("Unable to send PING command over channel: " + ctx.channel(), cause);
+                        log.error("Unable to send PING command over channel: {}", ctx.channel(), cause);
                     }
 
                     log.debug("channel: {} closed due to PING response timeout set in {} ms", ctx.channel(), config.getPingConnectionInterval());

--- a/redisson/src/main/java/org/redisson/cluster/ClusterConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/cluster/ClusterConnectionManager.java
@@ -315,7 +315,7 @@ public class ClusterConnectionManager extends MasterSlaveConnectionManager {
             CompletableFuture<RedisClient> f = entry.setupMasterEntry(new RedisURI(config.getMasterAddress()), configEndpointHostName);
             f.whenComplete((masterClient, ex3) -> {
                 if (ex3 != null) {
-                    log.error("Can't add master: " + partition.getMasterAddress() + " for slot ranges: " + partition.getSlotRanges(), ex3);
+                    log.error("Can't add master: {} for slot ranges: {}", partition.getMasterAddress(), partition.getSlotRanges(), ex3);
                     result.completeExceptionally(ex3);
                     return;
                 }
@@ -329,8 +329,7 @@ public class ClusterConnectionManager extends MasterSlaveConnectionManager {
                     CompletableFuture<Void> fs = entry.initSlaveBalancer(partition.getFailedSlaveAddresses(), configEndpointHostName);
                     fs.whenComplete((r, ex) -> {
                         if (ex != null) {
-                            log.error("unable to add slave for: " + partition.getMasterAddress()
-                                    + " slot ranges: " + partition.getSlotRanges(), ex);
+                            log.error("unable to add slave for: {} slot ranges: {}", partition.getMasterAddress(), partition.getSlotRanges(), ex);
                             result.completeExceptionally(ex);
                             return;
                         }
@@ -449,7 +448,7 @@ public class ClusterConnectionManager extends MasterSlaveConnectionManager {
         RFuture<List<ClusterNodeInfo>> future = connection.async(clusterNodesCommand);
         future.whenComplete((nodes, e) -> {
                 if (e != null) {
-                    log.error("Unable to execute " + clusterNodesCommand, e);
+                    log.error("Unable to execute {}", clusterNodesCommand, e);
                     lastException.set(e);
                     getShutdownLatch().release();
                     checkClusterState(cfg, iterator, lastException);
@@ -481,7 +480,7 @@ public class ClusterConnectionManager extends MasterSlaveConnectionManager {
                                 for (ClusterNodeInfo clusterNodeInfo : nodes) {
                                     nodesValue.append(clusterNodeInfo.getNodeInfo()).append("\n");
                                 }
-                                log.error("Unable to parse cluster nodes state got from: " + connection.getRedisClient().getAddr() + ":\n" + nodesValue, ex);
+                                log.error("Unable to parse cluster nodes state got from: {}:\n{}", connection.getRedisClient().getAddr(), nodesValue, ex);
                                 lastException.set(ex);
                                 getShutdownLatch().release();
                                 checkClusterState(cfg, iterator, lastException);
@@ -602,7 +601,7 @@ public class ClusterConnectionManager extends MasterSlaveConnectionManager {
             CompletableFuture<Void> slaveUpFuture = entry.addSlave(uri, false, NodeType.SLAVE, configEndpointHostName);
             slaveUpFuture = slaveUpFuture.whenComplete((res, ex) -> {
                 if (ex != null) {
-                    log.error("Can't add slave: " + uri, ex);
+                    log.error("Can't add slave: {}", uri, ex);
                 }
             }).thenCompose(res -> {
                 currentPart.addSlaveAddress(uri);

--- a/redisson/src/main/java/org/redisson/command/CommandBatchService.java
+++ b/redisson/src/main/java/org/redisson/command/CommandBatchService.java
@@ -312,7 +312,7 @@ public class CommandBatchService extends CommandAsyncService {
                                 entryResult = objectBuilder.tryHandleReference(entryResult, referenceType);
                             }
                         } catch (ReflectiveOperationException exc) {
-                            log.error("Unable to handle reference from " + entryResult, exc);
+                            log.error("Unable to handle reference from {}", entryResult, exc);
                         }
                         responses.add(entryResult);
                     }

--- a/redisson/src/main/java/org/redisson/connection/DNSMonitor.java
+++ b/redisson/src/main/java/org/redisson/connection/DNSMonitor.java
@@ -99,7 +99,7 @@ public class DNSMonitor {
             Future<InetSocketAddress> resolveFuture = resolver.resolve(InetSocketAddress.createUnresolved(entry.getKey().getHost(), entry.getKey().getPort()));
             resolveFuture.addListener((FutureListener<InetSocketAddress>) future -> {
                 if (!future.isSuccess()) {
-                    log.error("Unable to resolve " + entry.getKey().getHost(), future.cause());
+                    log.error("Unable to resolve {}", entry.getKey().getHost(), future.cause());
                     promise.complete(null);
                     return;
                 }
@@ -146,7 +146,7 @@ public class DNSMonitor {
             Future<InetSocketAddress> resolveFuture = resolver.resolve(InetSocketAddress.createUnresolved(entry.getKey().getHost(), entry.getKey().getPort()));
             resolveFuture.addListener((FutureListener<InetSocketAddress>) future -> {
                 if (!future.isSuccess()) {
-                    log.error("Unable to resolve " + entry.getKey().getHost(), future.cause());
+                    log.error("Unable to resolve {}", entry.getKey().getHost(), future.cause());
                     promise.complete(null);
                     return;
                 }
@@ -182,7 +182,7 @@ public class DNSMonitor {
                             CompletableFuture<Void> addFuture = masterSlaveEntry.addSlave(newSlaveAddr, entry.getKey());
                             addFuture.whenComplete((res, e) -> {
                                 if (e != null) {
-                                    log.error("Can't add slave: " + newSlaveAddr, e);
+                                    log.error("Can't add slave: {}", newSlaveAddr, e);
                                     promise.complete(null);
                                     return;
                                 }

--- a/redisson/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
@@ -572,7 +572,7 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
     public void releaseWrite(NodeSource source, RedisConnection connection) {
         MasterSlaveEntry entry = getEntry(source);
         if (entry == null) {
-            log.error("Node: " + source + " can't be found");
+            log.error("Node: {} can't be found", source);
         } else {
             entry.releaseWrite(connection);
         }
@@ -582,7 +582,7 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
     public void releaseRead(NodeSource source, RedisConnection connection) {
         MasterSlaveEntry entry = getEntry(source);
         if (entry == null) {
-            log.error("Node: " + source + " can't be found");
+            log.error("Node: {} can't be found", source);
         } else {
             entry.releaseRead(connection);
         }
@@ -720,7 +720,7 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
         Future<InetSocketAddress> future = resolver.resolve(addr);
         future.addListener((FutureListener<InetSocketAddress>) f -> {
             if (!f.isSuccess()) {
-                log.error("Unable to resolve " + address, f.cause());
+                log.error("Unable to resolve {}", address, f.cause());
                 result.completeExceptionally(f.cause());
                 return;
             }

--- a/redisson/src/main/java/org/redisson/connection/MasterSlaveEntry.java
+++ b/redisson/src/main/java/org/redisson/connection/MasterSlaveEntry.java
@@ -525,7 +525,7 @@ public class MasterSlaveEntry {
                     masterEntry.shutdownAsync();
                     masterEntry = oldMaster;
                 }
-                log.error("Unable to change master from: " + oldMaster.getClient().getAddr() + " to: " + address, e);
+                log.error("Unable to change master from: {} to: {}", oldMaster.getClient().getAddr(), address, e);
                 return;
             }
             

--- a/redisson/src/main/java/org/redisson/connection/ReplicatedConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/ReplicatedConnectionManager.java
@@ -98,7 +98,7 @@ public class ReplicatedConnectionManager extends MasterSlaveConnectionManager {
             throw new RedisConnectionException("Can't connect to servers!");
         }
         if (this.config.getReadMode() != ReadMode.MASTER && this.config.getSlaveAddresses().isEmpty()) {
-            log.warn("ReadMode = " + this.config.getReadMode() + ", but slave nodes are not found! Please specify all nodes in replicated mode.");
+            log.warn("ReadMode = {}, but slave nodes are not found! Please specify all nodes in replicated mode.", this.config.getReadMode());
         }
 
         initSingleEntry();
@@ -172,8 +172,7 @@ public class ReplicatedConnectionManager extends MasterSlaveConnectionManager {
                     RedisConnection connection = connectionFuture.toCompletableFuture().join();
                     if (!ip.equals(connection.getRedisClient().getAddr())) {
                         disconnectNode(uri);
-                        log.info("Hostname: " + uri + " has changed IP from: "
-                                    + connection.getRedisClient().getAddr() + " to " + ip);
+                        log.info("Hostname: {} has changed IP from: {} to {}", uri, connection.getRedisClient().getAddr(), ip);
                         return CompletableFuture.<Map<String, String>>completedFuture(null);
                     }
 
@@ -194,7 +193,7 @@ public class ReplicatedConnectionManager extends MasterSlaveConnectionManager {
                         } else if (currentMaster.compareAndSet(master, addr)) {
                             CompletableFuture<RedisClient> changeFuture = changeMaster(singleSlotRange.getStartSlot(), uri);
                             return changeFuture.exceptionally(e -> {
-                                    log.error("Unable to change master to " + addr, e);
+                                    log.error("Unable to change master to {}", addr, e);
                                     currentMaster.compareAndSet(addr, master);
                                     return null;
                             });

--- a/redisson/src/main/java/org/redisson/connection/SentinelConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/SentinelConnectionManager.java
@@ -203,7 +203,7 @@ public class SentinelConnectionManager extends MasterSlaveConnectionManager {
             throw new RedisConnectionException("Can't connect to servers!", lastException);
         }
         if (this.config.getReadMode() != ReadMode.MASTER && this.config.getSlaveAddresses().isEmpty()) {
-            log.warn("ReadMode = " + this.config.getReadMode() + ", but slave nodes are not found!");
+            log.warn("ReadMode = {}, but slave nodes are not found!", this.config.getReadMode());
         }
         
         initSingleEntry();
@@ -291,7 +291,7 @@ public class SentinelConnectionManager extends MasterSlaveConnectionManager {
             Future<List<InetSocketAddress>> allNodes = sentinelResolver.resolveAll(InetSocketAddress.createUnresolved(host.getHost(), host.getPort()));
             allNodes.addListener((FutureListener<List<InetSocketAddress>>) future -> {
                 if (!future.isSuccess()) {
-                    log.error("Unable to resolve " + host.getHost(), future.cause());
+                    log.error("Unable to resolve {}", host.getHost(), future.cause());
                     return;
                 }
 
@@ -369,7 +369,7 @@ public class SentinelConnectionManager extends MasterSlaveConnectionManager {
         CompletableFuture<Void> future = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
         future.whenComplete((r, e) -> {
             if (e != null) {
-                log.error("Can't execute SENTINEL commands on " + connection.getRedisClient().getAddr(), e);
+                log.error("Can't execute SENTINEL commands on {}", connection.getRedisClient().getAddr(), e);
             }
 
             getShutdownLatch().release();
@@ -460,7 +460,7 @@ public class SentinelConnectionManager extends MasterSlaveConnectionManager {
                 futures.add(resolvedFuture
                         .whenComplete((r, exc) -> {
                             if (exc != null) {
-                                log.error("Unable to resolve addresses " + host + " and/or " + masterHost, exc);
+                                log.error("Unable to resolve addresses {} and/or {}", host, masterHost, exc);
                             }
                         })
                         .thenCompose(res -> {
@@ -477,7 +477,7 @@ public class SentinelConnectionManager extends MasterSlaveConnectionManager {
                             currentSlaves.add(slaveAddr);
                             return addSlave(slaveAddr).whenComplete((r, e) -> {
                                 if (e != null) {
-                                    log.error("Unable to add slave " + slaveAddr, e);
+                                    log.error("Unable to add slave {}", slaveAddr, e);
                                 }
                             });
                 }));

--- a/redisson/src/main/java/org/redisson/connection/balancer/LoadBalancerManager.java
+++ b/redisson/src/main/java/org/redisson/connection/balancer/LoadBalancerManager.java
@@ -160,7 +160,7 @@ public class LoadBalancerManager {
                     CompletableFuture<Void> future = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
                     future.whenComplete((r, e) -> {
                         if (e != null) {
-                            log.error("Unable to unfreeze entry: " + entry, e);
+                            log.error("Unable to unfreeze entry: {}", entry, e);
                             entry.setInitialized(false);
                             connectionManager.newTimeout(t -> {
                                 unfreeze(entry, freezeReason);
@@ -197,7 +197,7 @@ public class LoadBalancerManager {
                     CompletableFuture<Void> future = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
                     return future.whenComplete((r, e) -> {
                         if (e != null) {
-                            log.error("Unable to unfreeze entry: " + entry, e);
+                            log.error("Unable to unfreeze entry: {}", entry, e);
                             entry.setInitialized(false);
                             return;
                         }

--- a/redisson/src/main/java/org/redisson/connection/pool/ConnectionPool.java
+++ b/redisson/src/main/java/org/redisson/connection/pool/ConnectionPool.java
@@ -341,8 +341,8 @@ abstract class ConnectionPool<T extends RedisConnection> {
     private void checkForReconnect(ClientConnectionsEntry entry, Throwable cause) {
         masterSlaveEntry.slaveDownAsync(entry, FreezeReason.RECONNECT).thenAccept(r -> {
             if (r) {
-                log.error("slave " + entry.getClient().getAddr() + " has been disconnected after "
-                        + config.getFailedSlaveCheckInterval() + " ms interval since moment of the first failed connection", cause);
+                log.error("slave {} has been disconnected after {} ms interval since moment of the first failed connection",
+                    entry.getClient().getAddr(), config.getFailedSlaveCheckInterval(), cause);
                 scheduleCheck(entry);
             }
         });

--- a/redisson/src/main/java/org/redisson/eviction/EvictionTask.java
+++ b/redisson/src/main/java/org/redisson/eviction/EvictionTask.java
@@ -74,7 +74,7 @@ abstract class EvictionTask implements Runnable {
         RFuture<Integer> future = execute();
         future.whenComplete((size, e) -> {
             if (e != null) {
-                log.error("Unable to evict elements for '" + getName() + "'", e);
+                log.error("Unable to evict elements for '{}'", getName(), e);
                 schedule();
                 return;
             }

--- a/redisson/src/main/java/org/redisson/executor/RedissonExecutorRemoteService.java
+++ b/redisson/src/main/java/org/redisson/executor/RedissonExecutorRemoteService.java
@@ -118,7 +118,7 @@ public class RedissonExecutorRemoteService extends RedissonRemoteService {
             }
             RemoteServiceResponse response = new RemoteServiceResponse(request.getId(), e.getCause());
             responsePromise.complete(response);
-            log.error("Can't execute: " + request, e);
+            log.error("Can't execute: {}", request, e);
         }
 
         if (cancelRequestFuture != null) {

--- a/redisson/src/main/java/org/redisson/remote/BaseRemoteProxy.java
+++ b/redisson/src/main/java/org/redisson/remote/BaseRemoteProxy.java
@@ -192,7 +192,7 @@ public abstract class BaseRemoteProxy {
                     return;
                 }
 
-                log.error("Can't get response from " + responseQueueName, e);
+                log.error("Can't get response from {}", responseQueueName, e);
                 return;
             }
 

--- a/redisson/src/test/java/org/redisson/RedissonFairLockTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonFairLockTest.java
@@ -76,21 +76,21 @@ public class RedissonFairLockTest extends BaseConcurrentTest {
         for (int i = 0; i < 50; i++) {
             final int finalI = i;
             executor.submit(() -> {
-                log.info("running " + finalI + " in thread " + Thread.currentThread().getId());
+                log.info("running {} in thread {}", finalI, Thread.currentThread().getId());
                 try {
                     if (lock.tryLock(500, leaseTimeSeconds * 1000, TimeUnit.MILLISECONDS)) {
-                        log.info("Lock taken by thread " + Thread.currentThread().getId());
+                        log.info("Lock taken by thread {}", Thread.currentThread().getId());
                         Thread.sleep(10000);
                         try {
                             //this could fail before use sleep for the same value as the lock expiry, that's fine
                             //for the purpose of this test
                             lock.unlock();
-                            log.info("Lock released by thread " + Thread.currentThread().getId());
+                            log.info("Lock released by thread {}", Thread.currentThread().getId());
                         } catch (Exception ignored) {
                         }
                     }
                 } catch (InterruptedException ex) {
-                    log.warn("Interrupted " + Thread.currentThread().getId());
+                    log.warn("Interrupted {}", Thread.currentThread().getId());
                 } catch (Exception ex) {
                     log.error(ex.getMessage(), ex);
                 }
@@ -104,17 +104,17 @@ public class RedissonFairLockTest extends BaseConcurrentTest {
         //we now launch one more thread and kill it before it manages to fail and clean up
         //that thread will end up with a timeout that will prevent any others from taking the lock for a long time
         executor.submit(() -> {
-            log.info("Final thread trying to take the lock with thread id: " + Thread.currentThread().getId());
+            log.info("Final thread trying to take the lock with thread id: {}", Thread.currentThread().getId());
             try {
                 lastThreadTryingToLock.set(true);
                 if (lock.tryLock(30000, 30000, TimeUnit.MILLISECONDS)) {
-                    log.info("Lock taken by final thread " + Thread.currentThread().getId());
+                    log.info("Lock taken by final thread {}", Thread.currentThread().getId());
                     Thread.sleep(1000);
                     lock.unlock();
-                    log.info("Lock released by final thread " + Thread.currentThread().getId());
+                    log.info("Lock released by final thread {}", Thread.currentThread().getId());
                 }
             } catch (InterruptedException ex) {
-                log.warn("Interrupted " + Thread.currentThread().getId());
+                log.warn("Interrupted {}", Thread.currentThread().getId());
             } catch (Exception ex) {
                 log.error(ex.getMessage(), ex);
             }
@@ -148,7 +148,7 @@ public class RedissonFairLockTest extends BaseConcurrentTest {
         int i = 0;
         for (Long timeout : queue) {
             long epiry = ((timeout - new Date().getTime()) / 1000);
-            log.info("Item " + (i++) + " expires in " + epiry + " seconds");
+            log.info("Item {} expires in {} seconds", i++, epiry);
             //the Redisson library uses this 60000*5ms delay in the code
             if (epiry > leaseTimeSeconds + 60*5) {
                 Assertions.fail("It would take more than " + leaseTimeSeconds + "s to get the lock!");
@@ -168,21 +168,21 @@ public class RedissonFairLockTest extends BaseConcurrentTest {
         for (int i = 0; i < 3; i++) {
             final int finalI = i;
             executor.submit(() -> {
-                log.info("running " + finalI + " in thread " + Thread.currentThread().getId());
+                log.info("running {} in thread {}", finalI, Thread.currentThread().getId());
                 try {
                     if (lock.tryLock(3000, leaseTimeSeconds * 1000, TimeUnit.MILLISECONDS)) {
-                        log.info("Lock taken by thread " + Thread.currentThread().getId());
+                        log.info("Lock taken by thread {}", Thread.currentThread().getId());
                         Thread.sleep(100);
                         try {
                             //this could fail before use sleep for the same value as the lock expiry, that's fine
                             //for the purpose of this test
                             lock.unlock();
-                            log.info("Lock released by thread " + Thread.currentThread().getId());
+                            log.info("Lock released by thread {}", Thread.currentThread().getId());
                         } catch (Exception ignored) {
                         }
                     }
                 } catch (InterruptedException ex) {
-                    log.warn("Interrupted " + Thread.currentThread().getId());
+                    log.warn("Interrupted {}", Thread.currentThread().getId());
                 } catch (Exception ex) {
                     log.error(ex.getMessage(), ex);
                 }
@@ -196,14 +196,14 @@ public class RedissonFairLockTest extends BaseConcurrentTest {
         //we now launch one more thread and kill it before it manages to fail and clean up
         //that thread will end up with a timeout that will prevent any others from taking the lock for a long time
         executor.submit(() -> {
-            log.info("Final thread trying to take the lock with thread id: " + Thread.currentThread().getId());
+            log.info("Final thread trying to take the lock with thread id: {}", Thread.currentThread().getId());
             try {
                 lastThreadTryingToLock.set(true);
                 if (lock.tryLock(30000, 30000, TimeUnit.MILLISECONDS)) {
-                    log.info("Lock taken by final thread " + Thread.currentThread().getId());
+                    log.info("Lock taken by final thread {}", Thread.currentThread().getId());
                     Thread.sleep(1000);
                     lock.unlock();
-                    log.info("Lock released by final thread " + Thread.currentThread().getId());
+                    log.info("Lock released by final thread {}", Thread.currentThread().getId());
                 }
             } catch (InterruptedException ex) {
                 log.warn("Interrupted");
@@ -240,7 +240,7 @@ public class RedissonFairLockTest extends BaseConcurrentTest {
         int i = 0;
         for (Long timeout : queue) {
             long epiry = ((timeout - new Date().getTime()) / 1000);
-            log.info("Item " + (i++) + " expires in " + epiry + " seconds");
+            log.info("Item {} expires in {} seconds", i++, epiry);
             //the Redisson library uses this 5000ms delay in the code
             if (epiry > leaseTimeSeconds + 60*5) {
                 Assertions.fail("It would take more than " + leaseTimeSeconds + "s to get the lock!");
@@ -499,21 +499,21 @@ public class RedissonFairLockTest extends BaseConcurrentTest {
         for (int i = 0; i < 10; i++) {
             final int finalI = i;
             executor.submit(() -> {
-                log.info("running " + finalI + " in thread " + Thread.currentThread().getId());
+                log.info("running {} in thread {}", finalI, Thread.currentThread().getId());
                 try {
                     if (lock.tryLock(3000, leaseTimeSeconds * 1000, TimeUnit.MILLISECONDS)) {
-                        log.info("Lock taken by thread " + Thread.currentThread().getId());
+                        log.info("Lock taken by thread {}", Thread.currentThread().getId());
                         Thread.sleep(100);
                         try {
                             //this could fail before use sleep for the same value as the lock expiry, that's fine
                             //for the purpose of this test
                             lock.unlock();
-                            log.info("Lock released by thread " + Thread.currentThread().getId());
+                            log.info("Lock released by thread {}", Thread.currentThread().getId());
                         } catch (Exception ignored) {
                         }
                     }
                 } catch (InterruptedException ex) {
-                    log.warn("Interrupted " + Thread.currentThread().getId());
+                    log.warn("Interrupted {}", Thread.currentThread().getId());
                 } catch (Exception ex) {
                     log.error(ex.getMessage(), ex);
                 }
@@ -527,17 +527,17 @@ public class RedissonFairLockTest extends BaseConcurrentTest {
         //we now launch one more thread and kill it before it manages to fail and clean up
         //that thread will end up with a timeout that will prevent any others from taking the lock for a long time
         executor.submit(() -> {
-            log.info("Final thread trying to take the lock with thread id: " + Thread.currentThread().getId());
+            log.info("Final thread trying to take the lock with thread id: {}", Thread.currentThread().getId());
             try {
                 lastThreadTryingToLock.set(true);
                 if (lock.tryLock(30000, 30000, TimeUnit.MILLISECONDS)) {
-                    log.info("Lock taken by final thread " + Thread.currentThread().getId());
+                    log.info("Lock taken by final thread {}", Thread.currentThread().getId());
                     Thread.sleep(1000);
                     lock.unlock();
-                    log.info("Lock released by final thread " + Thread.currentThread().getId());
+                    log.info("Lock released by final thread {}", Thread.currentThread().getId());
                 }
             } catch (InterruptedException ex) {
-                log.warn("Interrupted " + Thread.currentThread().getId());
+                log.warn("Interrupted {}", Thread.currentThread().getId());
             } catch (Exception ex) {
                 log.error(ex.getMessage(), ex);
             }
@@ -571,7 +571,7 @@ public class RedissonFairLockTest extends BaseConcurrentTest {
         for (int i = 0; i < queue.size(); i++) {
             long timeout = queue.get(i);
             long epiry = ((timeout - new Date().getTime()) / 1000);
-            log.info("Item " + i + " expires in " + epiry + " seconds");
+            log.info("Item {} expires in {} seconds", i, epiry);
             // the Redisson library uses this 60000*5ms delay in the code
             Assertions.assertFalse(epiry > leaseTimeSeconds + 60*5 * (i + 1),
                                     "It would take more than " + (leaseTimeSeconds + 60*5 * (i + 1)) + "s to get the lock!");


### PR DESCRIPTION
Changes for:
1. Late-binding message parameters
2. Grouping by message patterns in log aggregation systems