### PR TITLE
Fixed - SeekableByteChannel#truncate method

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonBinaryStream.java
+++ b/redisson/src/main/java/org/redisson/RedissonBinaryStream.java
@@ -179,6 +179,13 @@ public class RedissonBinaryStream extends RedissonBucket<byte[]> implements RBin
 
         @Override
         public SeekableByteChannel truncate(long size) throws IOException {
+            if (size < 0) {
+                throw new IllegalArgumentException("Negative size");
+            }
+            if (size == 0) {
+                delete();
+                return this;
+            }
             get(commandExecutor.evalWriteAsync(getRawName(), LongCodec.INSTANCE, RedisCommands.EVAL_VOID,
                 "local len = redis.call('strlen', KEYS[1]); " +
                         "if tonumber(ARGV[1]) >= len then " +

--- a/redisson/src/test/java/org/redisson/RedissonBinaryStreamTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonBinaryStreamTest.java
@@ -95,6 +95,9 @@ public class RedissonBinaryStreamTest extends RedisDockerTest {
         b.get(bb);
         assertThat(c.size()).isEqualTo(3);
         assertThat(bb).isEqualTo(new byte[]{1, 2, 3});
+        
+        c.truncate(0);
+        assertThat(c.size()).isEqualTo(0);
     }
 
     @Test


### PR DESCRIPTION
1. As the interface(SeekableByteChannel) defined : throws IllegalArgumentException If the new size is negative
2. if the new size is zero, size of the `string` object should be zero