### PR TITLE
Feature - Netty native transport for `io_uring`

### DIFF
--- a/redisson/pom.xml
+++ b/redisson/pom.xml
@@ -40,6 +40,13 @@
             <artifactId>netty-transport-native-epoll</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.netty.incubator</groupId>
+            <artifactId>netty-incubator-transport-native-io_uring</artifactId>
+            <scope>provided</scope>
+            <version>0.0.21.Final</version>
+            <classifier>linux-x86_64</classifier>
+        </dependency>
 
         <dependency>
             <groupId>io.netty</groupId>

--- a/redisson/src/main/java/org/redisson/config/TransportMode.java
+++ b/redisson/src/main/java/org/redisson/config/TransportMode.java
@@ -38,4 +38,9 @@ public enum TransportMode {
      */
     KQUEUE,
 
+    /**
+     * Use `io_uring` transport. Requires <b>netty-transport-io_uring</b> lib in classpath.
+     */
+    IO_URING,
+
 }


### PR DESCRIPTION
- add `TransportMode.IO_URING`
- add incubator uring dependency

Fixes and closes #5169