### PR TITLE
Correctly update shutdown timeout after each step in connection manager shutdown

### DIFF
--- a/redisson/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
@@ -512,7 +512,7 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
 
         long startTime = System.nanoTime();
         serviceManager.shutdownFutures(quietPeriod, unit);
-        timeoutInNanos = Math.max(0, timeoutInNanos - System.nanoTime() - startTime);
+        timeoutInNanos = Math.max(0, timeoutInNanos - (System.nanoTime() - startTime));
 
         if (isInitialized()) {
             List<CompletableFuture<Void>> futures = new ArrayList<>();
@@ -524,7 +524,7 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
             try {
                 startTime = System.nanoTime();
                 future.get(timeoutInNanos, TimeUnit.NANOSECONDS);
-                timeoutInNanos = Math.max(0, timeoutInNanos - System.nanoTime() - startTime);
+                timeoutInNanos = Math.max(0, timeoutInNanos - (System.nanoTime() - startTime));
             } catch (Exception e) {
                 // skip
             }
@@ -535,7 +535,7 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
             try {
                 startTime = System.nanoTime();
                 serviceManager.getExecutor().awaitTermination(timeoutInNanos, TimeUnit.NANOSECONDS);
-                timeoutInNanos = Math.max(0, timeoutInNanos - System.nanoTime() - startTime);
+                timeoutInNanos = Math.max(0, timeoutInNanos - (System.nanoTime() - startTime));
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }

--- a/redisson/src/test/java/org/redisson/RedissonTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonTest.java
@@ -858,4 +858,18 @@ public class RedissonTest extends RedisDockerTest {
         r.shutdown();
     }
 
+    @Test
+    public void testShutdownQuietPeriod() {
+        // On a very slow system this may give false positives,
+        // but at the same time a longer timeout would make the test suite slower
+        long quietPeriod = TimeUnit.MILLISECONDS.toMillis(50);
+        long timeOut = quietPeriod + TimeUnit.SECONDS.toMillis(2);
+        RedissonClient r = createInstance();
+        long startTime = System.currentTimeMillis();
+        r.shutdown(quietPeriod, timeOut, TimeUnit.MILLISECONDS);
+        long shutdownTime = System.currentTimeMillis() - startTime;
+
+        Assertions.assertTrue(shutdownTime > quietPeriod);
+    }
+
 }


### PR DESCRIPTION
See details here:
https://github.com/redisson/redisson/issues/5795#issuecomment-2107851479

I wasn't able to run successful unit tests locally on master, following this guide:
https://github.com/redisson/redisson/blob/7b29c420dee37977c5ca6f827a7205205d29b389/.github/CONTRIBUTING.md

New test fails before change and works with the change.