### PR TITLE
Code Review - Behaviors of FixedRate and FixedDelay should be similar in TasksRunnerService

### DIFF
--- a/redisson/src/main/java/org/redisson/executor/TasksRunnerService.java
+++ b/redisson/src/main/java/org/redisson/executor/TasksRunnerService.java
@@ -124,6 +124,10 @@ public class TasksRunnerService implements RemoteExecutorService {
     public void scheduleAtFixedRate(ScheduledAtFixedRateParameters params) {
         long start = System.nanoTime();
         executeRunnable(params, false);
+        if (!redisson.getMap(tasksName, StringCodec.INSTANCE).containsKey(params.getRequestId())) {
+            return;
+        }
+
         long spent = params.getSpentTime()
                                 + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
 

--- a/redisson/src/test/java/org/redisson/executor/RedissonScheduledExecutorServiceTest.java
+++ b/redisson/src/test/java/org/redisson/executor/RedissonScheduledExecutorServiceTest.java
@@ -514,6 +514,32 @@ public class RedissonScheduledExecutorServiceTest extends BaseTest {
         assertThat(redisson.getKeys().count()).isZero();
     }
 
+    @Test
+    public void testCancelAndInterruptSwallowedWithFixedDelay() throws InterruptedException, ExecutionException {
+        RScheduledExecutorService executor = redisson.getExecutorService("test");
+        RScheduledFuture<?> future = executor.scheduleWithFixedDelay(new SwallowingInterruptionTask("execution1", "cancel1"), 0, 1, TimeUnit.SECONDS);
+
+        Thread.sleep(TimeUnit.SECONDS.toMillis(1));
+
+        assertThat(redisson.getAtomicLong("cancel1").get()).isZero();
+        assertThat(redisson.getAtomicLong("execution1").get()).isEqualTo(1);
+
+        cancel(future);
+
+        assertThat(redisson.getAtomicLong("cancel1").get()).isEqualTo(1);
+        assertThat(redisson.getAtomicLong("execution1").get()).isEqualTo(1);
+
+        Thread.sleep(TimeUnit.SECONDS.toMillis(6));
+
+        assertThat(executor.getTaskCount()).isZero();
+        assertThat(redisson.getAtomicLong("cancel1").get()).isEqualTo(1);
+        assertThat(redisson.getAtomicLong("execution1").get()).isEqualTo(1);
+
+        executor.delete();
+        redisson.getKeys().delete("execution1", "cancel1");
+        assertThat(redisson.getKeys().count()).isZero();
+    }
+
     private void cancel(ScheduledFuture<?> future1) throws InterruptedException, ExecutionException {
         assertThat(future1.cancel(true)).isTrue();
         try {
@@ -578,6 +604,31 @@ public class RedissonScheduledExecutorServiceTest extends BaseTest {
         assertThat(redisson.getKeys().count()).isZero();
     }
 
+    @Test
+    public void testCancelAndInterruptSwallowedAtFixedRate() throws InterruptedException, ExecutionException {
+        RScheduledExecutorService executor = redisson.getExecutorService("test");
+        RScheduledFuture<?> future = executor.scheduleAtFixedRate(new SwallowingInterruptionTask("execution1", "cancel1"), 0, 6, TimeUnit.SECONDS);
+
+        Thread.sleep(TimeUnit.SECONDS.toMillis(1));
+
+        assertThat(redisson.getAtomicLong("cancel1").get()).isZero();
+        assertThat(redisson.getAtomicLong("execution1").get()).isEqualTo(1);
+
+        cancel(future);
+
+        assertThat(redisson.getAtomicLong("cancel1").get()).isEqualTo(1);
+        assertThat(redisson.getAtomicLong("execution1").get()).isEqualTo(1);
+
+        Thread.sleep(TimeUnit.SECONDS.toMillis(6));
+
+        assertThat(executor.getTaskCount()).isZero();
+        assertThat(redisson.getAtomicLong("cancel1").get()).isEqualTo(1);
+        assertThat(redisson.getAtomicLong("execution1").get()).isEqualTo(1);
+
+        executor.delete();
+        redisson.getKeys().delete("execution1", "cancel1");
+        assertThat(redisson.getKeys().count()).isZero();
+    }
 
     @Test
     public void testMultipleTasksWithTimeShift() throws InterruptedException, ExecutionException {

--- a/redisson/src/test/java/org/redisson/executor/SwallowingInterruptionTask.java
+++ b/redisson/src/test/java/org/redisson/executor/SwallowingInterruptionTask.java
@@ -11,13 +11,11 @@ import java.util.concurrent.TimeUnit;
 public class SwallowingInterruptionTask implements Runnable, Serializable {
     @RInject
     private RedissonClient redisson;
-    private final String objectName;
-    private final String cancelObjectName;
+    private String objectName;
+    private String cancelObjectName;
 
     public SwallowingInterruptionTask() {
         super();
-        objectName = null;
-        cancelObjectName = null;
     }
 
     public SwallowingInterruptionTask(String objectName, String cancelObjectName) {

--- a/redisson/src/test/java/org/redisson/executor/SwallowingInterruptionTask.java
+++ b/redisson/src/test/java/org/redisson/executor/SwallowingInterruptionTask.java
@@ -1,0 +1,43 @@
+package org.redisson.executor;
+
+import org.redisson.api.RedissonClient;
+import org.redisson.api.annotation.RInject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.util.concurrent.TimeUnit;
+
+public class SwallowingInterruptionTask implements Runnable, Serializable {
+    @RInject
+    private RedissonClient redisson;
+    private final String objectName;
+    private final String cancelObjectName;
+
+    public SwallowingInterruptionTask() {
+        super();
+        objectName = null;
+        cancelObjectName = null;
+    }
+
+    public SwallowingInterruptionTask(String objectName, String cancelObjectName) {
+        super();
+        this.objectName = objectName;
+        this.cancelObjectName = cancelObjectName;
+    }
+
+    @Override
+    public void run() {
+        Logger logger = LoggerFactory.getLogger(getClass());
+        logger.info("start");
+        redisson.getAtomicLong(objectName).incrementAndGet();
+        try {
+            Thread.sleep(TimeUnit.SECONDS.toMillis(5));
+        } catch (InterruptedException e) {
+            logger.info("interrupted");
+            redisson.getAtomicLong(cancelObjectName).incrementAndGet();
+            return;
+        }
+        logger.info("end");
+    }
+}


### PR DESCRIPTION
In `TasksRunnerService`, the behaviors of FixedRate and FixedDelay are quite different.

In method `scheduleWithFixedDelay`, we (1) execute `Runnable`, and then (2) check whether the task request id still exists, and finally (3) schedule next execution.

However, in method `scheduleAtFixedRate`, we (1) execute `Runnable`, and then (2) schedule next execution, without checking the task request id.

I believe that `FixedDelay` and `FixedRate` are similar and should not have such difference, so I raise this pull request to add a check in method `scheduleAtFixedRate`.

This pull request also addresses issue #5143 .