### PR TITLE
Add isHeldByThread(long threadId) to RLockReactive

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonBaseLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonBaseLock.java
@@ -258,6 +258,7 @@ public abstract class RedissonBaseLock extends RedissonExpirable implements RLoc
         return get(isHeldByThreadAsync(threadId));
     }
 
+    @Override
     public RFuture<Boolean> isHeldByThreadAsync(long threadId) {
         return commandExecutor.writeAsync(getRawName(), LongCodec.INSTANCE, RedisCommands.HEXISTS, getRawName(), getLockName(threadId));
     }

--- a/redisson/src/main/java/org/redisson/RedissonBaseLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonBaseLock.java
@@ -255,8 +255,11 @@ public abstract class RedissonBaseLock extends RedissonExpirable implements RLoc
 
     @Override
     public boolean isHeldByThread(long threadId) {
-        RFuture<Boolean> future = commandExecutor.writeAsync(getRawName(), LongCodec.INSTANCE, RedisCommands.HEXISTS, getRawName(), getLockName(threadId));
-        return get(future);
+        return get(isHeldByThreadAsync(threadId));
+    }
+
+    public RFuture<Boolean> isHeldByThreadAsync(long threadId) {
+        return commandExecutor.writeAsync(getRawName(), LongCodec.INSTANCE, RedisCommands.HEXISTS, getRawName(), getLockName(threadId));
     }
 
     private static final RedisCommand<Integer> HGET = new RedisCommand<Integer>("HGET", new MapValueDecoder(), new IntegerReplayConvertor(0));

--- a/redisson/src/main/java/org/redisson/RedissonMultiLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonMultiLock.java
@@ -490,6 +490,11 @@ public class RedissonMultiLock implements RLock {
     }
 
     @Override
