### PR TITLE
Optimization: Don't take lock in computeIfAbsent if only get is needed

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonMap.java
+++ b/redisson/src/main/java/org/redisson/RedissonMap.java
@@ -325,10 +325,15 @@ public class RedissonMap<K, V> extends RedissonExpirable implements RMap<K, V> {
         checkKey(key);
         Objects.requireNonNull(mappingFunction);
 
+        V value = get(key);
+        if (value != null) {
+            return value;
+        }
+
         RLock lock = getLock(key);
         lock.lock();
         try {
-            V value = get(key);
+            value = get(key);
             if (value == null) {
                 V newValue = mappingFunction.apply(key);
                 if (newValue != null) {


### PR DESCRIPTION
Inside computeIfAbsent() in RedissonMap, lock is being taken for the entire operation, however we don't need the lock if value is already present, in which case get() operation doesn't need a lock.

This gives a significant performance boost since we avoid distributed lock since most of the times value will be present.

Have also retained the original get() operation inside the lock because value may have been computed by the previous lock holder.