### PR TITLE
docs : change readme typo rediss -> redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Used by
 // 1. Create config object
 Config config = new Config();
 config.useClusterServers()
-       // use "rediss://" for SSL connection
+       // use "redis://" for SSL connection
       .addNodeAddress("redis://127.0.0.1:7181");
 
 // or read config from file


### PR DESCRIPTION
~~I am sending you a request because it is confirmed that the part I modified is a typo. 
Can you check it out?~~

I will confirm that the redis to be encrypted connection is written as `rediss` and close the request.