### PR TITLE
Log swallowed exceptions in RedissonRemoteService

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonRemoteService.java
+++ b/redisson/src/main/java/org/redisson/RedissonRemoteService.java
@@ -364,6 +364,13 @@ public class RedissonRemoteService extends BaseRemoteService implements RRemoteS
                     } else {
                         executeMethod(remoteInterface, requestQueue, executor, request, bean);
                     }
+                })
+                .exceptionally(exc -> {
+                    if (exc instanceof RedissonShutdownException) {
+                        return null;
+                    }
+                    log.error("Can't process the remote service request with id {}", requestId, exc);
+                    return null;
                 });
         });
     }


### PR DESCRIPTION
Log exception when can't process the remote service request, like when codec can't unmarshall the RemoteServiceRequest (eg: when using Typed/JsonJacksonCodec).
Closed bug #4163 has root on this, not entering this whenComplete [section](https://github.com/redisson/redisson/blob/c792670a2e3cdcf5e51279d46ccefbdf617c1fee/redisson/src/main/java/org/redisson/RedissonRemoteService.java#L237).