### PR TITLE
Fix #5426

### DIFF
--- a/redisson-tomcat/redisson-tomcat-10/src/main/java/org/redisson/tomcat/RedissonSession.java
+++ b/redisson-tomcat/redisson-tomcat-10/src/main/java/org/redisson/tomcat/RedissonSession.java
@@ -392,6 +392,32 @@ public class RedissonSession extends StandardSession {
         }
     }
 
+    @Override
+    public void setId(String id, boolean notify) {
+        if ((this.id != null) && (manager != null)) {
+            redissonManager.superRemove(this);
+            if (map == null) {
+                map = redissonManager.getMap(this.id);
+            }
+            map.rename(redissonManager.getTomcatSessionKeyName(id));
+        }
+
+        boolean idWasNull = this.id == null;
+        this.id = id;
+
+        if (manager != null) {
+            if (idWasNull) {
+                redissonManager.add(this);
+            } else {
+                redissonManager.superAdd(this);
+            }
+        }
+
+        if (notify) {
+            tellNew();
+        }
+    }
+
     public void save() {
         if (map == null) {
             map = redissonManager.getMap(id);

--- a/redisson-tomcat/redisson-tomcat-10/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-10/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -144,9 +144,13 @@ public class RedissonSessionManager extends ManagerBase {
         return redisson.getSet(name, StringCodec.INSTANCE);
     }
     
-    public RMap<String, Object> getMap(String sessionId) {
+    public String getTomcatSessionKeyName(String sessionId) {
         String separator = keyPrefix == null || keyPrefix.isEmpty() ? "" : ":";
-        String name = keyPrefix + separator + "redisson:tomcat_session:" + sessionId;
+        return keyPrefix + separator + "redisson:tomcat_session:" + sessionId;
+    }
+
+    public RMap<String, Object> getMap(String sessionId) {
+        String name = getTomcatSessionKeyName(sessionId);
         return redisson.getMap(name, new CompositeCodec(StringCodec.INSTANCE, codecToUse, codecToUse));
     }
 
@@ -212,6 +216,10 @@ public class RedissonSessionManager extends ManagerBase {
         return session;
     }
     
+    public void superRemove(Session session) {
+        super.remove(session, false);
+    }
+
     @Override
     public void remove(Session session, boolean update) {
         super.remove(session, update);
@@ -221,6 +229,10 @@ public class RedissonSessionManager extends ManagerBase {
         }
     }
     
+    public void superAdd(Session session) {
+        super.add(session);
+    }
+
     @Override
     public void add(Session session) {
         super.add(session);

--- a/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSession.java
+++ b/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSession.java
@@ -410,6 +410,32 @@ public class RedissonSession extends StandardSession {
         }
     }
 
+    @Override
+    public void setId(String id, boolean notify) {
+        if ((this.id != null) && (manager != null)) {
+            redissonManager.superRemove(this);
+            if (map == null) {
+                map = redissonManager.getMap(this.id);
+            }
+            map.rename(redissonManager.getTomcatSessionKeyName(id));
+        }
+
+        boolean idWasNull = this.id == null;
+        this.id = id;
+
+        if (manager != null) {
+            if (idWasNull) {
+                redissonManager.add(this);
+            } else {
+                redissonManager.superAdd(this);
+            }
+        }
+
+        if (notify) {
+            tellNew();
+        }
+    }
+
     public void save() {
         if (map == null) {
             map = redissonManager.getMap(id);

--- a/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -143,10 +143,14 @@ public class RedissonSessionManager extends ManagerBase {
         String name = keyPrefix + separator + "redisson:tomcat_notified_nodes:" + sessionId;
         return redisson.getSet(name, StringCodec.INSTANCE);
     }
-    
-    public RMap<String, Object> getMap(String sessionId) {
+
+    public String getTomcatSessionKeyName(String sessionId) {
         String separator = keyPrefix == null || keyPrefix.isEmpty() ? "" : ":";
-        String name = keyPrefix + separator + "redisson:tomcat_session:" + sessionId;
+        return keyPrefix + separator + "redisson:tomcat_session:" + sessionId;
+    }
+
+    public RMap<String, Object> getMap(String sessionId) {
+        String name = getTomcatSessionKeyName(sessionId);
         return redisson.getMap(name, new CompositeCodec(StringCodec.INSTANCE, codecToUse, codecToUse));
     }
 
@@ -212,6 +216,10 @@ public class RedissonSessionManager extends ManagerBase {
         return session;
     }
     
+    public void superRemove(Session session) {
+        super.remove(session, false);
+    }
+
     @Override
     public void remove(Session session, boolean update) {
         super.remove(session, update);
@@ -221,6 +229,10 @@ public class RedissonSessionManager extends ManagerBase {
         }
     }
     
+    public void superAdd(Session session) {
+        super.add(session);
+    }
+
     @Override
     public void add(Session session) {
         super.add(session);

--- a/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSession.java
+++ b/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSession.java
@@ -387,6 +387,32 @@ public class RedissonSession extends StandardSession {
         }
     }
 
+    @Override
+    public void setId(String id, boolean notify) {
+        if ((this.id != null) && (manager != null)) {
+            redissonManager.superRemove(this);
+            if (map == null) {
+                map = redissonManager.getMap(this.id);
+            }
+            map.rename(redissonManager.getTomcatSessionKeyName(id));
+        }
+
+        boolean idWasNull = this.id == null;
+        this.id = id;
+
+        if (manager != null) {
+            if (idWasNull) {
+                redissonManager.add(this);
+            } else {
+                redissonManager.superAdd(this);
+            }
+        }
+
+        if (notify) {
+            tellNew();
+        }
+    }
+
     public void save() {
         if (map == null) {
             map = redissonManager.getMap(id);

--- a/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -144,9 +144,13 @@ public class RedissonSessionManager extends ManagerBase {
         return redisson.getSet(name, StringCodec.INSTANCE);
     }
     
-    public RMap<String, Object> getMap(String sessionId) {
+    public String getTomcatSessionKeyName(String sessionId) {
         String separator = keyPrefix == null || keyPrefix.isEmpty() ? "" : ":";
-        String name = keyPrefix + separator + "redisson:tomcat_session:" + sessionId;
+        return keyPrefix + separator + "redisson:tomcat_session:" + sessionId;
+    }
+
+    public RMap<String, Object> getMap(String sessionId) {
+        String name = getTomcatSessionKeyName(sessionId);
         return redisson.getMap(name, new CompositeCodec(StringCodec.INSTANCE, codecToUse, codecToUse));
     }
 
@@ -212,6 +216,10 @@ public class RedissonSessionManager extends ManagerBase {
         return session;
     }
     
+    public void superRemove(Session session) {
+        super.remove(session, false);
+    }
+
     @Override
     public void remove(Session session, boolean update) {
         super.remove(session, update);
@@ -221,6 +229,10 @@ public class RedissonSessionManager extends ManagerBase {
         }
     }
     
+    public void superAdd(Session session) {
+        super.add(session);
+    }
+
     @Override
     public void add(Session session) {
         super.add(session);

--- a/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/RedissonSession.java
+++ b/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/RedissonSession.java
@@ -387,6 +387,32 @@ public class RedissonSession extends StandardSession {
         }
     }
 
+    @Override
+    public void setId(String id, boolean notify) {
+        if ((this.id != null) && (manager != null)) {
+            redissonManager.superRemove(this);
+            if (map == null) {
+                map = redissonManager.getMap(this.id);
+            }
+            map.rename(redissonManager.getTomcatSessionKeyName(id));
+        }
+
+        boolean idWasNull = this.id == null;
+        this.id = id;
+
+        if (manager != null) {
+            if (idWasNull) {
+                redissonManager.add(this);
+            } else {
+                redissonManager.superAdd(this);
+            }
+        }
+
+        if (notify) {
+            tellNew();
+        }
+    }
+
     public void save() {
         if (map == null) {
             map = redissonManager.getMap(id);

--- a/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -144,9 +144,13 @@ public class RedissonSessionManager extends ManagerBase {
         return redisson.getSet(name, StringCodec.INSTANCE);
     }
     
-    public RMap<String, Object> getMap(String sessionId) {
+    public String getTomcatSessionKeyName(String sessionId) {
         String separator = keyPrefix == null || keyPrefix.isEmpty() ? "" : ":";
-        String name = keyPrefix + separator + "redisson:tomcat_session:" + sessionId;
+        return keyPrefix + separator + "redisson:tomcat_session:" + sessionId;
+    }
+
+    public RMap<String, Object> getMap(String sessionId) {
+        String name = getTomcatSessionKeyName(sessionId);
         return redisson.getMap(name, new CompositeCodec(StringCodec.INSTANCE, codecToUse, codecToUse));
     }
 
@@ -212,6 +216,10 @@ public class RedissonSessionManager extends ManagerBase {
         return session;
     }
     
+    public void superRemove(Session session) {
+        super.remove(session, false);
+    }
+
     @Override
     public void remove(Session session, boolean update) {
         super.remove(session, update);
@@ -221,6 +229,10 @@ public class RedissonSessionManager extends ManagerBase {
         }
     }
     
+    public void superAdd(Session session) {
+        super.add(session);
+    }
+
     @Override
     public void add(Session session) {
         super.add(session);


### PR DESCRIPTION
Override changeSessionId from StandardSession to copy all items in old session to new in Redis layer.
This leaves intact all logic around when Session gets written to redis (Memory vs Redis and Default vs After Update) and ensures underlying cache is exactly the same as prior to ID change.