### PR TITLE
Missing methods in Quarkus Native

### DIFF
--- a/redisson-quarkus/redisson-quarkus-30/deployment/src/main/java/io/quarkus/redisson/client/deployment/QuarkusRedissonClientProcessor.java
+++ b/redisson-quarkus/redisson-quarkus-30/deployment/src/main/java/io/quarkus/redisson/client/deployment/QuarkusRedissonClientProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/redisson-quarkus/redisson-quarkus-30/deployment/src/main/java/io/quarkus/redisson/client/deployment/QuarkusRedissonClientProcessor.java
+++ b/redisson-quarkus/redisson-quarkus-30/deployment/src/main/java/io/quarkus/redisson/client/deployment/QuarkusRedissonClientProcessor.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (c) 2013-2022 Nikita Koksharov
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,13 +28,22 @@ import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.redisson.client.runtime.RedissonClientProducer;
 import io.quarkus.redisson.client.runtime.RedissonClientRecorder;
+import org.redisson.RedissonBucket;
+import org.redisson.RedissonMultimap;
+import org.redisson.RedissonObject;
+import org.redisson.api.RBucket;
+import org.redisson.api.RExpirable;
+import org.redisson.api.RObject;
+import org.redisson.api.RObjectReactive;
+import org.redisson.codec.Kryo5Codec;
+import org.redisson.config.*;
+import org.redisson.executor.RemoteExecutorService;
+import org.redisson.executor.RemoteExecutorServiceAsync;
 
 import java.io.IOException;
 
 /**
- *
  * @author Nikita Koksharov
- *
  */
 class QuarkusRedissonClientProcessor {
 
@@ -64,18 +73,62 @@ class QuarkusRedissonClientProcessor {
         nativeResources.produce(new NativeImageResourceBuildItem("META-INF/services/org.jboss.marshalling.ProviderDescriptor"));
         watchedFiles.produce(new HotDeploymentWatchedFileBuildItem("redisson.yaml"));
 
-        reflectiveItems.produce(new ReflectiveClassBuildItem(false, false, "org.redisson.codec.Kryo5Codec"));
+        reflectiveItems.produce(ReflectiveClassBuildItem.builder(Kryo5Codec.class)
+                .methods(false)
+                .fields(false)
+                .build()
+        );
 
-        reflectiveItems.produce(new ReflectiveClassBuildItem(true, false, "org.redisson.executor.RemoteExecutorService"));
-        reflectiveItems.produce(new ReflectiveClassBuildItem(true, false, "org.redisson.executor.RemoteExecutorServiceAsync"));
+        reflectiveItems.produce(ReflectiveClassBuildItem.builder(
+                        RemoteExecutorService.class,
+                        RemoteExecutorServiceAsync.class)
+                .methods(true)
+                .fields(false)
+                .build()
+        );
 
-        reflectiveItems.produce(new ReflectiveClassBuildItem(true, true, "org.redisson.config.Config"));
-        reflectiveItems.produce(new ReflectiveClassBuildItem(true, true, "org.redisson.config.BaseConfig"));
-        reflectiveItems.produce(new ReflectiveClassBuildItem(true, true, "org.redisson.config.BaseMasterSlaveServersConfig"));
-        reflectiveItems.produce(new ReflectiveClassBuildItem(true, true, "org.redisson.config.SingleServerConfig"));
-        reflectiveItems.produce(new ReflectiveClassBuildItem(true, true, "org.redisson.config.ReplicatedServersConfig"));
-        reflectiveItems.produce(new ReflectiveClassBuildItem(true, true, "org.redisson.config.SentinelServersConfig"));
-        reflectiveItems.produce(new ReflectiveClassBuildItem(true, true, "org.redisson.config.ClusterServersConfig"));
+        reflectiveItems.produce(ReflectiveClassBuildItem.builder(
+                        Config.class,
+                        BaseConfig.class,
+                        BaseMasterSlaveServersConfig.class,
+                        SingleServerConfig.class,
+                        ReplicatedServersConfig.class,
+                        SentinelServersConfig.class,
+                        ClusterServersConfig.class)
+                .methods(true)
+                .fields(true)
+                .build()
+        );
+
+        reflectiveItems.produce(ReflectiveClassBuildItem.builder(
+                        RBucket.class,
+                        RedissonBucket.class,
+                        RedissonObject.class,
+                        RedissonMultimap.class)
+                .methods(true)
+                .fields(true)
+                .build()
+        );
+
+        reflectiveItems.produce(ReflectiveClassBuildItem.builder(
+                        RBucket.class,
+                        RedissonBucket.class,
+                        RedissonObject.class,
+                        RedissonMultimap.class)
+                .methods(true)
+                .fields(true)
+                .build()
+        );
+
+        reflectiveItems.produce(ReflectiveClassBuildItem.builder(
+                        RObjectReactive.class,
+                        RExpirable.class,
+                        RObject.class)
+                .methods(true)
+                .build()
+        );
+
+
     }
 
     @BuildStep

--- a/redisson-quarkus/redisson-quarkus-30/deployment/src/main/java/io/quarkus/redisson/client/deployment/QuarkusRedissonClientProcessor.java
+++ b/redisson-quarkus/redisson-quarkus-30/deployment/src/main/java/io/quarkus/redisson/client/deployment/QuarkusRedissonClientProcessor.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (c) 2013-2022 Nikita Koksharov
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -43,7 +43,9 @@ import org.redisson.executor.RemoteExecutorServiceAsync;
 import java.io.IOException;
 
 /**
+ *
  * @author Nikita Koksharov
+ *
  */
 class QuarkusRedissonClientProcessor {
 

--- a/redisson-quarkus/redisson-quarkus-30/deployment/src/main/java/io/quarkus/redisson/client/deployment/QuarkusRedissonClientProcessor.java
+++ b/redisson-quarkus/redisson-quarkus-30/deployment/src/main/java/io/quarkus/redisson/client/deployment/QuarkusRedissonClientProcessor.java
@@ -113,16 +113,6 @@ class QuarkusRedissonClientProcessor {
         );
 
         reflectiveItems.produce(ReflectiveClassBuildItem.builder(
-                        RBucket.class,
-                        RedissonBucket.class,
-                        RedissonObject.class,
-                        RedissonMultimap.class)
-                .methods(true)
-                .fields(true)
-                .build()
-        );
-
-        reflectiveItems.produce(ReflectiveClassBuildItem.builder(
                         RObjectReactive.class,
                         RExpirable.class,
                         RObject.class)

--- a/redisson-quarkus/redisson-quarkus-30/integration-tests/src/main/java/org/redisson/quarkus/client/it/QuarkusRedissonClientResource.java
+++ b/redisson-quarkus/redisson-quarkus-30/integration-tests/src/main/java/org/redisson/quarkus/client/it/QuarkusRedissonClientResource.java
@@ -31,11 +31,13 @@
 */
 package org.redisson.quarkus.client.it;
 
+import io.smallrye.mutiny.Uni;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import org.redisson.api.*;
 import org.redisson.api.redisnode.RedisNodes;
+import org.redisson.client.codec.StringCodec;
 
 import java.util.concurrent.ExecutionException;
 
@@ -79,6 +81,22 @@ public class QuarkusRedissonClientResource {
 
         RExecutorFuture<String> r = t.submit(new Task());
         return r.get();
+    }
+
+    @GET
+    @Path("/bucket")
+    public Uni<String> getBucket(){
+        RBucketReactive<String> bucket = redisson.reactive().getBucket("test-bucket", new StringCodec());
+        return Uni.createFrom().future(bucket.set("world").toFuture())
+                .flatMap( unused -> Uni.createFrom().future(bucket.get().toFuture()));
+    }
+
+    @GET
+    @Path("/delBucket")
+    public Uni<Boolean> deleteBucket(){
+        RBucketReactive<String> bucket = redisson.reactive().getBucket("test-bucket", new StringCodec());
+        return Uni.createFrom().future(bucket.set("world").toFuture())
+                .flatMap( unused -> Uni.createFrom().future(bucket.delete().toFuture()));
     }
 
 }

--- a/redisson-quarkus/redisson-quarkus-30/integration-tests/src/test/java/org/redisson/quarkus/client/it/QuarkusRedissonClientResourceTest.java
+++ b/redisson-quarkus/redisson-quarkus-30/integration-tests/src/test/java/org/redisson/quarkus/client/it/QuarkusRedissonClientResourceTest.java
@@ -38,6 +38,24 @@ public class QuarkusRedissonClientResourceTest {
                 .body(is("OK"));
     }
 
+    @Test
+    public void testBucket() {
+        given()
+                .when().get("/quarkus-redisson-client/bucket")
+                .then()
+                .statusCode(200)
+                .body(is("world"));
+    }
+
+    @Test
+    public void testDeleteBucket() {
+        given()
+                .when().get("/quarkus-redisson-client/delBucket")
+                .then()
+                .statusCode(200)
+                .body(is(true));
+    }
+
 //    @Test
 //    public void testExecuteTask() {
 //        given()


### PR DESCRIPTION
When compile to Quarkus Native. Bucket delete in reactive shows method not found
After looking at the reflection output of the build, found certain methods to be missing.
Tested these configurations to be working with Bucket Delete