### PR TITLE
Bug fix: #5148

### DIFF
--- a/redisson/src/test/java/org/redisson/executor/RedissonScheduledExecutorServiceTest.java
+++ b/redisson/src/test/java/org/redisson/executor/RedissonScheduledExecutorServiceTest.java
@@ -420,7 +420,8 @@ RedissonScheduledExecutorServiceTest extends BaseTest {
         assertThat(redisson.getAtomicLong("counter").get()).isEqualTo(3);
 
         cancel(future);
-        assertThat(redisson.<Long>getBucket("executed").get()).isBetween(1000L, Long.MAX_VALUE);
+        Thread.sleep(50);
+        assertThat(redisson.<Long>getBucket("executed").get()).isGreaterThan(1000L);
 
         Thread.sleep(TimeUnit.SECONDS.toMillis(3));
         assertThat(redisson.getAtomicLong("counter").get()).isEqualTo(3);

--- a/redisson/src/test/java/org/redisson/executor/RedissonScheduledExecutorServiceTest.java
+++ b/redisson/src/test/java/org/redisson/executor/RedissonScheduledExecutorServiceTest.java
@@ -392,6 +392,41 @@ public class RedissonScheduledExecutorServiceTest extends BaseTest {
         assertThat(redisson.getAtomicLong("executed2").get()).isEqualTo(30);
     }
 
+    @Test
+    public void testCancelCronExpression() throws InterruptedException, ExecutionException {
+        RScheduledExecutorService executor = redisson.getExecutorService("test");
+        RScheduledFuture<?> future = executor.schedule(new ScheduledRunnableTask("executed"), CronSchedule.of("0/2 * * * * ?"));
+        Thread.sleep(TimeUnit.SECONDS.toMillis(10));
+        assertThat(redisson.getAtomicLong("executed").get()).isEqualTo(5);
+
+        cancel(future);
+
+        Thread.sleep(TimeUnit.SECONDS.toMillis(3));
+        assertThat(redisson.getAtomicLong("executed").get()).isEqualTo(5);
+
+        executor.delete();
+        redisson.getKeys().delete("executed");
+        assertThat(redisson.getKeys().count()).isZero();
+    }
+
+    @Test
+    public void testCancelAndInterruptCronExpression() throws InterruptedException, ExecutionException {
+        RScheduledExecutorService executor = redisson.getExecutorService("test");
+        RScheduledFuture<?> future = executor.schedule(new ScheduledLongRepeatableTask("counter", "executed"), CronSchedule.of("0/2 * * * * ?"));
+        Thread.sleep(TimeUnit.SECONDS.toMillis(6));
+        assertThat(redisson.getAtomicLong("counter").get()).isEqualTo(3);
+
+        cancel(future);
+        assertThat(redisson.<Long>getBucket("executed").get()).isBetween(1000L, Long.MAX_VALUE);
+
+        Thread.sleep(TimeUnit.SECONDS.toMillis(3));
+        assertThat(redisson.getAtomicLong("counter").get()).isEqualTo(3);
+
+        executor.delete();
+        redisson.getKeys().delete("counter", "executed");
+        assertThat(redisson.getKeys().count()).isZero();
+    }
+
     public static class RunnableTask2 implements Runnable, Serializable {
 
         @Override


### PR DESCRIPTION
This pull request addresses #5148 .

I made the following changes:

- Change the order of code statements, in order to execute Runnable before scheduling next execution.
- Add 2 unit test cases, referencing `testCancelAndInterruptWithFixedDelay` as an example.

With these changes, when we cancel cron tasks, they can be successfully interrupted. (I verified it on my local machine.)