### PR TITLE
Fixed 'race condition' while calling tryLock function

### DIFF
--- a/redisson/src/main/java/org/redisson/pubsub/PublishSubscribe.java
+++ b/redisson/src/main/java/org/redisson/pubsub/PublishSubscribe.java
@@ -119,7 +119,11 @@ abstract class PublishSubscribe<E extends PubSubEntry<E>> {
                     value.getPromise().completeExceptionally(e);
                     return;
                 }
-                value.getPromise().complete(value);
+                if (!value.getPromise().complete(value)) {
+                    if (value.getPromise().isCompletedExceptionally()) {
+                        entries.remove(entryName);
+                    }
+                }
             });
 
         });

--- a/redisson/src/test/java/org/redisson/pubsub/PublishSubscribeTest.java
+++ b/redisson/src/test/java/org/redisson/pubsub/PublishSubscribeTest.java
@@ -1,0 +1,79 @@
+package org.redisson.pubsub;
+
+import mockit.Injectable;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Tested;
+import org.junit.jupiter.api.Test;
+import org.redisson.RedissonLockEntry;
+import org.redisson.client.ChannelName;
+import org.redisson.client.RedisPubSubListener;
+import org.redisson.client.RedisTimeoutException;
+import org.redisson.client.codec.Codec;
+import org.redisson.misc.AsyncSemaphore;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PublishSubscribeTest {
+
+    @Tested
+    private LockPubSub lockPubSub;
+
+    @Injectable
+    private PublishSubscribeService publishSubscribeService;
+
+    @Test
+    public void testSubscribeForRaceCondition() throws InterruptedException {
+        AtomicReference<CompletableFuture<PubSubConnectionEntry>> sRef = new AtomicReference<>();
+        new MockUp<PublishSubscribeService>() {
+
+            @Mock
+            AsyncSemaphore getSemaphore(ChannelName channelName) {
+                return new AsyncSemaphore(1);
+            }
+
+            @Mock
+            CompletableFuture<PubSubConnectionEntry> subscribeNoTimeout(
+                    Codec codec, String channelName,
+                    AsyncSemaphore semaphore, RedisPubSubListener<?>... listeners) {
+                sRef.set(new CompletableFuture<>());
+                return sRef.get();
+            }
+        };
+
+        CompletableFuture<RedissonLockEntry> newPromise = lockPubSub.subscribe(
+                "test", "redisson_lock__channel__test"
+        );
+        sRef.get().whenComplete((r, e) -> {
+            try {
+                Thread.sleep(1);
+            } catch (InterruptedException ex) {
+                throw new RuntimeException(ex);
+            }
+        });
+
+        Thread thread1 = new Thread(() -> sRef.get().complete(null));
+        Thread thread2 = new Thread(() -> newPromise.completeExceptionally(new RedisTimeoutException("test")));
+
+        thread1.start();
+        thread2.start();
+        thread1.join();
+        thread2.join();
+
+        assertTrue(newPromise.isCompletedExceptionally());
+        assertTrue(sRef.get().isDone());
+        assertFalse(sRef.get().isCompletedExceptionally());
+
+        CompletableFuture<RedissonLockEntry> secondPromise = lockPubSub.subscribe(
+                "test", "redisson_lock__channel__test"
+        );
+        Thread thread3 = new Thread(() -> secondPromise.complete(null));
+        thread3.start();
+        thread3.join();
+        assertTrue(secondPromise.isDone());
+        assertFalse(secondPromise.isCompletedExceptionally());
+    }
+}


### PR DESCRIPTION
### Fix `race condition` of PublishSubscribe.subscribe function.

I got RedisTimeoutException while calling RedissonLock.tryLock function. After this exception, 'tryLock' call on same key failed with exactly same exception and message.
```
2024-07-19T10:40:05.638Z ERROR 1 --- [tContainer#13-7] org.redisson.RedissonLock                : org.redisson.client.RedisTimeoutException: Unable to acquire subscription lock after 13ms. Try to increase 'subscriptionsPerConnection' and/or 'subscriptionConnectionPoolSize' parameters.\
\
java.util.concurrent.ExecutionException: org.redisson.client.RedisTimeoutException: Unable to acquire subscription lock after 13ms. Try to increase 'subscriptionsPerConnection' and/or 'subscriptionConnectionPoolSize' parameters.\
	at java.base/java.util.concurrent.CompletableFuture.reportGet(Unknown Source)\
	at java.base/java.util.concurrent.CompletableFuture.get(Unknown Source)\
	at org.redisson.RedissonLock.tryLock(RedissonLock.java:250)\
```
  1. exception was thrown by first catch (line 252 RedisTimeoutException)
  2. logging logic located in second catch (line 264, Logging Manager Name `org.redisson.RedissonLock`)
   => Origin exception was thrown by first thread, after then next threads received already raised exception .
  3. finally we found the race condition on subscribe function of PublishSubscribe (LockPubSub).  
https://github.com/redisson/redisson/blob/f86744d0ff38c3dbcffbcee65b7f9cd362722111/redisson/src/main/java/org/redisson/RedissonLock.java#L249-L267

#### Reproduction Procedure (rarely happen but possible)
  1. s (CompletableFuture) completed successfully
  2. just after 1, newPromise (CompletableFuture) completed with RedisTimeoutException
  3. `line 116 logic` run after 2
     - `e is null` so entryName (lock key) does not removed.
     - value's promise (newPromise) already completedWithException 
     - next call `subscribe` with same lock key would throw previous exception

https://github.com/redisson/redisson/blob/f86744d0ff38c3dbcffbcee65b7f9cd362722111/redisson/src/main/java/org/redisson/pubsub/PublishSubscribe.java#L111-L122