### PR TITLE
100万高并发下，过多Future导致OOM问题修复

### DIFF
--- a/redisson/src/main/java/org/redisson/connection/ServiceManager.java
+++ b/redisson/src/main/java/org/redisson/connection/ServiceManager.java
@@ -340,8 +340,12 @@ public final class ServiceManager {
     }
 
     private final Set<CompletableFuture<?>> futures = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    private final int limits = (int) Runtime.getRuntime().maxMemory() / (1024*1024);
 
     public void addFuture(CompletableFuture<?> future) {
+        while (futures.size() > limits){
+            Thread.yield();
+        }
         futures.add(future);
     }
 


### PR DESCRIPTION
100百万高并发，过多Future会导致OOM
详细压测过程请参阅 
[redission实践-踩坑-高并发-内存泄露-OOM-CSDN博客.pdf](https://github.com/user-attachments/files/15936730/redission.-.-.-.-OOM-CSDN.pdf)
