### PR TITLE
feat: add auto-detection of unavailable master in replicated mode

### DIFF
--- a/redisson/src/main/java/org/redisson/config/ReplicatedServersConfig.java
+++ b/redisson/src/main/java/org/redisson/config/ReplicatedServersConfig.java
@@ -39,6 +39,12 @@ public class ReplicatedServersConfig extends BaseMasterSlaveServersConfig<Replic
     private int scanInterval = 1000;
 
     /**
+     * Master node unreachable maximum time before failure in milliseconds
+     * A value of 0 indicates that the client will never fail
+     */
+    private int masterUnreachableTimeout = 0;
+
+    /**
      * Database index used for Redis connection
      */
     private int database = 0;
@@ -54,6 +60,7 @@ public class ReplicatedServersConfig extends BaseMasterSlaveServersConfig<Replic
         setScanInterval(config.getScanInterval());
         setDatabase(config.getDatabase());
         setMonitorIPChanges(config.isMonitorIPChanges());
+        setMasterUnreachableTimeout(config.getMasterUnreachableTimeout());
     }
 
     /**
@@ -121,5 +128,24 @@ public class ReplicatedServersConfig extends BaseMasterSlaveServersConfig<Replic
 
     public boolean isMonitorIPChanges() {
         return monitorIPChanges;
+    }
+
+    /**
+     * Master unreachable timeout in milliseconds. After the configured amount of time
+     * the client will throw {@link org.redisson.client.RedisConnectionException}.
+     * <p>
+     * Default is <code>0</code>, indicating that the client will never throw,
+     * but only log the error.
+     *
+     * @param masterUnreachableTimeout
+     * @return config
+     */
+    public ReplicatedServersConfig setMasterUnreachableTimeout(int masterUnreachableTimeout) {
+        this.masterUnreachableTimeout = masterUnreachableTimeout;
+        return this;
+    }
+
+    public int getMasterUnreachableTimeout() {
+        return masterUnreachableTimeout;
     }
 }

--- a/redisson/src/main/java/org/redisson/config/ReplicatedServersConfig.java
+++ b/redisson/src/main/java/org/redisson/config/ReplicatedServersConfig.java
@@ -39,12 +39,6 @@ public class ReplicatedServersConfig extends BaseMasterSlaveServersConfig<Replic
     private int scanInterval = 1000;
 
     /**
-     * Master node unreachable maximum time before failure in milliseconds
-     * A value of 0 indicates that the client will never fail
-     */
-    private int masterUnreachableTimeout = 0;
-
-    /**
      * Database index used for Redis connection
      */
     private int database = 0;
@@ -60,7 +54,6 @@ public class ReplicatedServersConfig extends BaseMasterSlaveServersConfig<Replic
         setScanInterval(config.getScanInterval());
         setDatabase(config.getDatabase());
         setMonitorIPChanges(config.isMonitorIPChanges());
-        setMasterUnreachableTimeout(config.getMasterUnreachableTimeout());
     }
 
     /**
@@ -128,24 +121,5 @@ public class ReplicatedServersConfig extends BaseMasterSlaveServersConfig<Replic
 
     public boolean isMonitorIPChanges() {
         return monitorIPChanges;
-    }
-
-    /**
-     * Master unreachable timeout in milliseconds. After the configured amount of time
-     * the client will throw {@link org.redisson.client.RedisConnectionException}.
-     * <p>
-     * Default is <code>0</code>, indicating that the client will never throw,
-     * but only log the error.
-     *
-     * @param masterUnreachableTimeout
-     * @return config
-     */
-    public ReplicatedServersConfig setMasterUnreachableTimeout(int masterUnreachableTimeout) {
-        this.masterUnreachableTimeout = masterUnreachableTimeout;
-        return this;
-    }
-
-    public int getMasterUnreachableTimeout() {
-        return masterUnreachableTimeout;
     }
 }


### PR DESCRIPTION
In replicated mode, the ConnectionManager is checking periodically which node is the current master and does auto failover.

However, in a situation where none of the previous configured addresses points to a master of the cluster, Redisson silently keeps working without logging an error. This situation may happen for example in case of an horizontal scale up of the cluster not followed by a configuration change of the addresses. This may go undetected for a while, as the client can still read from Redis, only writes are impacted.

The proposal consist of:
- add new master detection check inside `scheduleMasterChangeCheck`, gathering the roles of each node (which was already checked in existing code), and at least log an error when the master is not found.
- add a new fail-fast configuration `masterUnreachableTimeout`, which will cause the client to throw a `RedissonConnectionException` if the master is unavailable for more than the configured amount of time. The default behaviour maintains retro-compatibility, so it doesn't throw.