### PR TITLE
Modify jmockit mvn version to 1.52.0 that used in maven-surefire-plugin

### DIFF
--- a/redisson/pom.xml
+++ b/redisson/pom.xml
@@ -545,7 +545,7 @@
 
                         <forkCount>4</forkCount>
                         <reuseForks>true</reuseForks>
-                        <argLine>${argLine} -javaagent:"${settings.localRepository}"/com/github/hazendaz/jmockit/jmockit/1.51.0/jmockit-1.51.0.jar</argLine>
+                        <argLine>${argLine} -javaagent:"${settings.localRepository}"/com/github/hazendaz/jmockit/jmockit/1.52.0/jmockit-1.52.0.jar</argLine>
                     </configuration>
             </plugin>
 


### PR DESCRIPTION
The jmockit version is set to 1.52.0 in the redisson-parent pom.xml.
However, inside maven-surefire-plugin, version 1.51.0 were being used.
So I got issued that mvn can not find jmockit that version 1.51.0 when I executing mvn test.

Therefore, I have updated all stuff that used in jmockit javaagent version to target 1.52.0.


Below are the log messages I got.
```
Error occurred during initialization of VM
agent library failed Agent_OnLoad: instrument
Error opening zip file or JAR manifest missing : /Users/aronroh/.m2/repository/com/github/hazendaz/jmockit/jmockit/1.51.0/jmockit-1.51.0.jar
```

