### PR TITLE
Performance: replace loggers for instances by loggers for classes

### DIFF
--- a/redisson-hibernate/redisson-hibernate-4/src/main/java/org/redisson/hibernate/region/BaseRegion.java
+++ b/redisson-hibernate/redisson-hibernate-4/src/main/java/org/redisson/hibernate/region/BaseRegion.java
@@ -39,7 +39,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class BaseRegion implements TransactionalDataRegion, GeneralDataRegion {
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(BaseRegion.class);
 
     final RMapCache<Object, Object> mapCache;
     final RegionFactory regionFactory;

--- a/redisson-hibernate/redisson-hibernate-5/src/main/java/org/redisson/hibernate/region/BaseRegion.java
+++ b/redisson-hibernate/redisson-hibernate-5/src/main/java/org/redisson/hibernate/region/BaseRegion.java
@@ -40,7 +40,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class BaseRegion implements TransactionalDataRegion, GeneralDataRegion {
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(BaseRegion.class);
 
     final RMapCache<Object, Object> mapCache;
     final RegionFactory regionFactory;

--- a/redisson-hibernate/redisson-hibernate-52/src/main/java/org/redisson/hibernate/region/BaseRegion.java
+++ b/redisson-hibernate/redisson-hibernate-52/src/main/java/org/redisson/hibernate/region/BaseRegion.java
@@ -40,7 +40,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class BaseRegion implements TransactionalDataRegion, GeneralDataRegion {
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(BaseRegion.class);
 
     final RMapCache<Object, Object> mapCache;
     final RegionFactory regionFactory;

--- a/redisson/src/main/java/org/redisson/RedissonIdGenerator.java
+++ b/redisson/src/main/java/org/redisson/RedissonIdGenerator.java
@@ -41,7 +41,7 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class RedissonIdGenerator extends RedissonExpirable implements RIdGenerator {
 
-    final Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger log = LoggerFactory.getLogger(RedissonIdGenerator.class);
 
     RedissonIdGenerator(CommandAsyncExecutor connectionManager, String name) {
         super(connectionManager, name);

--- a/redisson/src/main/java/org/redisson/RedissonMap.java
+++ b/redisson/src/main/java/org/redisson/RedissonMap.java
@@ -66,7 +66,7 @@ import java.util.stream.StreamSupport;
  */
 public class RedissonMap<K, V> extends RedissonExpirable implements RMap<K, V> {
 
-    private final Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger log = LoggerFactory.getLogger(RedissonMap.class);
     
     final RedissonClient redisson;
     final MapOptions<K, V> options;

--- a/redisson/src/main/java/org/redisson/client/handler/CommandDecoder.java
+++ b/redisson/src/main/java/org/redisson/client/handler/CommandDecoder.java
@@ -57,7 +57,7 @@ import java.util.concurrent.CompletableFuture;
  */
 public class CommandDecoder extends ReplayingDecoder<State> {
     
-    final Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger log = LoggerFactory.getLogger(CommandDecoder.class);
 
     private static final char CR = '\r';
     private static final char LF = '\n';

--- a/redisson/src/main/java/org/redisson/client/handler/CommandEncoder.java
+++ b/redisson/src/main/java/org/redisson/client/handler/CommandEncoder.java
@@ -57,7 +57,7 @@ import java.util.stream.LongStream;
 @Sharable
 public class CommandEncoder extends MessageToByteEncoder<CommandData<?, ?>> {
 
-    private final Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger log = LoggerFactory.getLogger(CommandEncoder.class);
 
     private static final char ARGS_PREFIX = '*';
     private static final char BYTES_PREFIX = '$';

--- a/redisson/src/main/java/org/redisson/client/handler/CommandPubSubDecoder.java
+++ b/redisson/src/main/java/org/redisson/client/handler/CommandPubSubDecoder.java
@@ -33,6 +33,8 @@ import org.redisson.client.protocol.pubsub.PubSubMessage;
 import org.redisson.client.protocol.pubsub.PubSubPatternMessage;
 import org.redisson.client.protocol.pubsub.PubSubStatusMessage;
 import org.redisson.misc.LogHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.*;
@@ -45,6 +47,8 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  */
 public class CommandPubSubDecoder extends CommandDecoder {
+
+    private static final Logger log = LoggerFactory.getLogger(CommandPubSubDecoder.class);
 
     private static final Set<String> UNSUBSCRIBE_COMMANDS = new HashSet<>(Arrays.asList(RedisCommands.PUNSUBSCRIBE.getName(), RedisCommands.UNSUBSCRIBE.getName(), RedisCommands.SUNSUBSCRIBE.getName()));
     private static final Set<String> SUBSCRIBE_COMMANDS = new HashSet<>(Arrays.asList(RedisCommands.PSUBSCRIBE.getName(), RedisCommands.SUBSCRIBE.getName(), RedisCommands.SSUBSCRIBE.getName()));

--- a/redisson/src/main/java/org/redisson/client/handler/ConnectionWatchdog.java
+++ b/redisson/src/main/java/org/redisson/client/handler/ConnectionWatchdog.java
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeUnit;
 @Sharable
 public class ConnectionWatchdog extends ChannelInboundHandlerAdapter {
 
-    private final Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger log = LoggerFactory.getLogger(ConnectionWatchdog.class);
 
     private final Timer timer;
     private final Bootstrap bootstrap;

--- a/redisson/src/main/java/org/redisson/cluster/ClusterConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/cluster/ClusterConnectionManager.java
@@ -47,7 +47,7 @@ import java.util.stream.Collectors;
  */
 public class ClusterConnectionManager extends MasterSlaveConnectionManager {
 
-    private final Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger log = LoggerFactory.getLogger(ClusterConnectionManager.class);
 
     private final Map<Integer, ClusterPartition> lastPartitions = new ConcurrentHashMap<>();
     private final Map<RedisURI, ClusterPartition> lastUri2Partition = new ConcurrentHashMap<>();

--- a/redisson/src/main/java/org/redisson/connection/ClientConnectionsEntry.java
+++ b/redisson/src/main/java/org/redisson/connection/ClientConnectionsEntry.java
@@ -39,7 +39,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class ClientConnectionsEntry {
 
-    final Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger log = LoggerFactory.getLogger(ClientConnectionsEntry.class);
 
     private final ConnectionsHolder<RedisConnection> connectionsHolder;
 

--- a/redisson/src/main/java/org/redisson/connection/ConnectionsHolder.java
+++ b/redisson/src/main/java/org/redisson/connection/ConnectionsHolder.java
@@ -37,7 +37,7 @@ import java.util.function.Function;
  */
 public class ConnectionsHolder<T extends RedisConnection> {
 
-    final Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger log = LoggerFactory.getLogger(ConnectionsHolder.class);
 
     private final Queue<T> allConnections = new ConcurrentLinkedQueue<>();
     private final Queue<T> freeConnections = new ConcurrentLinkedQueue<>();

--- a/redisson/src/main/java/org/redisson/connection/IdleConnectionWatcher.java
+++ b/redisson/src/main/java/org/redisson/connection/IdleConnectionWatcher.java
@@ -36,7 +36,7 @@ import java.util.stream.Collectors;
 
 public class IdleConnectionWatcher {
 
-    private final Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger log = LoggerFactory.getLogger(IdleConnectionWatcher.class);
 
     public static class Entry {
 

--- a/redisson/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
@@ -46,7 +46,7 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
 
     protected final ClusterSlotRange singleSlotRange = new ClusterSlotRange(0, MAX_SLOT-1);
 
-    private final Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger log = LoggerFactory.getLogger(MasterSlaveConnectionManager.class);
 
     protected DNSMonitor dnsMonitor;
 

--- a/redisson/src/main/java/org/redisson/connection/MasterSlaveEntry.java
+++ b/redisson/src/main/java/org/redisson/connection/MasterSlaveEntry.java
@@ -51,7 +51,7 @@ import java.util.function.Function;
  */
 public class MasterSlaveEntry {
 
-    final Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger log = LoggerFactory.getLogger(MasterSlaveEntry.class);
 
     volatile ClientConnectionsEntry masterEntry;
 

--- a/redisson/src/main/java/org/redisson/connection/ReplicatedConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/ReplicatedConnectionManager.java
@@ -52,7 +52,7 @@ public class ReplicatedConnectionManager extends MasterSlaveConnectionManager {
 
     private static final String ROLE_KEY = "role";
 
-    private final Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger log = LoggerFactory.getLogger(ReplicatedConnectionManager.class);
 
     private final AtomicReference<InetSocketAddress> currentMaster = new AtomicReference<>();
 

--- a/redisson/src/main/java/org/redisson/connection/SentinelConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/SentinelConnectionManager.java
@@ -46,7 +46,7 @@ import java.util.stream.Collectors;
  */
 public class SentinelConnectionManager extends MasterSlaveConnectionManager {
 
-    private final Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger log = LoggerFactory.getLogger(SentinelConnectionManager.class);
 
     private final Set<RedisURI> sentinelHosts = new HashSet<>();
     private final ConcurrentMap<RedisURI, RedisClient> sentinels = new ConcurrentHashMap<>();

--- a/redisson/src/main/java/org/redisson/connection/ServiceManager.java
+++ b/redisson/src/main/java/org/redisson/connection/ServiceManager.java
@@ -83,7 +83,7 @@ import java.util.stream.Collectors;
  */
 public final class ServiceManager {
 
-    private final Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger log = LoggerFactory.getLogger(ServiceManager.class);
 
     public static final Timeout DUMMY_TIMEOUT = new Timeout() {
         @Override

--- a/redisson/src/main/java/org/redisson/connection/pool/ConnectionPool.java
+++ b/redisson/src/main/java/org/redisson/connection/pool/ConnectionPool.java
@@ -44,7 +44,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  */
 abstract class ConnectionPool<T extends RedisConnection> {
 
-    private final Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger log = LoggerFactory.getLogger(ConnectionPool.class);
 
     protected final Queue<ClientConnectionsEntry> entries = new ConcurrentLinkedQueue<>();
 

--- a/redisson/src/main/java/org/redisson/eviction/EvictionTask.java
+++ b/redisson/src/main/java/org/redisson/eviction/EvictionTask.java
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit;
  */
 abstract class EvictionTask implements TimerTask {
 
-    private final Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger log = LoggerFactory.getLogger(EvictionTask.class);
     
     final Deque<Integer> sizeHistory = new LinkedList<>();
     final int minDelay;

--- a/redisson/src/main/java/org/redisson/remote/BaseRemoteProxy.java
+++ b/redisson/src/main/java/org/redisson/remote/BaseRemoteProxy.java
@@ -44,7 +44,7 @@ import java.util.function.BiConsumer;
  */
 public abstract class BaseRemoteProxy {
 
-    private final Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger log = LoggerFactory.getLogger(BaseRemoteProxy.class);
     
     final CommandAsyncExecutor commandExecutor;
     private final String name;


### PR DESCRIPTION
Hi

I found some places where `redisson` creates logger for instance of class. It's slow down operations with redis(for example `getMap(String)` which creates `RedissonMap` with logger each time). I wanna propose to replace instance loggers by class loggers. 

Thank you