### PR TITLE
change maven spring-boot-starter-actuator dependency is optional

### DIFF
--- a/redisson-spring-boot-starter/pom.xml
+++ b/redisson-spring-boot-starter/pom.xml
@@ -83,6 +83,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
change maven spring-boot-starter-actuator dependency is optional