### PR TITLE
Fix work with multiple different RLocalCachedMap in the same RTransaction

### DIFF
--- a/redisson/src/main/java/org/redisson/transaction/RedissonTransaction.java
+++ b/redisson/src/main/java/org/redisson/transaction/RedissonTransaction.java
@@ -54,7 +54,7 @@ public class RedissonTransaction implements RTransaction {
     private final TransactionOptions options;
     private List<TransactionalOperation> operations = new CopyOnWriteArrayList<>();
     private Set<String> localCaches = new HashSet<>();
-    private final Map<RLocalCachedMap<?, ?>, RLocalCachedMap<?, ?>> localCacheInstances = new HashMap<>();
+    private final Map<String, RLocalCachedMap<?, ?>> localCacheInstances = new HashMap<>();
     private final Map<String, Object> instances = new HashMap<>();
 
     private RedissonTransactionalBuckets bucketsInstance;
@@ -85,7 +85,7 @@ public class RedissonTransaction implements RTransaction {
         checkState();
 
         localCaches.add(fromInstance.getName());
-        return (RLocalCachedMap<K, V>) localCacheInstances.computeIfAbsent(fromInstance, k -> {
+        return (RLocalCachedMap<K, V>) localCacheInstances.computeIfAbsent(fromInstance.getName(), k -> {
             return new RedissonTransactionalLocalCachedMap<>(commandExecutor,
                     operations, options.getTimeout(), executed, fromInstance, id);
         });

--- a/redisson/src/test/java/org/redisson/transaction/RedissonTransactionalLocalCachedMapTest.java
+++ b/redisson/src/test/java/org/redisson/transaction/RedissonTransactionalLocalCachedMapTest.java
@@ -124,5 +124,21 @@ public class RedissonTransactionalLocalCachedMapTest extends RedisDockerTest {
         assertThat(m2.get("3")).isEqualTo("4");
     }
 
-    
+    @Test
+    public void testPut2Maps() throws InterruptedException {
+        RLocalCachedMap<String, String> m1 = redisson.getLocalCachedMap("test1", LocalCachedMapOptions.defaults());
+        RLocalCachedMap<String, String> m2 = redisson.getLocalCachedMap("test2", LocalCachedMapOptions.defaults());
+
+        RTransaction transaction = redisson.createTransaction(TransactionOptions.defaults());
+        RMap<String, String> tMap1 = transaction.getLocalCachedMap(m1);
+        RMap<String, String> tMap2 = transaction.getLocalCachedMap(m2);
+        tMap1.put("1", "2");
+        tMap2.put("3", "4");
+
+        transaction.commit();
+
+        assertThat(m1.get("1")).isEqualTo("2");
+        assertThat(m1.get("3")).isEqualTo("4");
+    }
+
 }


### PR DESCRIPTION
Work with 2 different `RLocalCachedMap`s was broken. The root cause:
1. `RTransaction` tries to cache locally instances of `RedissonTransactionalLocalCachedMap`s for origin `RLocalCachedMap`s.
2. The origin `RLocalCachedMap` is used as a **key** in that local cache.
3. Keys for the local cache are calculated via`RLocalCachedMap.hashCode()` method.
4. `RLocalCachedMap.hashCode` method calculates the hash based only on map entries
5. As a result, different empty `RLocalCachedMap` were mapped to the same key and the local cache was broken.

The described case is reproduced in PR in the test `testPut2Maps`.

Proposed solution: use the name of the origin `RLocalCachedMap` as a key in the local cache.