### PR TITLE
Fixed - Redisearch parse params error

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonSearch.java
+++ b/redisson/src/main/java/org/redisson/RedissonSearch.java
@@ -269,6 +269,9 @@ public class RedissonSearch implements RSearch {
                 args.add("SEPARATOR");
                 args.add(params.getSeparator());
             }
+            if (params.isWithSuffixTrie()) {
+                args.add("WITHSUFFIXTRIE");
+            }
             if (params.getSortMode() != null) {
                 args.add("SORTABLE");
                 if (params.getSortMode() == SortMode.UNNORMALIZED) {
@@ -277,9 +280,6 @@ public class RedissonSearch implements RSearch {
             }
             if (params.isNoIndex()) {
                 args.add("NOINDEX");
-            }
-            if (params.isWithSuffixTrie()) {
-                args.add("WITHSUFFIXTRIE");
             }
         }
     }
@@ -293,17 +293,8 @@ public class RedissonSearch implements RSearch {
                 args.add(params.getAs());
             }
             args.add("TEXT");
-            if (params.getSortMode() != null) {
-                args.add("SORTABLE");
-                if (params.getSortMode() == SortMode.UNNORMALIZED) {
-                    args.add("UNF");
-                }
-            }
             if (params.isNoStem()) {
                 args.add("NOSTEM");
-            }
-            if (params.isNoIndex()) {
-                args.add("NOINDEX");
             }
             if (params.getMatcher() != null) {
                 args.add("PHONETIC");
@@ -315,6 +306,15 @@ public class RedissonSearch implements RSearch {
             }
             if (params.isWithSuffixTrie()) {
                 args.add("WITHSUFFIXTRIE");
+            }
+            if (params.getSortMode() != null) {
+                args.add("SORTABLE");
+                if (params.getSortMode() == SortMode.UNNORMALIZED) {
+                    args.add("UNF");
+                }
+            }
+            if (params.isNoIndex()) {
+                args.add("NOINDEX");
             }
         }
     }

--- a/redisson/src/test/java/org/redisson/RedissonSearchTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonSearchTest.java
@@ -410,8 +410,26 @@ public class RedissonSearchTest extends DockerRedisStackTest {
         FieldIndex[] fields = new FieldIndex[]{
                 FieldIndex.tag("$.name")
                         .caseSensitive()
+                        .withSuffixTrie()
                         .noIndex()
                         .separator("a")
+                        .sortMode(SortMode.NORMALIZED)
+                        .as("name")
+        };
+        RSearch s = redisson.getSearch();
+        s.createIndex("itemIndex", indexOptions, fields);
+    }
+
+    @Test
+    public void testFieldText() {
+        IndexOptions indexOptions = IndexOptions.defaults()
+                .on(IndexType.JSON)
+                .prefix(Arrays.asList("items"));
+
+        FieldIndex[] fields = new FieldIndex[]{
+                FieldIndex.text("$.name")
+                        .noStem()
+                        .noIndex()
                         .sortMode(SortMode.NORMALIZED)
                         .as("name")
         };


### PR DESCRIPTION
when create index , parameters passed in the wrong order.

refer to :
[RediSearch param sequence](https://github.com/RediSearch/RediSearch/blob/v2.8.14/src/spec.c#L876)