### PR TITLE
Update README.md - fix application.settings to match RedissonProperties

### DIFF
--- a/redisson-spring-boot-starter/README.md
+++ b/redisson-spring-boot-starter/README.md
@@ -68,7 +68,7 @@ Using Redisson config file ([single mode](https://github.com/redisson/redisson/w
 spring:
   redis:
    redisson: 
-      file: classpath:redisson.yaml
+      config: classpath:redisson.yaml
 ```
 
 Using Redisson settings ([single mode](https://github.com/redisson/redisson/wiki/2.-Configuration#262-single-instance-yaml-config-format),


### PR DESCRIPTION
The setting "spring.redis.redisson.file = classpath:redisson.yaml" is incorrect.
Correct be "spring.redis.redisson.config = classpath:redisson.yaml"