### PR TITLE
Add evictions metrics support for RedissonCache

### DIFF
--- a/redisson/src/main/java/org/redisson/spring/cache/RedissonCache.java
+++ b/redisson/src/main/java/org/redisson/spring/cache/RedissonCache.java
@@ -46,6 +46,8 @@ public class RedissonCache implements Cache {
     private final AtomicLong puts = new AtomicLong();
     
     private final AtomicLong misses = new AtomicLong();
+
+    private final AtomicLong evictions = new AtomicLong();
     
     public RedissonCache(RMapCache<Object, Object> mapCache, CacheConfig config, boolean allowNullValues) {
         this(mapCache, allowNullValues);
@@ -144,7 +146,8 @@ public class RedissonCache implements Cache {
 
     @Override
     public void evict(Object key) {
-        map.fastRemove(key);
+        long delta = map.fastRemove(key);
+        addCacheEvictions(delta);
     }
 
     @Override
@@ -238,6 +241,10 @@ public class RedissonCache implements Cache {
     long getCachePuts() {
         return puts.get();
     }
+
+    long getCacheEvictions() {
+        return evictions.get();
+    }
     
     private void addCachePut() {
         puts.incrementAndGet();
@@ -251,4 +258,7 @@ public class RedissonCache implements Cache {
         misses.incrementAndGet();
     }
 
+    private void addCacheEvictions(long delta) {
+        evictions.addAndGet(delta);
+    }
 }

--- a/redisson/src/main/java/org/redisson/spring/cache/RedissonCacheMetrics.java
+++ b/redisson/src/main/java/org/redisson/spring/cache/RedissonCacheMetrics.java
@@ -63,7 +63,7 @@ public class RedissonCacheMetrics extends CacheMeterBinder {
 
     @Override
     protected Long evictionCount() {
-        return null;
+        return cache.getCacheEvictions();
     }
 
     @Override


### PR DESCRIPTION
Currently, `RedissonCache` (aka the implementation `org.springframework.cache.Cache`) supports some metrics (hits, misses, puts) but evictions are not taken into account.
