### PR TITLE
Fixed - Concurrency problem

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonBaseLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonBaseLock.java
@@ -165,11 +165,11 @@ public abstract class RedissonBaseLock extends RedissonExpirable implements RLoc
     
     protected void scheduleExpirationRenewal(long threadId) {
         ExpirationEntry entry = new ExpirationEntry();
+        entry.addThreadId(threadId);
         ExpirationEntry oldEntry = EXPIRATION_RENEWAL_MAP.putIfAbsent(getEntryName(), entry);
         if (oldEntry != null) {
             oldEntry.addThreadId(threadId);
         } else {
-            entry.addThreadId(threadId);
             try {
                 renewExpiration();
             } finally {


### PR DESCRIPTION
in mehod scheduleExpirationRenewal
oldEntry.addThreadId may happen before entry.addThreadId
