### PR TITLE
Fixed NPE while booting when pub message set to null

### DIFF
--- a/redisson/src/main/java/org/redisson/client/handler/CommandEncoder.java
+++ b/redisson/src/main/java/org/redisson/client/handler/CommandEncoder.java
@@ -31,10 +31,7 @@
  */
 package org.redisson.client.handler;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.ByteBufUtil;
-import io.netty.buffer.Unpooled;
+import io.netty.buffer.*;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
@@ -117,6 +114,9 @@ public class CommandEncoder extends MessageToByteEncoder<CommandData<?, ?>> {
     }
 
     private ByteBuf encode(Object in) {
+        if (in == null) {
+            return new EmptyByteBuf(ByteBufAllocator.DEFAULT);
+        }
         if (in instanceof byte[]) {
             return Unpooled.wrappedBuffer((byte[]) in);
         }


### PR DESCRIPTION
We found it failed to boot after adding redisson dependency into our springboot application. It's because we set the pub message to null just to check the connection with redis and it work well when using lettuce(the pub method we use is org.springframework.data.redis.core.RedisTemplate#convertAndSend).