### PR TITLE
Fix waitTime when TimeUnit is not MILLISECONDS and leaseTime is not set

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonLock.java
@@ -161,7 +161,8 @@ public class RedissonLock extends RedissonBaseLock {
         if (leaseTime > 0) {
             acquiredFuture = tryLockInnerAsync(waitTime, leaseTime, unit, threadId, RedisCommands.EVAL_NULL_BOOLEAN);
         } else {
-            acquiredFuture = tryLockInnerAsync(waitTime, internalLockLeaseTime,
+            long waitTimeMillis = unit.toMillis(waitTime);
+            acquiredFuture = tryLockInnerAsync(waitTimeMillis, internalLockLeaseTime,
                     TimeUnit.MILLISECONDS, threadId, RedisCommands.EVAL_NULL_BOOLEAN);
         }
 
@@ -186,7 +187,8 @@ public class RedissonLock extends RedissonBaseLock {
         if (leaseTime > 0) {
             ttlRemainingFuture = tryLockInnerAsync(waitTime, leaseTime, unit, threadId, RedisCommands.EVAL_LONG);
         } else {
-            ttlRemainingFuture = tryLockInnerAsync(waitTime, internalLockLeaseTime,
+            long waitTimeMillis = unit.toMillis(waitTime);
+            ttlRemainingFuture = tryLockInnerAsync(waitTimeMillis, internalLockLeaseTime,
                     TimeUnit.MILLISECONDS, threadId, RedisCommands.EVAL_LONG);
         }
         CompletionStage<Long> s = handleNoSync(threadId, ttlRemainingFuture);


### PR DESCRIPTION
When we do a tryAcquire without leaseTime, TimeUnit is forced to MILLISECONDS even if waitTime is not in MILLISECONDS. This can cause inconsistency and lead to troubles.