### PR TITLE
feat: Eviction by key for RMap

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonMap.java
+++ b/redisson/src/main/java/org/redisson/RedissonMap.java
@@ -662,6 +662,12 @@ public class RedissonMap<K, V> extends RedissonExpirable implements RMap<K, V> {
     }
 
     @Override
+    public V evict(Object key) {
+        checkKey(key);
+        return get(removeOperationAsync((K) key));
+    }
+
+    @Override
     public final void putAll(Map<? extends K, ? extends V> map) {
         get(putAllAsync(map));
     }

--- a/redisson/src/main/java/org/redisson/api/RMap.java
+++ b/redisson/src/main/java/org/redisson/api/RMap.java
@@ -272,7 +272,18 @@ public interface RMap<K, V> extends ConcurrentMap<K, V>, RExpirable, RMapAsync<K
      */
     @Override
     boolean remove(Object key, Object value);
-    
+
+    /**
+     * Evict map entry by specified <code>key</code> and returns value.
+     * <p>
+     * If {@link MapWriter} is defined then <code>key</code>is not deleted in write-through mode.
+     * Use {@link #remove} if {@link MapWriter#delete} needs to be called.
+     *
+     * @param key - map key
+     * @return deleted value, <code>null</code> if map entry doesn't exist
+     */
+    V evict(Object key);
+
     /**
      * Stores map entries specified in <code>map</code> object in batch mode.
      * <p>

--- a/redisson/src/test/java/org/redisson/BaseMapTest.java
+++ b/redisson/src/test/java/org/redisson/BaseMapTest.java
@@ -1619,4 +1619,19 @@ public abstract class BaseMapTest extends BaseTest {
         destroy(map);
     }
 
+    @Test
+    public void testWriterEvict() {
+        Map<String, String> store = new HashMap<>();
+        RMap<String, String> map = getWriterTestMap("test", store);
+
+        map.put("1", "11");
+        map.evict("1");
+        map.put("3", "33");
+
+        Map<String, String> expected = new HashMap<>();
+        expected.put("1", "11");
+        expected.put("3", "33");
+        assertThat(store).isEqualTo(expected);
+    }
+
 }


### PR DESCRIPTION
Issue: https://github.com/redisson/redisson/issues/4842
Evict feature at `RMap` to make it possible to remove cache without affecting external storage

Signed-off-by: ls-rein-martha