### PR TITLE
Bug fix: #5152

### DIFF
--- a/redisson/src/test/java/org/redisson/executor/RedissonScheduledExecutorServiceTest.java
+++ b/redisson/src/test/java/org/redisson/executor/RedissonScheduledExecutorServiceTest.java
@@ -493,7 +493,7 @@ public class RedissonScheduledExecutorServiceTest extends BaseTest {
         assertThat(redisson.getAtomicLong("counter").get()).isEqualTo(3);
         
         cancel(future1);
-        assertThat(redisson.<Long>getBucket("executed1").get()).isBetween(1000L, Long.MAX_VALUE);
+        assertThat(redisson.getAtomicLong("executed1").get()).isBetween(1000L, Long.MAX_VALUE);
 
         Thread.sleep(3000);
         assertThat(redisson.getAtomicLong("counter").get()).isEqualTo(3);
@@ -504,13 +504,15 @@ public class RedissonScheduledExecutorServiceTest extends BaseTest {
         assertThat(redisson.getAtomicLong("counter").get()).isEqualTo(3);
         
         executor.cancelTask(future2.getTaskId());
-        assertThat(redisson.<Long>getBucket("executed2").get()).isBetween(1000L, Long.MAX_VALUE);
+        assertThat(redisson.getAtomicLong("executed2").get()).isBetween(1000L, Long.MAX_VALUE);
 
         Thread.sleep(3000);
         assertThat(redisson.getAtomicLong("counter").get()).isEqualTo(3);
         
         executor.delete();
-        redisson.getKeys().delete("counter", "executed1", "executed2");
+
+        // There may be another key that exists, starting with "{remote_response}:".
+        redisson.getKeys().delete(redisson.getKeys().getKeysStream().toArray(String[]::new));
         assertThat(redisson.getKeys().count()).isZero();
     }
 

--- a/redisson/src/test/java/org/redisson/executor/ScheduledLongRepeatableTask.java
+++ b/redisson/src/test/java/org/redisson/executor/ScheduledLongRepeatableTask.java
@@ -26,9 +26,13 @@ public class ScheduledLongRepeatableTask implements Runnable, Serializable {
     public void run() {
         if (redisson.getAtomicLong(counterName).incrementAndGet() == 3) {
             for (long i = 0; i < Long.MAX_VALUE; i++) {
-                if (Thread.currentThread().isInterrupted()) {
+                // Clear interrupted flag in order to access database
+                if (Thread.interrupted()) {
                     System.out.println("interrupted " + i);
-                    redisson.getBucket(objectName).set(i);
+                    redisson.getAtomicLong(objectName).set(i);
+
+                    // Set interrupted flag back
+                    Thread.currentThread().interrupt();
                     return;
                 }
             }


### PR DESCRIPTION
This pull request addresses #5152 , and only affects unit tests.

Changes:

- In ScheduledLongRepeatableTask, clear the interruption flag before accessing database, and later set it back.
- In ScheduledLongRepeatableTask, change `getBucket` into `getAtomicLong`
- In `testCancelAndInterruptWithFixedDelay`,  delete a key that starts with `{remote_response}:`.