### PR TITLE
Fix: JsonJacksonCodec fails to serialize Throwable on Java17

### DIFF
--- a/redisson/src/main/java/org/redisson/codec/JsonJacksonCodec.java
+++ b/redisson/src/main/java/org/redisson/codec/JsonJacksonCodec.java
@@ -65,7 +65,7 @@ public class JsonJacksonCodec extends BaseCodec {
     public static final JsonJacksonCodec INSTANCE = new JsonJacksonCodec();
 
     @JsonIdentityInfo(generator=ObjectIdGenerators.IntSequenceGenerator.class, property="@id")
-    @JsonAutoDetect(fieldVisibility = Visibility.ANY, 
+    @JsonAutoDetect(fieldVisibility = Visibility.NON_PRIVATE,
                     getterVisibility = Visibility.PUBLIC_ONLY, 
                     setterVisibility = Visibility.NONE, 
                     isGetterVisibility = Visibility.NONE)

--- a/redisson/src/test/java/org/redisson/codec/JsonJacksonCodecTest.java
+++ b/redisson/src/test/java/org/redisson/codec/JsonJacksonCodecTest.java
@@ -2,6 +2,7 @@ package org.redisson.codec;
 
 import java.io.IOException;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -35,6 +36,17 @@ public class JsonJacksonCodecTest {
             JsonJacksonCodec codec = new JsonJacksonCodec();
             codec.getObjectMapper().readValue(JSON, Bean1599.class);
         });
+    }
+
+    @Test
+    public void shouldSerializeAndDeserializeThrowable() throws JsonProcessingException {
+        //given
+        ObjectMapper objectMapper = JsonJacksonCodec.INSTANCE.getObjectMapper();
+        //when
+        String serialized = objectMapper.writeValueAsString(new RuntimeException("Example message"));
+        RuntimeException deserialized = objectMapper.readValue(serialized, RuntimeException.class);
+        //then
+        Assertions.assertEquals("Example message", deserialized.getMessage());
     }
 
     @Test


### PR DESCRIPTION
This fixes issue: #5369

The serialization of Throwable instances would fail on Java17 with error:
```
com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Invalid type definition for type `java.lang.Throwable`: Failed to call `setAccess()` on Field 'detailMessage' (of class `java.lang.Throwable`) due to `java.lang.reflect.InaccessibleObjectException`, problem: Unable to make field private java.lang.String java.lang.Throwable.detailMessage accessible: module java.base does not "opens java.lang" to unnamed module @32eff876
  //...
Caused by: java.lang.IllegalArgumentException: Failed to call `setAccess()` on Field 'detailMessage' (of class `java.lang.Throwable`) due to `java.lang.reflect.InaccessibleObjectException`, problem: Unable to make field private java.lang.String java.lang.Throwable.detailMessage accessible: module java.base does not "opens java.lang" to unnamed module @32eff876
   // ...
Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make field private java.lang.String java.lang.Throwable.detailMessage accessible: module java.base does not "opens java.lang" to unnamed module @32eff876
  // ...
```