### PR TITLE
Fix possible memory leak in JsonJacksonCodec during warmup

### DIFF
--- a/redisson/src/main/java/org/redisson/codec/JsonJacksonCodec.java
+++ b/redisson/src/main/java/org/redisson/codec/JsonJacksonCodec.java
@@ -120,12 +120,16 @@ public class JsonJacksonCodec extends BaseCodec {
         }
         warmedup = true;
 
+        ByteBuf d = null;
         try {
-            ByteBuf d = getValueEncoder().encode("testValue");
+            d = getValueEncoder().encode("testValue");
             getValueDecoder().decode(d, null);
-            d.release();
         } catch (IOException e) {
             e.printStackTrace();
+        } finally {
+            if (d != null) {
+                d.release();
+            }
         }
     }
 


### PR DESCRIPTION
During warmup we call `ByteBuf.release` after decoding the value, however, the decoding action can fail which will lead to a memory leak so we move the ByteBuf release method to a `finally` block.