### PR TITLE
Fix issue #5728 - Executing multiple RSet.add and RSet.contains methods within the same transaction results in the LEAK error

### DIFF
--- a/redisson/src/main/java/org/redisson/transaction/BaseTransactionalSet.java
+++ b/redisson/src/main/java/org/redisson/transaction/BaseTransactionalSet.java
@@ -417,8 +417,8 @@ public abstract class BaseTransactionalSet<V> extends BaseTransactionalObject {
         try {
             return valueBuf.equals(oldValueBuf);
         } finally {
-            valueBuf.readableBytes();
-            oldValueBuf.readableBytes();
+            valueBuf.release();
+            oldValueBuf.release();
         }
     }
 

--- a/redisson/src/test/java/org/redisson/RedissonSetTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonSetTest.java
@@ -23,7 +23,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNoException;
 
 public class RedissonSetTest extends RedisDockerTest {
 

--- a/redisson/src/test/java/org/redisson/RedissonSetTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonSetTest.java
@@ -1,20 +1,9 @@
 package org.redisson;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNoException;
-
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
+import io.netty.util.ResourceLeakDetector;
+import mockit.Invocation;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.redisson.RedisRunner.FailedToStartRedisException;
@@ -26,6 +15,15 @@ import org.redisson.api.SortOrder;
 import org.redisson.api.TransactionOptions;
 import org.redisson.client.codec.IntegerCodec;
 import org.redisson.client.codec.StringCodec;
+
+import java.io.Serializable;
+import java.util.*;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 public class RedissonSetTest extends RedisDockerTest {
 
@@ -107,21 +105,21 @@ public class RedissonSetTest extends RedisDockerTest {
         list.add(1);
         list.add(2);
         list.add(3);
-
+        
         Set<Integer> descSort = list.readSort(SortOrder.DESC);
         assertThat(descSort).containsExactly(3, 2, 1);
 
         Set<Integer> ascSort = list.readSort(SortOrder.ASC);
         assertThat(ascSort).containsExactly(1, 2, 3);
     }
-
+    
     @Test
     public void testSortOrderLimit() {
         RSet<Integer> list = redisson.getSet("list", IntegerCodec.INSTANCE);
         list.add(1);
         list.add(2);
         list.add(3);
-
+        
         Set<Integer> descSort = list.readSort(SortOrder.DESC, 1, 2);
         assertThat(descSort).containsExactly(2, 1);
 
@@ -135,29 +133,29 @@ public class RedissonSetTest extends RedisDockerTest {
         list.add(1);
         list.add(2);
         list.add(3);
-
+        
         redisson.getBucket("test1", IntegerCodec.INSTANCE).set(3);
         redisson.getBucket("test2", IntegerCodec.INSTANCE).set(2);
         redisson.getBucket("test3", IntegerCodec.INSTANCE).set(1);
-
+        
         Set<Integer> descSort = list.readSort("test*", SortOrder.DESC);
         assertThat(descSort).containsExactly(1, 2, 3);
 
         Set<Integer> ascSort = list.readSort("test*", SortOrder.ASC);
         assertThat(ascSort).containsExactly(3, 2, 1);
     }
-
+    
     @Test
     public void testSortOrderByPatternLimit() {
         RSet<Integer> list = redisson.getSet("list", IntegerCodec.INSTANCE);
         list.add(1);
         list.add(2);
         list.add(3);
-
+        
         redisson.getBucket("test1", IntegerCodec.INSTANCE).set(3);
         redisson.getBucket("test2", IntegerCodec.INSTANCE).set(2);
         redisson.getBucket("test3", IntegerCodec.INSTANCE).set(1);
-
+        
         Set<Integer> descSort = list.readSort("test*", SortOrder.DESC, 1, 2);
         assertThat(descSort).containsExactly(2, 3);
 
@@ -171,37 +169,37 @@ public class RedissonSetTest extends RedisDockerTest {
         list.add("1");
         list.add("2");
         list.add("3");
-
+        
         redisson.getBucket("test1", IntegerCodec.INSTANCE).set(1);
         redisson.getBucket("test2", IntegerCodec.INSTANCE).set(2);
         redisson.getBucket("test3", IntegerCodec.INSTANCE).set(3);
-
+        
         redisson.getBucket("tester1", StringCodec.INSTANCE).set("obj1");
         redisson.getBucket("tester2", StringCodec.INSTANCE).set("obj2");
         redisson.getBucket("tester3", StringCodec.INSTANCE).set("obj3");
-
+        
         Collection<String> descSort = list.readSort("test*", Arrays.asList("tester*"), SortOrder.DESC);
         assertThat(descSort).containsExactly("obj3", "obj2", "obj1");
 
         Collection<String> ascSort = list.readSort("test*", Arrays.asList("tester*"), SortOrder.ASC);
         assertThat(ascSort).containsExactly("obj1", "obj2", "obj3");
     }
-
+    
     @Test
     public void testSortOrderByPatternGetLimit() {
         RSet<String> list = redisson.getSet("list", StringCodec.INSTANCE);
         list.add("1");
         list.add("2");
         list.add("3");
-
+        
         redisson.getBucket("test1", IntegerCodec.INSTANCE).set(1);
         redisson.getBucket("test2", IntegerCodec.INSTANCE).set(2);
         redisson.getBucket("test3", IntegerCodec.INSTANCE).set(3);
-
+        
         redisson.getBucket("tester1", StringCodec.INSTANCE).set("obj1");
         redisson.getBucket("tester2", StringCodec.INSTANCE).set("obj2");
         redisson.getBucket("tester3", StringCodec.INSTANCE).set("obj3");
-
+        
         Collection<String> descSort = list.readSort("test*", Arrays.asList("tester*"), SortOrder.DESC, 1, 2);
         assertThat(descSort).containsExactly("obj2", "obj1");
 
@@ -333,7 +331,7 @@ public class RedissonSetTest extends RedisDockerTest {
         assertThat(list.sortTo("test3", SortOrder.DESC)).isEqualTo(3);
         RList<String> list2 = redisson.getList("test3", StringCodec.INSTANCE);
         assertThat(list2).containsExactly("3", "2", "1");
-
+        
         assertThat(list.sortTo("test4", SortOrder.ASC)).isEqualTo(3);
         RList<String> list3 = redisson.getList("test4", StringCodec.INSTANCE);
         assertThat(list3).containsExactly("1", "2", "3");
@@ -346,11 +344,11 @@ public class RedissonSetTest extends RedisDockerTest {
         list.add(1);
         list.add(2);
         list.add(3);
-
+        
         assertThat(list.sortTo("test3", SortOrder.DESC, 1, 2)).isEqualTo(2);
         RList<String> list2 = redisson.getList("test3", StringCodec.INSTANCE);
         assertThat(list2).containsExactly("2", "1");
-
+        
         assertThat(list.sortTo("test4", SortOrder.ASC, 1, 2)).isEqualTo(2);
         RList<String> list3 = redisson.getList("test4", StringCodec.INSTANCE);
         assertThat(list3).containsExactly("2", "3");
@@ -362,21 +360,21 @@ public class RedissonSetTest extends RedisDockerTest {
         list.add(1);
         list.add(2);
         list.add(3);
-
+        
         redisson.getBucket("test1", IntegerCodec.INSTANCE).set(3);
         redisson.getBucket("test2", IntegerCodec.INSTANCE).set(2);
         redisson.getBucket("test3", IntegerCodec.INSTANCE).set(1);
-
+        
         assertThat(list.sortTo("tester3", "test*", SortOrder.DESC, 1, 2)).isEqualTo(2);
         RList<String> list2 = redisson.getList("tester3", StringCodec.INSTANCE);
         assertThat(list2).containsExactly("2", "3");
-
+        
         assertThat(list.sortTo("tester4", "test*", SortOrder.ASC, 1, 2)).isEqualTo(2);
         RList<String> list3 = redisson.getList("tester4", StringCodec.INSTANCE);
         assertThat(list3).containsExactly("2", "1");
     }
 
-
+    
     @Test
     public void testRemoveRandom() {
         RSet<Integer> set = redisson.getSet("simple");
@@ -389,7 +387,7 @@ public class RedissonSetTest extends RedisDockerTest {
         assertThat(set.removeRandom()).isIn(1, 2, 3);
         assertThat(set.removeRandom()).isNull();
     }
-
+    
     @Test
     public void testRemoveRandomAmount() {
         RSet<Integer> set = redisson.getSet("simple");
@@ -412,11 +410,11 @@ public class RedissonSetTest extends RedisDockerTest {
         for (int i = 0; i < 10; i++) {
             set.add(i);
         }
-
+        
         assertThat(set.random(3)).containsAnyElementsOf(set.readAll()).hasSize(3);
     }
-
-
+    
+    
     @Test
     public void testRandom() {
         RSet<Integer> set = redisson.getSet("simple");
@@ -580,7 +578,7 @@ public class RedissonSetTest extends RedisDockerTest {
             assertThat(keys).hasSize(size);
         });
     }
-
+    
     @Test
     public void testIteratorRemoveHighVolume() throws InterruptedException {
         Set<Integer> set = redisson.getSet("set") /*new HashSet<Integer>()*/;
@@ -798,7 +796,7 @@ public class RedissonSetTest extends RedisDockerTest {
         assertThat(set).containsOnly(6, 5, 7);
     }
 
-
+    
     @Test
     public void testMove() throws Exception {
         RSet<Integer> set = redisson.getSet("set");
@@ -828,8 +826,8 @@ public class RedissonSetTest extends RedisDockerTest {
         Assertions.assertEquals(1, set.size());
         Assertions.assertEquals(0, otherSet.size());
     }
-
-
+    
+    
     @Test
     public void testRemoveAllEmpty() {
         Set<Integer> list = redisson.getSet("list");
@@ -902,19 +900,30 @@ public class RedissonSetTest extends RedisDockerTest {
 
     @Test
     public void testAddAndContainsInTransactionShouldNotShowResourceLeak() {
-        int arbitraryElementsCount = 1000;
+
+        new MockUp<ResourceLeakDetector<?>>() {
+            @Mock
+            void reportTracedLeak(Invocation invocation, String resourceType, String records) {
+                invocation.proceed();
+                Assertions.fail();
+            }
+
+            @Mock
+            void reportUntracedLeak(Invocation invocation, String resourceType) {
+                invocation.proceed();
+                Assertions.fail();
+            }
+        };
 
         RTransaction tx = redisson.createTransaction(TransactionOptions.defaults());
         RSet<Integer> testSet = tx.getSet("testSet");
-        // Should check the log when we run this test and see if there is any resource leak error
-        assertThatNoException().isThrownBy(()->{
-            for (int index = 0; index < arbitraryElementsCount; index++) {
-                testSet.add(index);
-                if (testSet.contains(index)) {
-                    System.out.println("Element " + index + " is in the set");
-                }
+        for (int index = 0; index < 1000; index++) {
+            testSet.add(index);
+            if (testSet.contains(index)) {
+                // do nothing
             }
-        });
+        }
+
         tx.commit();
     }
 }


### PR DESCRIPTION
Fix issue #5728 - resource leak error when executing multiple contains operation of RSet in transaction