### PR TITLE
Fixed - commands_queue don't match if there is exception in CommandEncoder

### DIFF
--- a/redisson/src/main/java/org/redisson/client/handler/CommandDecoder.java
+++ b/redisson/src/main/java/org/redisson/client/handler/CommandDecoder.java
@@ -79,6 +79,11 @@ public class CommandDecoder extends ReplayingDecoder<State> {
         QueueCommandHolder holder = getCommand(ctx);
         QueueCommand data = null;
         if (holder != null) {
+            if (holder.getChannelPromise().isDone() && !holder.getChannelPromise().isSuccess()) {
+                sendNext(ctx.channel());
+                decode(ctx, in, out);
+                return;
+            }
             data = holder.getCommand();
         }
 
@@ -98,12 +103,6 @@ public class CommandDecoder extends ReplayingDecoder<State> {
                 }
             }
         } else {
-            if (holder.getChannelPromise().isDone() && !holder.getChannelPromise().isSuccess()) {
-                sendNext(ctx.channel());
-                // throw REPLAY error
-                in.indexOf(Integer.MAX_VALUE/2, Integer.MAX_VALUE, (byte) 0);
-                return;
-            }
 
             int endIndex = 0;
             if (!(data instanceof CommandsData)) {

--- a/redisson/src/test/java/org/redisson/client/handler/CommandWriteExceptionTest.java
+++ b/redisson/src/test/java/org/redisson/client/handler/CommandWriteExceptionTest.java
@@ -1,0 +1,99 @@
+package org.redisson.client.handler;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.redisson.RedisRunner;
+import org.redisson.Redisson;
+import org.redisson.api.RMapCache;
+import org.redisson.api.RScheduledExecutorService;
+import org.redisson.api.RedissonClient;
+import org.redisson.api.WorkerOptions;
+import org.redisson.client.codec.StringCodec;
+import org.redisson.config.Config;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CommandWriteExceptionTest {
+
+    private static final Logger log = LoggerFactory.getLogger(CommandWriteExceptionTest.class);
+
+
+    protected static RedissonClient redisson;
+
+    @BeforeAll
+    public static void beforeClass() throws IOException, InterruptedException {
+        RedisRunner.startDefaultRedisServerInstance();
+        redisson = createInstance();
+    }
+
+    @AfterAll
+    public static void afterClass() throws InterruptedException {
+        redisson.shutdown();
+        RedisRunner.shutDownDefaultRedisServerInstance();
+    }
+
+    public static Config createConfig() {
+
+        Config config = new Config();
+        config.setCodec(new StringCodec());
+        config.useSingleServer()
+            .setConnectionPoolSize(2)
+            .setConnectionMinimumIdleSize(1)
+            .setAddress(RedisRunner.getDefaultRedisServerBindAddressAndPort());
+        return config;
+    }
+
+    public static RedissonClient createInstance() {
+        Config config = createConfig();
+        return Redisson.create(config);
+    }
+
+
+    @Test
+    public void testGetAndClearExpire() {
+
+
+        RScheduledExecutorService executorService = redisson.getExecutorService("redis-executor-test");
+        executorService.registerWorkers(WorkerOptions.defaults());
+
+        String orderInfo = "orderInfo";
+        String orderNo = "orderId_";
+        RMapCache<String, String> mapCache = redisson.getMapCache("mapCache");
+        mapCache.clear();
+        for (int i = 0; i < 100; i++) {
+            mapCache.put(orderNo + i, orderInfo + "_" + i, 30, TimeUnit.MINUTES);
+        }
+
+        long startTime = System.currentTimeMillis();
+        for (int j = 0; j < 10; j++) {
+            try {
+                executorService.cancelTask(null);
+            } catch (Exception ex) {
+                // ignore
+            }
+        }
+        log.info("cancelTask, time cost(ms):{}", System.currentTimeMillis() - startTime);
+        startTime = System.currentTimeMillis();
+        try {
+            String cacheValue = mapCache.get(orderNo + "0");
+            log.info("cacheValue={}, time cost(ms):{}", cacheValue, System.currentTimeMillis() - startTime);
+        } catch (Exception ex) {
+            log.error("fetch cache fail,time cost(ms):{}, ex:{}", System.currentTimeMillis() - startTime,
+                ex.getMessage(), ex);
+        }
+        try {
+            Thread.sleep(10000);
+        } catch (Exception ex) {
+            //ignore
+        }
+
+        executorService.shutdown();
+
+
+    }
+
+}


### PR DESCRIPTION
I use Redison-3.17.6 in the production environment, and I also encountered the problem of #4381. When the redisresponsetimeoutexception occurred, there was  also some ```io.netty.handler.codec.EncoderException: java.lang.NullPointerException```. I write the test code ```org.redisson.client.handler.CommandWriteExceptionTest```，the ```RedisResponseTimeoutException``` can reproduce, using the version 3.17.6-3.19.1 .

the commit  bb656c96 ```[fix]NPE when pub message is null```  fixed the EncoderException, if rollback this commit, the ```RedisResponseTimeoutException``` can reproduce in 3.19.2-SNAPSHOT.


```
2023.01.27 13:37:16.721 ERROR CommandWriteExceptionTest : fetch cache fail,time cost(ms):17141, ex:Redis server response timeout (3000 ms) occured after 3 retry attempts, is non-idempotent command: false Check connection with Redis node: localhost/127.0.0.1:46398 for TCP packet drops.  Try to increase nettyThreads and/or timeout settings. Command: (EVAL), params: [local value = redis.call('hget', KEYS[1], ARGV[2]); if value == false then return nil; end; local t, val = struct.unpack('dLc0', value); local expireDate = 92233720368547758; local expireDateScore = redis.call('zscore', KEYS[2], ARGV[2]); if expireDateScore ~= false then expireDate = tonumber(expireDateScore) end; if t ~= 0 then local expireIdle = redis.call('zscore', KEYS[3], ARGV[2]); if expireIdle ~= false then if tonumber(expireIdle) > tonumber(ARGV[1]) then redis.call('zadd', KEYS[3], t + tonumber(ARGV[1]), ARGV[2]); end; expireDate = math.min(expireDate, tonumber(expireIdle)) end; end; if expireDate <= tonumber(ARGV[1]) then return nil; end; local maxSize = tonumber(redis.call('hget', KEYS[5], 'max-size')); if maxSize ~= nil and maxSize ~= 0 then local mode = redis.call('hget', KEYS[5], 'mode'); if mode == false or mode == 'LRU' then redis.call('zadd', KEYS[4], tonumber(ARGV[1]), ARGV[2]); else redis.call('zincrby', KEYS[4], 1, ARGV[2]); end; end; return val; , 5, mapCache, redisson__timeout__set:{mapCache}, redisson__idle__set:{mapCache}, redisson__map_cache__last_access__set:{mapCache}, {mapCache}:redisson_options, 1674797819580, PooledUnsafeDirectByteBuf(ridx: 0, widx: 9, cap: 256)], channel: [id: 0xed78d2cc, L:/127.0.0.1:56412 - R:localhost/127.0.0.1:46398]
org.redisson.client.RedisResponseTimeoutException: Redis server response timeout (3000 ms) occured after 3 retry attempts, is non-idempotent command: false Check connection with Redis node: localhost/127.0.0.1:46398 for TCP packet drops.  Try to increase nettyThreads and/or timeout settings. Command: (EVAL), params: [local value = redis.call('hget', KEYS[1], ARGV[2]); if value == false then return nil; end; local t, val = struct.unpack('dLc0', value); local expireDate = 92233720368547758; local expireDateScore = redis.call('zscore', KEYS[2], ARGV[2]); if expireDateScore ~= false then expireDate = tonumber(expireDateScore) end; if t ~= 0 then local expireIdle = redis.call('zscore', KEYS[3], ARGV[2]); if expireIdle ~= false then if tonumber(expireIdle) > tonumber(ARGV[1]) then redis.call('zadd', KEYS[3], t + tonumber(ARGV[1]), ARGV[2]); end; expireDate = math.min(expireDate, tonumber(expireIdle)) end; end; if expireDate <= tonumber(ARGV[1]) then return nil; end; local maxSize = tonumber(redis.call('hget', KEYS[5], 'max-size')); if maxSize ~= nil and maxSize ~= 0 then local mode = redis.call('hget', KEYS[5], 'mode'); if mode == false or mode == 'LRU' then redis.call('zadd', KEYS[4], tonumber(ARGV[1]), ARGV[2]); else redis.call('zincrby', KEYS[4], 1, ARGV[2]); end; end; return val; , 5, mapCache, redisson__timeout__set:{mapCache}, redisson__idle__set:{mapCache}, redisson__map_cache__last_access__set:{mapCache}, {mapCache}:redisson_options, 1674797819580, PooledUnsafeDirectByteBuf(ridx: 0, widx: 9, cap: 256)], channel: [id: 0xed78d2cc, L:/127.0.0.1:56412 - R:localhost/127.0.0.1:46398]
	at org.redisson.command.RedisExecutor.lambda$scheduleResponseTimeout$9(RedisExecutor.java:405)
	at io.netty.util.HashedWheelTimer$HashedWheelTimeout.run(HashedWheelTimer.java:715)
	at io.netty.util.concurrent.ImmediateExecutor.execute(ImmediateExecutor.java:34)
	at io.netty.util.HashedWheelTimer$HashedWheelTimeout.expire(HashedWheelTimer.java:703)
	at io.netty.util.HashedWheelTimer$HashedWheelBucket.expireTimeouts(HashedWheelTimer.java:790)
	at io.netty.util.HashedWheelTimer$Worker.run(HashedWheelTimer.java:503)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:833)
2023.01.27 13:37:23.721 INFO  RedisExecutor : connection released for command (EVAL) and params [if redis.call('setnx', KEYS[6], ARGV[4]) == 0 then return -1;end;redis.call('expire', KEYS[6], ARGV[3]); local expiredKeys1 = redis.call('zrangebyscore', KEYS[2], 0, ARGV[1], 'limit', 0, ARGV[2]); for i, key in ipairs(expiredKeys1) do local v = redis.call('hget', KEYS[1], key); if v ~= false then local t, val = struct.unpack('dLc0', v); local msg = struct.pack('Lc0Lc0', string.len(key), key, string.len(val), val); local listeners = redis.call('publish', KEYS[4], msg); if (listeners == 0) then break;end; end;end;for i=1, #expiredKeys1, 5000 do redis.call('zrem', KEYS[5], unpack(expiredKeys1, i, math.min(i+4999, table.getn(expiredKeys1)))); redis.call('zrem', KEYS[3], unpack(expiredKeys1, i, math.min(i+4999, table.getn(expiredKeys1)))); redis.call('zrem', KEYS[2], unpack(expiredKeys1, i, math.min(i+4999, table.getn(expiredKeys1)))); redis.call('hdel', KEYS[1], unpack(expiredKeys1, i, math.min(i+4999, table.getn(expiredKeys1)))); end; local expiredKeys2 = redis.call('zrangebyscore', KEYS[..., 6, mapCache, redisson__timeout__set:{mapCache}, redisson__idle__set:{mapCache}, redisson_map_cache_expired:{mapCache}, redisson__map_cache__last_access__set:{mapCache}, redisson__execute_task_once_latch:{mapCache}, 1674797840626, 100, ...] from slot NodeSource [slot=0, addr=null, redisClient=null, redirect=null, entry=null] using connection RedisConnection@898602781 [redisClient=[addr=redis://localhost:46398], channel=[id: 0xed78d2cc, L:/127.0.0.1:56412 - R:localhost/127.0.0.1:46398], currentCommand=CommandData [promise=java.util.concurrent.CompletableFuture@625ea510[Completed exceptionally: java.lang.NullPointerException: Cannot invoke "Object.toString()" because "in" is null], command=(EVAL), params=[if redis.call('exists', KEYS[3]) == 0 then return nil;end;local task = redis.call('hget', KEYS[6], ARGV[1]); redis.call('hdel', KEYS[6], ARGV[1]); redis.call('zrem', KEYS[2], 'ff:' .. ARGV[1]); redis.call('zrem', KEYS[8], ARGV[1]); local removedScheduled = redis.call('zrem', KEYS[2], ARGV[1]); local removed = redis.call('lrem', KEYS[1], 1, ARGV[1]); if task ~= false and (removed > 0 or removedScheduled > 0) then if redis.call('decr', KEYS[3]) == 0 then redis.call('del', KEYS[3]);if redis.call('get', KEYS[4]) == ARGV[2] then redis.call('del', KEYS[7]);redis.call('set', KEYS[4], ARGV[3]);redis.call('publish', KEYS[5], ARGV[3]);end;end;return 1;end;if task == false then return nil; end;return 0;, 8, {redis-executor-test:org.redisson.executor.RemoteExecutorService}, {redis-executor-test:org.redisson.executor.RemoteExecutorService}:scheduler, {redis-executor-test:org.redisson.executor.RemoteExecutorService}:counter, {redis-executor-test:org.redisson.executor.RemoteExecutorService}:status, {redis-executor-test:org.redisson.executor.RemoteExecutorService}:termination-topic, {redis-executor-test:org.redisson.executor.RemoteExecutorService}:tasks, {redis-executor-test:org.redisson.executor.RemoteExecutorService}:retry-interval, {redis-executor-test:org.redisson.executor.RemoteExecutorService}:expiration, ...], codec=org.redisson.client.codec.StringCodec], usage=0]
2023.01.27 13:37:23.721 ERROR MapCacheEvictionTask : Unable to evict elements for 'mapCache'
org.redisson.client.RedisResponseTimeoutException: Redis server response timeout (3000 ms) occured after 0 retry attempts, is non-idempotent command: false Check connection with Redis node: localhost/127.0.0.1:46398 for TCP packet drops.  Try to increase nettyThreads and/or timeout settings. Command: (EVAL), params: [if redis.call('setnx', KEYS[6], ARGV[4]) == 0 then return -1;end;redis.call('expire', KEYS[6], ARGV[3]); local expiredKeys1 = redis.call('zrangebyscore', KEYS[2], 0, ARGV[1], 'limit', 0, ARGV[2]); for i, key in ipairs(expiredKeys1) do local v = redis.call('hget', KEYS[1], key); if v ~= false then local t, val = struct.unpack('dLc0', v); local msg = struct.pack('Lc0Lc0', string.len(key), key, string.len(val), val); local listeners = redis.call('publish', KEYS[4], msg); if (listeners == 0) then break;end; end;end;for i=1, #expiredKeys1, 5000 do redis.call('zrem', KEYS[5], unpack(expiredKeys1, i, math.min(i+4999, table.getn(expiredKeys1)))); redis.call('zrem', KEYS[3], unpack(expiredKeys1, i, math.min(i+4999, table.getn(expiredKeys1)))); redis.call('zrem', KEYS[2], unpack(expiredKeys1, i, math.min(i+4999, table.getn(expiredKeys1)))); redis.call('hdel', KEYS[1], unpack(expiredKeys1, i, math.min(i+4999, table.getn(expiredKeys1)))); end; local expiredKeys2 = redis.call('zrangebyscore', KEYS[..., 6, mapCache, redisson__timeout__set:{mapCache}, redisson__idle__set:{mapCache}, redisson_map_cache_expired:{mapCache}, redisson__map_cache__last_access__set:{mapCache}, redisson__execute_task_once_latch:{mapCache}, 1674797840626, 100, ...], channel: [id: 0xed78d2cc, L:/127.0.0.1:56412 - R:localhost/127.0.0.1:46398]
	at org.redisson.command.RedisExecutor.lambda$scheduleResponseTimeout$9(RedisExecutor.java:405)
	at io.netty.util.HashedWheelTimer$HashedWheelTimeout.run(HashedWheelTimer.java:715)
	at io.netty.util.concurrent.ImmediateExecutor.execute(ImmediateExecutor.java:34)
	at io.netty.util.HashedWheelTimer$HashedWheelTimeout.expire(HashedWheelTimer.java:703)
	at io.netty.util.HashedWheelTimer$HashedWheelBucket.expireTimeouts(HashedWheelTimer.java:790)
	at io.netty.util.HashedWheelTimer$Worker.run(HashedWheelTimer.java:503)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

```
Failed to mark a promise as failure because it has failed already: DefaultChannelPromise@780d1c5b(failure: io.netty.handler.codec.EncoderException: java.lang.NullPointerException), unnotified cause: io.netty.handler.codec.EncoderException: java.lang.NullPointerException
	at io.netty.handler.codec.MessageToByteEncoder.write(MessageToByteEncoder.java:125)
	at org.redisson.client.handler.CommandEncoder.write(CommandEncoder.java:75)
	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:717)
	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:709)
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:792)
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:702)
	at io.netty.handler.codec.MessageToByteEncoder.write(MessageToByteEncoder.java:120)
	at org.redisson.client.handler.CommandBatchEncoder.write(CommandBatchEncoder.java:45)
	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:717)
	at io.netty.channel.AbstractChannelHandlerContext.invokeWriteAndFlush(AbstractChannelHandlerContext.java:764)
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:790)
	at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:758)
	at org.redisson.client.handler.CommandsQueue.write(CommandsQueue.java:83)
	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:717)
	at io.netty.channel.AbstractChannelHandlerContext.invokeWriteAndFlush(AbstractChannelHandlerContext.java:764)
	at io.netty.channel.AbstractChannelHandlerContext$WriteTask.run(AbstractChannelHandlerContext.java:1071)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:500)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Thread.java:750)
