### PR TITLE
Fixed - upgrade Jmockit version to 1.54.0

### DIFF
--- a/redisson-spring-data/redisson-spring-data-32/pom.xml
+++ b/redisson-spring-data/redisson-spring-data-32/pom.xml
@@ -48,7 +48,7 @@
 
                         <forkCount>4</forkCount>
                         <reuseForks>true</reuseForks>
-                        <argLine>${argLine} -javaagent:"${settings.localRepository}"/com/github/hazendaz/jmockit/jmockit/1.52.0/jmockit-1.52.0.jar</argLine>
+                        <argLine>${argLine} -javaagent:"${settings.localRepository}"/com/github/hazendaz/jmockit/jmockit/1.54.0/jmockit-1.54.0.jar</argLine>
                     </configuration>
             </plugin>
 

--- a/redisson-spring-data/redisson-spring-data-33/pom.xml
+++ b/redisson-spring-data/redisson-spring-data-33/pom.xml
@@ -48,7 +48,7 @@
 
                         <forkCount>4</forkCount>
                         <reuseForks>true</reuseForks>
-                        <argLine>${argLine} -javaagent:"${settings.localRepository}"/com/github/hazendaz/jmockit/jmockit/1.52.0/jmockit-1.52.0.jar</argLine>
+                        <argLine>${argLine} -javaagent:"${settings.localRepository}"/com/github/hazendaz/jmockit/jmockit/1.54.0/jmockit-1.54.0.jar</argLine>
                     </configuration>
             </plugin>
 

--- a/redisson/pom.xml
+++ b/redisson/pom.xml
@@ -527,7 +527,7 @@
 
                         <forkCount>4</forkCount>
                         <reuseForks>false</reuseForks>
-                        <argLine>${argLine} -javaagent:"${settings.localRepository}"/com/github/hazendaz/jmockit/jmockit/1.52.0/jmockit-1.52.0.jar</argLine>
+                        <argLine>${argLine} -javaagent:"${settings.localRepository}"/com/github/hazendaz/jmockit/jmockit/1.54.0/jmockit-1.54.0.jar</argLine>
                     </configuration>
             </plugin>
 


### PR DESCRIPTION
Keep the jmockit version in the plugin consistent with that in the dependencies.
Jmockit version in dependencies is 1.54.0, but is 1.52.0 in plugin.