### PR TITLE
Allow retry of NOREPLICAS error

### DIFF
--- a/redisson/src/main/java/org/redisson/client/RedisNoReplicasException.java
+++ b/redisson/src/main/java/org/redisson/client/RedisNoReplicasException.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2013-2024 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.client;
+
+/**
+ * This error occurs when Redis a redis master has insufficient slaves to handle a request.
+ * *
+ */
+public class RedisNoReplicasException extends RedisRetryException {
+
+    private static final long serialVersionUID = -5658453331593029252L;
+
+    public RedisNoReplicasException(String message) {
+        super(message);
+    }
+}

--- a/redisson/src/main/java/org/redisson/client/handler/CommandDecoder.java
+++ b/redisson/src/main/java/org/redisson/client/handler/CommandDecoder.java
@@ -410,7 +410,10 @@ public class CommandDecoder extends ReplayingDecoder<State> {
             } else if (error.startsWith("READONLY")) {
                 data.tryFailure(new RedisReadonlyException(error
                         + ". channel: " + channel + " data: " + data));
-            }else {
+            }  else if (error.startsWith("NOREPLICAS")) {
+                data.tryFailure(new RedisNoReplicasException(error
+                        + ". channel: " + channel + " data: " + data));
+            } else {
                 if (data != null) {
                     data.tryFailure(new RedisException(error + ". channel: " + channel + " command: " + LogHelper.toString(data)));
                 } else {


### PR DESCRIPTION
* During a failover event where a new redis master is being promoted there is a period of time before the slaves begin to follow the new master. This can lead to write calls failing with NOREPLICAS. This usually happens when min-slaves-to-write is configured as non 0.
* This error could occur for a misconfiguration, and reties wouldnt help, but we have found that in practice we see failed writes on most failovers due to this error, and a treating it as retryable would have prevented those exception cases.

Scenarios for reproduction:

1. Create a 3 redis 3 sentinel setup, and configure min-slaves-to-write.
2. Create a client which continually fires off write request to redis
3. Kill off the redis listed as master
4. Observe that NOREPLICAS error is thrown, and the write call fails without retrying.