Caused by: java.lang.NullPointerException
	at org.redisson.client.handler.CommandEncoder.encode(CommandEncoder.java:130)
	at org.redisson.client.handler.CommandEncoder.encode(CommandEncoder.java:99)
	at org.redisson.client.handler.CommandEncoder.encode(CommandEncoder.java:55)
	at io.netty.handler.codec.MessageToByteEncoder.write(MessageToByteEncoder.java:107)
	... 22 more

io.netty.handler.codec.EncoderException: java.lang.NullPointerException
	at io.netty.handler.codec.MessageToByteEncoder.write(MessageToByteEncoder.java:125)
	at org.redisson.client.handler.CommandEncoder.write(CommandEncoder.java:75)
	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:717)
	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:709)
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:792)
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:702)
	at io.netty.handler.codec.MessageToByteEncoder.write(MessageToByteEncoder.java:120)
	at org.redisson.client.handler.CommandBatchEncoder.write(CommandBatchEncoder.java:45)
	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:717)
	at io.netty.channel.AbstractChannelHandlerContext.invokeWriteAndFlush(AbstractChannelHandlerContext.java:764)
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:790)
	at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:758)
	at org.redisson.client.handler.CommandsQueue.write(CommandsQueue.java:83)
	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:717)
	at io.netty.channel.AbstractChannelHandlerContext.invokeWriteAndFlush(AbstractChannelHandlerContext.java:764)
	at io.netty.channel.AbstractChannelHandlerContext$WriteTask.run(AbstractChannelHandlerContext.java:1071)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:500)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Thread.java:750)
Caused by: java.lang.NullPointerException: null
	at org.redisson.client.handler.CommandEncoder.encode(CommandEncoder.java:130)
	at org.redisson.client.handler.CommandEncoder.encode(CommandEncoder.java:99)
	at org.redisson.client.handler.CommandEncoder.encode(CommandEncoder.java:55)
	at io.netty.handler.codec.MessageToByteEncoder.write(MessageToByteEncoder.java:107)
	... 22 common frames omitted
```