### PR TITLE
Initialize LinkedHashMap with correct initial size to avoid resizing

### DIFF
--- a/redisson/src/main/java/org/redisson/client/protocol/decoder/MultiDecoder.java
+++ b/redisson/src/main/java/org/redisson/client/protocol/decoder/MultiDecoder.java
@@ -15,6 +15,7 @@
  */
 package org.redisson.client.protocol.decoder;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 
 import org.redisson.client.codec.Codec;
@@ -38,5 +39,12 @@ public interface MultiDecoder<T> {
     }
     
     T decode(List<Object> parts, State state);
+
+    static <K, V> LinkedHashMap<K, V> newLinkedHashMap(int expectedSize) {
+        if (expectedSize < 3) {
+            return new LinkedHashMap<>(expectedSize + 1);
+        }
+        return new LinkedHashMap<>((int) Math.ceil(expectedSize / 0.75));
+    }
 
 }

--- a/redisson/src/main/java/org/redisson/client/protocol/decoder/ObjectMapDecoder.java
+++ b/redisson/src/main/java/org/redisson/client/protocol/decoder/ObjectMapDecoder.java
@@ -55,7 +55,8 @@ public class ObjectMapDecoder implements MultiDecoder<Object> {
             return parts;
         }
 
-        Map<Object, Object> result = new LinkedHashMap<>(parts.size()/2);
+        int size = parts.size()/2;
+        Map<Object, Object> result = new LinkedHashMap<>(size < 3 ? size + 1 : (int) Math.ceil(size/0.75));
         for (int i = 0; i < parts.size(); i++) {
             if (i % 2 != 0) {
                 result.put(parts.get(i-1), parts.get(i));

--- a/redisson/src/main/java/org/redisson/client/protocol/decoder/ObjectMapDecoder.java
+++ b/redisson/src/main/java/org/redisson/client/protocol/decoder/ObjectMapDecoder.java
@@ -15,7 +15,6 @@
  */
 package org.redisson.client.protocol.decoder;
 
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -55,8 +54,7 @@ public class ObjectMapDecoder implements MultiDecoder<Object> {
             return parts;
         }
 
-        int size = parts.size()/2;
-        Map<Object, Object> result = new LinkedHashMap<>(size < 3 ? size + 1 : (int) Math.ceil(size/0.75));
+        Map<Object, Object> result = MultiDecoder.newLinkedHashMap(parts.size()/2);
         for (int i = 0; i < parts.size(); i++) {
             if (i % 2 != 0) {
                 result.put(parts.get(i-1), parts.get(i));

--- a/redisson/src/main/java/org/redisson/client/protocol/decoder/ObjectMapEntryReplayDecoder.java
+++ b/redisson/src/main/java/org/redisson/client/protocol/decoder/ObjectMapEntryReplayDecoder.java
@@ -42,7 +42,8 @@ public class ObjectMapEntryReplayDecoder implements MultiDecoder<Set<Entry<Objec
 
     @Override
     public Set<Entry<Object, Object>> decode(List<Object> parts, State state) {
-        Map<Object, Object> result = new LinkedHashMap<Object, Object>(parts.size()/2);
+        int size = parts.size()/2;
+        Map<Object, Object> result = new LinkedHashMap<>(size < 3 ? size + 1 : (int) Math.ceil(size/0.75));
         for (int i = 0; i < parts.size(); i++) {
             if (i % 2 != 0) {
                 result.put(parts.get(i-1), parts.get(i));

--- a/redisson/src/main/java/org/redisson/client/protocol/decoder/ObjectMapEntryReplayDecoder.java
+++ b/redisson/src/main/java/org/redisson/client/protocol/decoder/ObjectMapEntryReplayDecoder.java
@@ -19,7 +19,6 @@ import org.redisson.client.codec.Codec;
 import org.redisson.client.handler.State;
 import org.redisson.client.protocol.Decoder;
 
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -42,8 +41,7 @@ public class ObjectMapEntryReplayDecoder implements MultiDecoder<Set<Entry<Objec
 
     @Override
     public Set<Entry<Object, Object>> decode(List<Object> parts, State state) {
-        int size = parts.size()/2;
-        Map<Object, Object> result = new LinkedHashMap<>(size < 3 ? size + 1 : (int) Math.ceil(size/0.75));
+        Map<Object, Object> result = MultiDecoder.newLinkedHashMap(parts.size()/2);
         for (int i = 0; i < parts.size(); i++) {
             if (i % 2 != 0) {
                 result.put(parts.get(i-1), parts.get(i));

--- a/redisson/src/main/java/org/redisson/client/protocol/decoder/ObjectMapReplayDecoder.java
+++ b/redisson/src/main/java/org/redisson/client/protocol/decoder/ObjectMapReplayDecoder.java
@@ -19,7 +19,6 @@ import org.redisson.client.codec.Codec;
 import org.redisson.client.handler.State;
 import org.redisson.client.protocol.Decoder;
 
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -52,8 +51,7 @@ public class ObjectMapReplayDecoder<K, V> implements MultiDecoder<Map<K, V>> {
 
     @Override
     public Map<K, V> decode(List<Object> parts, State state) {
-        int size = parts.size()/2;
-        Map<K, V> result = new LinkedHashMap<>(size < 3 ? size + 1 : (int) Math.ceil(size/0.75));
+        Map<K, V> result = MultiDecoder.newLinkedHashMap(parts.size()/2);
         for (int i = 0; i < parts.size(); i++) {
             if (i % 2 != 0) {
                 result.put((K) parts.get(i-1), (V) parts.get(i));

--- a/redisson/src/main/java/org/redisson/client/protocol/decoder/ObjectMapReplayDecoder.java
+++ b/redisson/src/main/java/org/redisson/client/protocol/decoder/ObjectMapReplayDecoder.java
@@ -52,7 +52,8 @@ public class ObjectMapReplayDecoder<K, V> implements MultiDecoder<Map<K, V>> {
 
     @Override
     public Map<K, V> decode(List<Object> parts, State state) {
-        Map<K, V> result = new LinkedHashMap<>(parts.size()/2);
+        int size = parts.size()/2;
+        Map<K, V> result = new LinkedHashMap<>(size < 3 ? size + 1 : (int) Math.ceil(size/0.75));
         for (int i = 0; i < parts.size(); i++) {
             if (i % 2 != 0) {
                 result.put((K) parts.get(i-1), (V) parts.get(i));

--- a/redisson/src/main/java/org/redisson/client/protocol/decoder/StringMapReplayDecoder.java
+++ b/redisson/src/main/java/org/redisson/client/protocol/decoder/StringMapReplayDecoder.java
@@ -30,7 +30,8 @@ public class StringMapReplayDecoder implements MultiDecoder<Map<String, String>>
 
     @Override
     public Map<String, String> decode(List<Object> parts, State state) {
-        Map<String, String> result = new LinkedHashMap<>(parts.size()/2);
+        int size = parts.size()/2;
+        Map<String, String> result = new LinkedHashMap<>(size < 3 ? size + 1 : (int) Math.ceil(size/0.75));
         for (int i = 0; i < parts.size(); i++) {
             if (i % 2 != 0) {
                 result.put(parts.get(i-1).toString(), parts.get(i).toString());

--- a/redisson/src/main/java/org/redisson/client/protocol/decoder/StringMapReplayDecoder.java
+++ b/redisson/src/main/java/org/redisson/client/protocol/decoder/StringMapReplayDecoder.java
@@ -17,7 +17,6 @@ package org.redisson.client.protocol.decoder;
 
 import org.redisson.client.handler.State;
 
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -30,8 +29,7 @@ public class StringMapReplayDecoder implements MultiDecoder<Map<String, String>>
 
     @Override
     public Map<String, String> decode(List<Object> parts, State state) {
-        int size = parts.size()/2;
-        Map<String, String> result = new LinkedHashMap<>(size < 3 ? size + 1 : (int) Math.ceil(size/0.75));
+        Map<String, String> result = MultiDecoder.newLinkedHashMap(parts.size()/2);
         for (int i = 0; i < parts.size(); i++) {
             if (i % 2 != 0) {
                 result.put(parts.get(i-1).toString(), parts.get(i).toString());


### PR DESCRIPTION
We are seeing a lot of allocations coming from `ObjectMapReplyDecoder` in production. The culprit is `LinkedHashMap.resize()`.

The map is currently sized with `parts.size()\2`, but doesn't take the default load factor of the map into account. This PR uses the same approach as [Guava](https://github.com/google/guava/blob/master/guava/src/com/google/common/collect/Maps.java#L286) to prevent additional resizes.

Is there a utility class where the sizing logic could be centralized? I'm not very happy about the code duplication.
