### PR TITLE
Fixed - caused RedisException when execute lua-script

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonSubList.java
+++ b/redisson/src/main/java/org/redisson/RedissonSubList.java
@@ -164,13 +164,13 @@ public class RedissonSubList<V> extends RedissonList<V> implements RList<V> {
                 "local v = 0; " +
                 "local fromIndex = table.remove(ARGV, 1);" +
                 "local toIndex = table.remove(ARGV, 1);" +
-                "local count = table.remove(ARGV, 3);" +
+                "local count = table.remove(ARGV, 1);" +
                 "local items = redis.call('lrange', KEYS[1], fromIndex, toIndex); " +
 
                 "for i=1, #items do " +
                     "for j = 1, #ARGV, 1 do " +
                         "if items[i] == ARGV[j] then " +
-                            "redis.call('lrem', KEYS[1], count, ARGV[i]); " +
+                            "redis.call('lrem', KEYS[1], count, ARGV[j]); " +
                             "v = 1; " +
                         "end; " +
                     "end; " +
@@ -329,13 +329,13 @@ public class RedissonSubList<V> extends RedissonList<V> implements RList<V> {
     public RFuture<Integer> lastIndexOfAsync(Object o) {
         return commandExecutor.evalReadAsync(getRawName(), codec, RedisCommands.EVAL_INTEGER,
                 "local key = KEYS[1] " +
-                "local obj = ARGV[1] " +
+                "local obj = table.remove(ARGV, 1);" +
                 "local fromIndex = table.remove(ARGV, 1);" +
-                "local toIndex = table.remove(ARGV, 2);" +
-                "local items = redis.call('lrange', key, tonumber(fromIndex), tonumber(toIndexs)) " +
-                "for i = #items, 0, -1 do " +
+                "local toIndex = table.remove(ARGV, 1);" +
+                "local items = redis.call('lrange', key, fromIndex, toIndex) " +
+                "for i = #items, 1, -1 do " +
                     "if items[i] == obj then " +
-                        "return tonumber(ARGV[2]) + i - 1 " +
+                        "return tonumber(fromIndex) + i - 1; " +
                     "end; " +
                 "end; " +
                 "return -1; ",

--- a/redisson/src/test/java/org/redisson/RedissonListTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonListTest.java
@@ -959,7 +959,42 @@ public class RedissonListTest extends RedisDockerTest {
         assertThat(val1).isEqualTo(6);
         assertThat(subList.iterator()).toIterable().containsExactly(3, 4);
     }
-
+    
+    @Test
+    public void testSubListRemoveAll() {
+        List<Integer> list = redisson.getList("list");
+        list.add(1);
+        list.add(2);
+        list.add(3);
+        list.add(4);
+        list.add(5);
+        list.add(6);
+        list.add(7);
+        list.add(8);
+        
+        List<Integer> subList = list.subList(2, 6);
+        assertThat(subList.iterator()).toIterable().containsExactly(3, 4, 5, 6);
+        assertThat(subList.removeAll(List.of(3, 5))).isTrue();
+        assertThat(subList.iterator()).toIterable().containsExactly(4, 6, 7, 8);
+    }
+    
+    @Test
+    public void testSubListLastIndexOf() {
+        List<Integer> list = redisson.getList("list");
+        list.add(1);
+        list.add(2);
+        list.add(3);
+        list.add(4);
+        list.add(5);
+        list.add(5);
+        list.add(6);
+        list.add(7);
+        
+        List<Integer> subList = list.subList(2, 6);
+        assertThat(subList.lastIndexOf(3)).isEqualTo(2);
+        assertThat(subList.lastIndexOf(4)).isEqualTo(3);
+        assertThat(subList.lastIndexOf(5)).isEqualTo(5);
+    }
 
     @Test
     public void testSet() {


### PR DESCRIPTION
Currently, the two methods `lastIndexOfAsync` and `removeAllAsync` of the SubList do not perform as expected.
It will caused a RedisException when execute lua-script