### PR TITLE
Redisearch FT.INFO result decoder throws NumberFormatException

### DIFF
--- a/redisson/src/main/java/org/redisson/api/search/index/IndexInfo.java
+++ b/redisson/src/main/java/org/redisson/api/search/index/IndexInfo.java
@@ -39,13 +39,13 @@ public class IndexInfo {
 
     private Map<String, Object> dialectStats;
 
-    private Long docs;
+    private Double docs;
 
-    private Long maxDocId;
+    private Double maxDocId;
 
-    private Long terms;
+    private Double terms;
 
-    private Long records;
+    private Double records;
 
     private Double invertedSize;
 
@@ -141,38 +141,38 @@ public class IndexInfo {
         return this;
     }
 
-    public Long getDocs() {
+    public Double getDocs() {
         return docs;
     }
 
-    public IndexInfo setDocs(Long docs) {
+    public IndexInfo setDocs(Double docs) {
         this.docs = docs;
         return this;
     }
 
-    public Long getMaxDocId() {
+    public Double getMaxDocId() {
         return maxDocId;
     }
 
-    public IndexInfo setMaxDocId(Long maxDocId) {
+    public IndexInfo setMaxDocId(Double maxDocId) {
         this.maxDocId = maxDocId;
         return this;
     }
 
-    public Long getTerms() {
+    public Double getTerms() {
         return terms;
     }
 
-    public IndexInfo setTerms(Long terms) {
+    public IndexInfo setTerms(Double terms) {
         this.terms = terms;
         return this;
     }
 
-    public Long getRecords() {
+    public Double getRecords() {
         return records;
     }
 
-    public IndexInfo setRecords(Long records) {
+    public IndexInfo setRecords(Double records) {
         this.records = records;
         return this;
     }

--- a/redisson/src/main/java/org/redisson/client/protocol/decoder/IndexInfoDecoder.java
+++ b/redisson/src/main/java/org/redisson/client/protocol/decoder/IndexInfoDecoder.java
@@ -46,10 +46,10 @@ public class IndexInfoDecoder implements MultiDecoder<Object> {
             ii.setOptions((Map<String, Object>) result.get("index_options"));
             ii.setDefinition((Map<String, Object>) result.get("index_definition"));
             ii.setAttributes((List<Map<String, Object>>) result.get("attributes"));
-            ii.setDocs(toLong(result, "num_docs"));
-            ii.setMaxDocId(toLong(result, "max_doc_id"));
-            ii.setTerms(toLong(result, "num_terms"));
-            ii.setRecords(toLong(result, "num_records"));
+            ii.setDocs(toDouble(result, "num_docs"));
+            ii.setMaxDocId(toDouble(result, "max_doc_id"));
+            ii.setTerms(toDouble(result, "num_terms"));
+            ii.setRecords(toDouble(result, "num_records"));
             ii.setInvertedSize(toDouble(result, "inverted_sz_mb"));
             ii.setVectorIndexSize(toDouble(result, "vector_index_sz_mb"));
             ii.setTotalInvertedIndexBlocks(toDouble(result, "total_inverted_index_blocks"));


### PR DESCRIPTION
Follow-up to #5950

Redisson 3.34.1
Redisearch 2.8.8
Redis 6.2.13

The problem remains for other non-explicitly integer fields. Personally encountered on (erroneous) output of
```
15) num_records
16) "1.8446744073709543e+19"
```
but since all those fields can technically have scientific notion and can become unrepresentable in Java signed long (the value in this case is approaching 2^64 and would become -9223372036854767192) even if only in case of redisearch errors, it would be prudent to reflect that in data types.