### PR TITLE
ConnectionManger.shutdown completes within timeout

### DIFF
--- a/redisson/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
@@ -472,6 +472,7 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
         if (dnsMonitor != null) {
             dnsMonitor.stop();
         }
+        long timeoutInNanos = unit.toNanos(timeout);
 
         serviceManager.getConnectionWatcher().stop();
 
@@ -483,7 +484,9 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
             CompletableFuture<Void> future = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
 
             try {
-                future.get(timeout, unit);
+                long startTime = System.nanoTime();
+                future.get(timeoutInNanos, TimeUnit.NANOSECONDS);
+                timeoutInNanos -= (System.nanoTime() - startTime);
             } catch (Exception e) {
                 // skip
             }
@@ -495,7 +498,9 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
         if (serviceManager.getCfg().getExecutor() == null) {
             serviceManager.getExecutor().shutdown();
             try {
-                serviceManager.getExecutor().awaitTermination(timeout, unit);
+                long startTime = System.nanoTime();
+                serviceManager.getExecutor().awaitTermination(timeoutInNanos, TimeUnit.NANOSECONDS);
+                timeoutInNanos -= (System.nanoTime() - startTime);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
@@ -505,7 +510,9 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
         serviceManager.getShutdownLatch().awaitUninterruptibly();
 
         if (serviceManager.getCfg().getEventLoopGroup() == null) {
-            serviceManager.getGroup().shutdownGracefully(quietPeriod, timeout, unit).syncUninterruptibly();
+            long startTime = System.nanoTime();
+            serviceManager.getGroup().shutdownGracefully(quietPeriod, timeoutInNanos, TimeUnit.NANOSECONDS).syncUninterruptibly();
+            timeoutInNanos -= (System.nanoTime() - startTime);
         }
 
         serviceManager.getTimer().stop();

--- a/redisson/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
@@ -486,7 +486,7 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
             try {
                 long startTime = System.nanoTime();
                 future.get(timeoutInNanos, TimeUnit.NANOSECONDS);
-                timeoutInNanos -= (System.nanoTime() - startTime);
+                timeoutInNanos -= System.nanoTime() - startTime;
             } catch (Exception e) {
                 // skip
             }
@@ -500,7 +500,7 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
             try {
                 long startTime = System.nanoTime();
                 serviceManager.getExecutor().awaitTermination(timeoutInNanos, TimeUnit.NANOSECONDS);
-                timeoutInNanos -= (System.nanoTime() - startTime);
+                timeoutInNanos -= System.nanoTime() - startTime;
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
@@ -512,7 +512,7 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
         if (serviceManager.getCfg().getEventLoopGroup() == null) {
             long startTime = System.nanoTime();
             serviceManager.getGroup().shutdownGracefully(quietPeriod, timeoutInNanos, TimeUnit.NANOSECONDS).syncUninterruptibly();
-            timeoutInNanos -= (System.nanoTime() - startTime);
+            timeoutInNanos -= System.nanoTime() - startTime;
         }
 
         serviceManager.getTimer().stop();


### PR DESCRIPTION
Make sure that the total time of shutdown() does not exceed the provided timeout.

Signed-off-by: Dave Golombek

5370