### PR TITLE
Improvement - Copy command execute through multi db

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonObject.java
+++ b/redisson/src/main/java/org/redisson/RedissonObject.java
@@ -193,7 +193,7 @@ public abstract class RedissonObject implements RObject {
             List<Object> args = new LinkedList<>();
             args.add(keys.get(0));
             args.add(keys.get(1));
-            if (database > 0) {
+            if (database >= 0) {
                 args.add("DB");
                 args.add(database);
             }
@@ -213,11 +213,12 @@ public abstract class RedissonObject implements RObject {
                             + "else "
                                 + "res = res + redis.call('copy', KEYS[j], KEYS[newKeysIndex + j], 'db', ARGV[1]); "
                             + "end; "
-                        + "end; "
-                        + "if ARGV[2] == '1' then "
-                            + "res = res + redis.call('copy', KEYS[j], KEYS[newKeysIndex + j], 'replace'); "
                         + "else "
-                            + "res = res + redis.call('copy', KEYS[j], KEYS[newKeysIndex + j]); "
+                            + "if ARGV[2] == '1' then "
+                                + "res = res + redis.call('copy', KEYS[j], KEYS[newKeysIndex + j], 'replace'); "
+                            + "else "
+                                + "res = res + redis.call('copy', KEYS[j], KEYS[newKeysIndex + j]); "
+                            + "end; "
                         + "end; "
                     + "end; "
                     + "return math.min(res, 1); ",

--- a/redisson/src/test/java/org/redisson/RedisDockerTest.java
+++ b/redisson/src/test/java/org/redisson/RedisDockerTest.java
@@ -87,7 +87,21 @@ public class RedisDockerTest {
         Config config = createConfig();
         return Redisson.create(config);
     }
-
+    
+    protected void testTwoDatabase(BiConsumer<RedissonClient, RedissonClient> consumer) {
+        Config config1 = createConfig();
+        config1.useSingleServer().setDatabase(0);
+        RedissonClient r1 = Redisson.create(config1);
+        Config config2 = createConfig();
+        config2.useSingleServer().setDatabase(1);
+        RedissonClient r2 = Redisson.create(config2);
+        
+        consumer.accept(r1, r2);
+        
+        r1.shutdown();
+        r2.shutdown();
+    }
+    
     protected void testWithParams(Consumer<RedissonClient> redissonCallback, String... params) {
         GenericContainer<?> redis = createRedis(params);
         redis.start();

--- a/redisson/src/test/java/org/redisson/RedissonBucketTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonBucketTest.java
@@ -638,6 +638,33 @@ public class RedissonBucketTest extends RedisDockerTest {
         RBucket<String> bucket2 = redisson.getBucket("test2");
         assertThat(bucket2.get()).isEqualTo("someValue");
     }
+    
+    @Test
+    public void testCopy3() {
+        testTwoDatabase((r1, r2) -> {
+            // normal test
+            RBucket<String> bucket1 = r1.getBucket("test");
+            bucket1.set("someValue");
+            bucket1.copy("test", 1);
+            
+            RBucket<String> bucket2 = r2.getBucket("test");
+            assertThat(bucket2.get()).isEqualTo("someValue");
+        });
+    }
+    
+    @Test
+    public void testCopy4() {
+        testTwoDatabase((r1, r2) -> {
+            // database1 copy to database0
+            // this will cause a RedisException
+            RBucket<String> bucket2 = r2.getBucket("test");
+            bucket2.set("database1");
+            bucket2.copy("test", 0);
+            
+            RBucket<String> bucket1 = r1.getBucket("test");
+            assertThat(bucket1.get()).isEqualTo("database1");
+        });
+    }
 
     @Test
     public void testRename() {

--- a/redisson/src/test/java/org/redisson/RedissonIdGeneratorTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonIdGeneratorTest.java
@@ -30,5 +30,17 @@ public class RedissonIdGeneratorTest extends RedisDockerTest {
             assertThat(generator.nextId()).isEqualTo(i);
         }
     }
+    
+    @Test
+    public void testCopy() {
+        testTwoDatabase((r1, r2) -> {
+            RIdGenerator generator = r1.getIdGenerator("test");
+            generator.tryInit(12, 2931);
+            
+            generator.copy("test1", 1);
+            assertThat(r1.getKeys().count()).isEqualTo(2);
+            assertThat(r2.getKeys().count()).isEqualTo(2);
+        });
+    }
 
 }


### PR DESCRIPTION

1. RedissonBucketTest#testCopy3:  
completion test case which replication across different dbs.

2. RedissonBucketTest#testCopy4:  
copy the key `test`(db1) to the target key `test`(db0): 
this case shows after `copy` command executed, the result is not match expectations. db0 did not have the key `test`.

3. RedissonIdGeneratorTest#testCopy: 
when the lua script in copy method executed, the number of keys in the source database is incorrect.