+    public RFuture<Boolean> isHeldByThreadAsync(long threadId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public boolean isHeldByCurrentThread() {
         throw new UnsupportedOperationException();
     }

--- a/redisson/src/main/java/org/redisson/api/RLockAsync.java
+++ b/redisson/src/main/java/org/redisson/api/RLockAsync.java
@@ -148,7 +148,16 @@ public interface RLockAsync {
      * @return <code>true</code> if lock acquired otherwise <code>false</code>
      */
     RFuture<Boolean> tryLockAsync(long waitTime, long leaseTime, TimeUnit unit, long threadId);
-    
+
+    /**
+     * Checks if the lock is held by thread with defined <code>threadId</code>
+     *
+     * @param threadId Thread ID of locking thread
+     * @return <code>true</code> if held by thread with given id
+     *          otherwise <code>false</code>
+     */
+    RFuture<Boolean> isHeldByThreadAsync(long threadId);
+
     /**
      * Number of holds on this lock by the current thread
      *

--- a/redisson/src/main/java/org/redisson/api/RLockReactive.java
+++ b/redisson/src/main/java/org/redisson/api/RLockReactive.java
@@ -173,6 +173,15 @@ public interface RLockReactive {
     Mono<Boolean> isLocked();
 
     /**
+     * Checks if the lock is held by thread with defined <code>threadId</code>
+     *
+     * @param threadId Thread ID of locking thread
+     * @return <code>true</code> if held by thread with given id
+     *          otherwise <code>false</code>
+     */
+    Mono<Boolean> isHeldByThread(long threadId);
+
+    /**
      * Remaining time to live of the lock
      *
      * @return time in milliseconds

--- a/redisson/src/main/java/org/redisson/api/RLockRx.java
+++ b/redisson/src/main/java/org/redisson/api/RLockRx.java
@@ -174,6 +174,15 @@ public interface RLockRx {
     Single<Boolean> isLocked();
 
     /**
+     * Checks if the lock is held by thread with defined <code>threadId</code>
+     *
+     * @param threadId Thread ID of locking thread
+     * @return <code>true</code> if held by thread with given id
+     *          otherwise <code>false</code>
+     */
+    Single<Boolean> isHeldByThread(long threadId);
+
+    /**
      * Remaining time to live of the lock
      *
      * @return time in milliseconds

--- a/redisson/src/test/java/org/redisson/RedissonLockReactiveTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonLockReactiveTest.java
@@ -4,13 +4,9 @@ import org.junit.jupiter.api.Test;
 import org.redisson.api.RLockReactive;
 import reactor.core.publisher.Mono;
 
-import java.time.Duration;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class RedissonLockReactiveTest extends BaseReactiveTest {
-
-    private static final int MAX_DURATION = 5;
 
     @Test
     public void testMultiLock() {
@@ -24,7 +20,7 @@ public class RedissonLockReactiveTest extends BaseReactiveTest {
     }
 
     @Test
-    void testIsHeldByThread() {
+    public void testIsHeldByThread() {
         String lockName = "lock1";
         RLockReactive lock1 = redisson.getLock(lockName);
         RLockReactive lock2 = redisson.getLock(lockName);
@@ -34,16 +30,16 @@ public class RedissonLockReactiveTest extends BaseReactiveTest {
         int threadId2 = 2;
         Mono<Boolean> lockMono2 = lock1.tryLock(threadId2);
 
-        assertThat(lockMono1.block(Duration.ofSeconds(MAX_DURATION))).isTrue();
-        assertThat(lock1.isHeldByThread(threadId1).block(Duration.ofSeconds(MAX_DURATION))).isTrue();
+        assertThat(sync(lockMono1)).isTrue();
+        assertThat(sync(lock1.isHeldByThread(threadId1))).isTrue();
 
-        lock1.unlock(threadId1).block(Duration.ofSeconds(MAX_DURATION));
-        assertThat(lock1.isHeldByThread(threadId1).block(Duration.ofSeconds(MAX_DURATION))).isFalse();
-        assertThat(lockMono2.block(Duration.ofSeconds(MAX_DURATION))).isTrue();
-        assertThat(lock2.isHeldByThread(threadId2).block(Duration.ofSeconds(MAX_DURATION))).isTrue();
+        sync(lock1.unlock(threadId1));
+        assertThat(sync(lock1.isHeldByThread(threadId1))).isFalse();
+        assertThat(sync(lockMono2)).isTrue();
+        assertThat(sync(lock2.isHeldByThread(threadId2))).isTrue();
 
-        lock2.unlock(threadId2).block(Duration.ofSeconds(MAX_DURATION));
-        assertThat(lock1.isHeldByThread(threadId1).block(Duration.ofSeconds(MAX_DURATION))).isFalse();
-        assertThat(lock2.isHeldByThread(threadId2).block(Duration.ofSeconds(MAX_DURATION))).isFalse();
+        sync(lock2.unlock(threadId2));
+        assertThat(sync(lock1.isHeldByThread(threadId1))).isFalse();
+        assertThat(sync(lock2.isHeldByThread(threadId2))).isFalse();
     }
 }

--- a/redisson/src/test/java/org/redisson/RedissonLockReactiveTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonLockReactiveTest.java
@@ -2,10 +2,15 @@ package org.redisson;
 
 import org.junit.jupiter.api.Test;
 import org.redisson.api.RLockReactive;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class RedissonLockReactiveTest extends BaseReactiveTest {
+
+    private static final int MAX_DURATION = 5;
 
     @Test
     public void testMultiLock() {
@@ -18,4 +23,27 @@ public class RedissonLockReactiveTest extends BaseReactiveTest {
         assertThat(sync(l2.isLocked())).isTrue();
     }
 
+    @Test
+    void testIsHeldByThread() {
+        String lockName = "lock1";
+        RLockReactive lock1 = redisson.getLock(lockName);
+        RLockReactive lock2 = redisson.getLock(lockName);
+
+        int threadId1 = 1;
+        Mono<Boolean> lockMono1 = lock1.tryLock(threadId1);
+        int threadId2 = 2;
+        Mono<Boolean> lockMono2 = lock1.tryLock(threadId2);
+
+        assertThat(lockMono1.block(Duration.ofSeconds(MAX_DURATION))).isTrue();
+        assertThat(lock1.isHeldByThread(threadId1).block(Duration.ofSeconds(MAX_DURATION))).isTrue();
+
+        lock1.unlock(threadId1).block(Duration.ofSeconds(MAX_DURATION));
+        assertThat(lock1.isHeldByThread(threadId1).block(Duration.ofSeconds(MAX_DURATION))).isFalse();
+        assertThat(lockMono2.block(Duration.ofSeconds(MAX_DURATION))).isTrue();
+        assertThat(lock2.isHeldByThread(threadId2).block(Duration.ofSeconds(MAX_DURATION))).isTrue();
+
+        lock2.unlock(threadId2).block(Duration.ofSeconds(MAX_DURATION));
+        assertThat(lock1.isHeldByThread(threadId1).block(Duration.ofSeconds(MAX_DURATION))).isFalse();
+        assertThat(lock2.isHeldByThread(threadId2).block(Duration.ofSeconds(MAX_DURATION))).isFalse();
+    }
 }

--- a/redisson/src/test/java/org/redisson/RedissonLockRxTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonLockRxTest.java
@@ -1,5 +1,6 @@
 package org.redisson;
 
+import io.reactivex.rxjava3.core.Single;
 import org.junit.jupiter.api.Test;
 import org.redisson.api.RLockRx;
 import org.redisson.rx.BaseRxTest;
@@ -19,4 +20,27 @@ public class RedissonLockRxTest extends BaseRxTest {
         assertThat(sync(l2.isLocked())).isTrue();
     }
 
+    @Test
+    public void testIsHeldByThread() {
+        String lockName = "lock1";
+        RLockRx lock1 = redisson.getLock(lockName);
+        RLockRx lock2 = redisson.getLock(lockName);
+
+        int threadId1 = 1;
+        Single<Boolean> lockMono1 = lock1.tryLock(threadId1);
+        int threadId2 = 2;
+        Single<Boolean> lockMono2 = lock1.tryLock(threadId2);
+
+        assertThat(sync(lockMono1)).isTrue();
+        assertThat(sync(lock1.isHeldByThread(threadId1))).isTrue();
+
+        sync(lock1.unlock(threadId1));
+        assertThat(sync(lock1.isHeldByThread(threadId1))).isFalse();
+        assertThat(sync(lockMono2)).isTrue();
+        assertThat(sync(lock2.isHeldByThread(threadId2))).isTrue();
+
+        sync(lock2.unlock(threadId2));
+        assertThat(sync(lock1.isHeldByThread(threadId1))).isFalse();
+        assertThat(sync(lock2.isHeldByThread(threadId2))).isFalse();
+    }
 }


### PR DESCRIPTION
We can acquire a lock for a given threadId using methods like `Mono<Boolean> tryLock(long threadId)`.
But we can't check, if a lock is held by a given threadId for reactive API.

We already  have the method `boolean isHeldByThread(long threadId)` in RLock.
Adding similar method to RLockReactive: `Mono<Boolean> isHeldByThread(long threadId);`