### PR TITLE
Fixed - releaseConnection may not execute correctly

### DIFF
--- a/redisson/src/main/java/org/redisson/command/RedisQueuedBatchExecutor.java
+++ b/redisson/src/main/java/org/redisson/command/RedisQueuedBatchExecutor.java
@@ -100,7 +100,10 @@ public class RedisQueuedBatchExecutor<V, R> extends BaseRedisBatchExecutor<V, R>
                 || RedisCommands.DISCARD.getName().equals(command.getName())) {
             if (attempt < attempts
                     && attemptPromise.isCompletedExceptionally()) {
-                return;
+                Throwable cause = cause(attemptPromise);
+                if (cause instanceof CancellationException) {
+                    return;
+                }
             }
 
             super.releaseConnection(attemptPromise, connectionFuture);

--- a/redisson/src/main/java/org/redisson/command/RedisQueuedBatchExecutor.java
+++ b/redisson/src/main/java/org/redisson/command/RedisQueuedBatchExecutor.java
@@ -99,11 +99,8 @@ public class RedisQueuedBatchExecutor<V, R> extends BaseRedisBatchExecutor<V, R>
         if (RedisCommands.EXEC.getName().equals(command.getName())
                 || RedisCommands.DISCARD.getName().equals(command.getName())) {
             if (attempt < attempts
-                    && attemptPromise.isCompletedExceptionally()) {
-                Throwable cause = cause(attemptPromise);
-                if (cause instanceof CancellationException) {
-                    return;
-                }
+                    && attemptPromise.isCancelled()) {
+                return;
             }
 
             super.releaseConnection(attemptPromise, connectionFuture);


### PR DESCRIPTION
1. use redis-cli "set test test"
2. run the code
`
RBatch batch = client.createBatch(BatchOptions.defaults().executionMode(ExecutionMode.REDIS_WRITE_ATOMIC));
batch.getAtomicLong("test").incrementAndGetAsync();
batch.executeAsync();
`


that will cause RedisException, than the connection that 'batch' used will not release.