### PR TITLE
Fixed - RingBuffer#setCapacity, trim list incorrect

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonRingBuffer.java
+++ b/redisson/src/main/java/org/redisson/RedissonRingBuffer.java
@@ -68,8 +68,10 @@ public class RedissonRingBuffer<V> extends RedissonQueue<V> implements RRingBuff
     public RFuture<Void> setCapacityAsync(int capacity) {
         return commandExecutor.evalWriteAsync(getRawName(), LongCodec.INSTANCE, RedisCommands.EVAL_VOID,
                 "redis.call('set', KEYS[2], ARGV[1]); " +
-                      "local len = redis.call('llen', KEYS[1]); " +
-                      "redis.call('ltrim', KEYS[1], len - tonumber(ARGV[1]), len - 1); ",
+                        "local len = redis.call('llen', KEYS[1]); " +
+                        "if len > tonumber(ARGV[1]) then " +
+                            "redis.call('ltrim', KEYS[1], len - tonumber(ARGV[1]), -1); " +
+                        "end; ",
              Arrays.asList(getRawName(), settingsName), capacity);
     }
 

--- a/redisson/src/test/java/org/redisson/RedissonRingBufferTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonRingBufferTest.java
@@ -32,6 +32,28 @@ public class RedissonRingBufferTest extends RedisDockerTest {
     }
 
     @Test
+    public void testReSetCapacity() {
+        RRingBuffer<Integer> buffer = redisson.getRingBuffer("test");
+        buffer.trySetCapacity(3);
+        for (int i = 0; i < 3; i++) {
+            buffer.add(i);
+        }
+
+        assertThat(buffer).containsExactly(0, 1, 2);
+        assertThat(buffer.size()).isEqualTo(3);
+
+        // new capacity greater than list's length, not trim
+        buffer.setCapacity(5);
+        assertThat(buffer).containsExactly(0, 1, 2);
+        assertThat(buffer.size()).isEqualTo(3);
+
+        // new capacity less than list's length, trim size to new capacity
+        buffer.setCapacity(1);
+        assertThat(buffer).containsExactly(2);
+        assertThat(buffer.size()).isEqualTo(1);
+    }
+
+    @Test
     public void testAdd() {
         RRingBuffer<Integer> buffer = redisson.getRingBuffer("test");
         assertThat(buffer.capacity()).isZero();


### PR DESCRIPTION
RingBuffer
start with capacit(3) and values of {0, 1, 2}, after reset capacity to 5, the list should persist values {0, 1, 2}, not {1, 2}