### PR TITLE
fixed - xcaim method should verify minIdleTime not idleTime

### DIFF
--- a/redisson-spring-data/redisson-spring-data-23/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStreamCommands.java
+++ b/redisson-spring-data/redisson-spring-data-23/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStreamCommands.java
@@ -70,7 +70,7 @@ public class RedissonReactiveStreamCommands extends RedissonBaseReactive impleme
             params.add(k);
             params.add(command.getGroupName());
             params.add(command.getNewOwner());
-            params.add(Objects.requireNonNull(command.getOptions().getIdleTime()).toMillis());
+            params.add(Objects.requireNonNull(command.getOptions().getMinIdleTime()).toMillis());
             params.addAll(Arrays.asList(command.getOptions().getIdsAsStringArray()));
             params.add("JUSTID");
 
@@ -95,7 +95,7 @@ public class RedissonReactiveStreamCommands extends RedissonBaseReactive impleme
             params.add(k);
             params.add(command.getGroupName());
             params.add(command.getNewOwner());
-            params.add(Objects.requireNonNull(command.getOptions().getIdleTime()).toMillis());
+            params.add(Objects.requireNonNull(command.getOptions().getMinIdleTime()).toMillis());
             params.addAll(Arrays.asList(command.getOptions().getIdsAsStringArray()));
 
             Mono<Map<StreamMessageId, Map<byte[], byte[]>>> m = write(k, ByteArrayCodec.INSTANCE, RedisCommands.XCLAIM, params.toArray());

--- a/redisson-spring-data/redisson-spring-data-23/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
+++ b/redisson-spring-data/redisson-spring-data-23/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
@@ -80,7 +80,7 @@ public class RedissonStreamCommands implements RedisStreamCommands {
         params.add(key);
         params.add(group);
         params.add(newOwner);
-        params.add(Objects.requireNonNull(options.getIdleTime()).toMillis());
+        params.add(Objects.requireNonNull(options.getMinIdleTime()).toMillis());
         params.addAll(Arrays.asList(options.getIdsAsStringArray()));
         params.add("JUSTID");
 
@@ -98,7 +98,7 @@ public class RedissonStreamCommands implements RedisStreamCommands {
         params.add(key);
         params.add(group);
         params.add(newOwner);
-        params.add(Objects.requireNonNull(options.getIdleTime()).toMillis());
+        params.add(Objects.requireNonNull(options.getMinIdleTime()).toMillis());
         params.addAll(Arrays.asList(options.getIdsAsStringArray()));
 
         return connection.write(key, ByteArrayCodec.INSTANCE, new RedisCommand<List<ByteRecord>>("XCLAIM",

--- a/redisson-spring-data/redisson-spring-data-24/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStreamCommands.java
+++ b/redisson-spring-data/redisson-spring-data-24/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStreamCommands.java
@@ -70,7 +70,7 @@ public class RedissonReactiveStreamCommands extends RedissonBaseReactive impleme
             params.add(k);
             params.add(command.getGroupName());
             params.add(command.getNewOwner());
-            params.add(Objects.requireNonNull(command.getOptions().getIdleTime()).toMillis());
+            params.add(Objects.requireNonNull(command.getOptions().getMinIdleTime()).toMillis());
             params.addAll(Arrays.asList(command.getOptions().getIdsAsStringArray()));
             params.add("JUSTID");
 
@@ -95,7 +95,7 @@ public class RedissonReactiveStreamCommands extends RedissonBaseReactive impleme
             params.add(k);
             params.add(command.getGroupName());
             params.add(command.getNewOwner());
-            params.add(Objects.requireNonNull(command.getOptions().getIdleTime()).toMillis());
+            params.add(Objects.requireNonNull(command.getOptions().getMinIdleTime()).toMillis());
             params.addAll(Arrays.asList(command.getOptions().getIdsAsStringArray()));
 
             Mono<Map<StreamMessageId, Map<byte[], byte[]>>> m = write(k, ByteArrayCodec.INSTANCE, RedisCommands.XCLAIM, params.toArray());

--- a/redisson-spring-data/redisson-spring-data-24/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
+++ b/redisson-spring-data/redisson-spring-data-24/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
@@ -80,7 +80,7 @@ public class RedissonStreamCommands implements RedisStreamCommands {
         params.add(key);
         params.add(group);
         params.add(newOwner);
-        params.add(Objects.requireNonNull(options.getIdleTime()).toMillis());
+        params.add(Objects.requireNonNull(options.getMinIdleTime()).toMillis());
         params.addAll(Arrays.asList(options.getIdsAsStringArray()));
         params.add("JUSTID");
 
@@ -98,7 +98,7 @@ public class RedissonStreamCommands implements RedisStreamCommands {
         params.add(key);
         params.add(group);
         params.add(newOwner);
-        params.add(Objects.requireNonNull(options.getIdleTime()).toMillis());
+        params.add(Objects.requireNonNull(options.getMinIdleTime()).toMillis());
         params.addAll(Arrays.asList(options.getIdsAsStringArray()));
 
         return connection.write(key, ByteArrayCodec.INSTANCE, new RedisCommand<List<ByteRecord>>("XCLAIM",

--- a/redisson-spring-data/redisson-spring-data-25/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStreamCommands.java
+++ b/redisson-spring-data/redisson-spring-data-25/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStreamCommands.java
@@ -70,7 +70,7 @@ public class RedissonReactiveStreamCommands extends RedissonBaseReactive impleme
             params.add(k);
             params.add(command.getGroupName());
             params.add(command.getNewOwner());
-            params.add(Objects.requireNonNull(command.getOptions().getIdleTime()).toMillis());
+            params.add(Objects.requireNonNull(command.getOptions().getMinIdleTime()).toMillis());
             params.addAll(Arrays.asList(command.getOptions().getIdsAsStringArray()));
             params.add("JUSTID");
 
@@ -95,7 +95,7 @@ public class RedissonReactiveStreamCommands extends RedissonBaseReactive impleme
             params.add(k);
             params.add(command.getGroupName());
             params.add(command.getNewOwner());
-            params.add(Objects.requireNonNull(command.getOptions().getIdleTime()).toMillis());
+            params.add(Objects.requireNonNull(command.getOptions().getMinIdleTime()).toMillis());
             params.addAll(Arrays.asList(command.getOptions().getIdsAsStringArray()));
 
             Mono<Map<StreamMessageId, Map<byte[], byte[]>>> m = write(k, ByteArrayCodec.INSTANCE, RedisCommands.XCLAIM, params.toArray());

--- a/redisson-spring-data/redisson-spring-data-25/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
+++ b/redisson-spring-data/redisson-spring-data-25/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
@@ -80,7 +80,7 @@ public class RedissonStreamCommands implements RedisStreamCommands {
         params.add(key);
         params.add(group);
         params.add(newOwner);
-        params.add(Objects.requireNonNull(options.getIdleTime()).toMillis());
+        params.add(Objects.requireNonNull(options.getMinIdleTime()).toMillis());
         params.addAll(Arrays.asList(options.getIdsAsStringArray()));
         params.add("JUSTID");
 
@@ -98,7 +98,7 @@ public class RedissonStreamCommands implements RedisStreamCommands {
         params.add(key);
         params.add(group);
         params.add(newOwner);
-        params.add(Objects.requireNonNull(options.getIdleTime()).toMillis());
+        params.add(Objects.requireNonNull(options.getMinIdleTime()).toMillis());
         params.addAll(Arrays.asList(options.getIdsAsStringArray()));
 
         return connection.write(key, ByteArrayCodec.INSTANCE, new RedisCommand<List<ByteRecord>>("XCLAIM",

--- a/redisson-spring-data/redisson-spring-data-26/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStreamCommands.java
+++ b/redisson-spring-data/redisson-spring-data-26/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStreamCommands.java
@@ -70,7 +70,7 @@ public class RedissonReactiveStreamCommands extends RedissonBaseReactive impleme
             params.add(k);
             params.add(command.getGroupName());
             params.add(command.getNewOwner());
-            params.add(Objects.requireNonNull(command.getOptions().getIdleTime()).toMillis());
+            params.add(Objects.requireNonNull(command.getOptions().getMinIdleTime()).toMillis());
             params.addAll(Arrays.asList(command.getOptions().getIdsAsStringArray()));
             params.add("JUSTID");
 
@@ -95,7 +95,7 @@ public class RedissonReactiveStreamCommands extends RedissonBaseReactive impleme
             params.add(k);
             params.add(command.getGroupName());
             params.add(command.getNewOwner());
-            params.add(Objects.requireNonNull(command.getOptions().getIdleTime()).toMillis());
+            params.add(Objects.requireNonNull(command.getOptions().getMinIdleTime()).toMillis());
             params.addAll(Arrays.asList(command.getOptions().getIdsAsStringArray()));
 
             Mono<Map<StreamMessageId, Map<byte[], byte[]>>> m = write(k, ByteArrayCodec.INSTANCE, RedisCommands.XCLAIM, params.toArray());

--- a/redisson-spring-data/redisson-spring-data-26/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
+++ b/redisson-spring-data/redisson-spring-data-26/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
@@ -80,7 +80,7 @@ public class RedissonStreamCommands implements RedisStreamCommands {
         params.add(key);
         params.add(group);
         params.add(newOwner);
-        params.add(Objects.requireNonNull(options.getIdleTime()).toMillis());
+        params.add(Objects.requireNonNull(options.getMinIdleTime()).toMillis());
         params.addAll(Arrays.asList(options.getIdsAsStringArray()));
         params.add("JUSTID");
 
@@ -98,7 +98,7 @@ public class RedissonStreamCommands implements RedisStreamCommands {
         params.add(key);
         params.add(group);
         params.add(newOwner);
-        params.add(Objects.requireNonNull(options.getIdleTime()).toMillis());
+        params.add(Objects.requireNonNull(options.getMinIdleTime()).toMillis());
         params.addAll(Arrays.asList(options.getIdsAsStringArray()));
 
         return connection.write(key, ByteArrayCodec.INSTANCE, new RedisCommand<List<ByteRecord>>("XCLAIM",

--- a/redisson-spring-data/redisson-spring-data-27/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStreamCommands.java
+++ b/redisson-spring-data/redisson-spring-data-27/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStreamCommands.java
@@ -70,7 +70,7 @@ public class RedissonReactiveStreamCommands extends RedissonBaseReactive impleme
             params.add(k);
             params.add(command.getGroupName());
             params.add(command.getNewOwner());
-            params.add(Objects.requireNonNull(command.getOptions().getIdleTime()).toMillis());
+            params.add(Objects.requireNonNull(command.getOptions().getMinIdleTime()).toMillis());
             params.addAll(Arrays.asList(command.getOptions().getIdsAsStringArray()));
             params.add("JUSTID");
 
@@ -95,7 +95,7 @@ public class RedissonReactiveStreamCommands extends RedissonBaseReactive impleme
             params.add(k);
             params.add(command.getGroupName());
             params.add(command.getNewOwner());
-            params.add(Objects.requireNonNull(command.getOptions().getIdleTime()).toMillis());
+            params.add(Objects.requireNonNull(command.getOptions().getMinIdleTime()).toMillis());
             params.addAll(Arrays.asList(command.getOptions().getIdsAsStringArray()));
 
             Mono<Map<StreamMessageId, Map<byte[], byte[]>>> m = write(k, ByteArrayCodec.INSTANCE, RedisCommands.XCLAIM, params.toArray());

--- a/redisson-spring-data/redisson-spring-data-27/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
+++ b/redisson-spring-data/redisson-spring-data-27/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
@@ -80,7 +80,7 @@ public class RedissonStreamCommands implements RedisStreamCommands {
         params.add(key);
         params.add(group);
         params.add(newOwner);
-        params.add(Objects.requireNonNull(options.getIdleTime()).toMillis());
+        params.add(Objects.requireNonNull(options.getMinIdleTime()).toMillis());
         params.addAll(Arrays.asList(options.getIdsAsStringArray()));
         params.add("JUSTID");
 
@@ -98,7 +98,7 @@ public class RedissonStreamCommands implements RedisStreamCommands {
         params.add(key);
         params.add(group);
         params.add(newOwner);
-        params.add(Objects.requireNonNull(options.getIdleTime()).toMillis());
+        params.add(Objects.requireNonNull(options.getMinIdleTime()).toMillis());
         params.addAll(Arrays.asList(options.getIdsAsStringArray()));
 
         return connection.write(key, ByteArrayCodec.INSTANCE, new RedisCommand<List<ByteRecord>>("XCLAIM",

--- a/redisson-spring-data/redisson-spring-data-30/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStreamCommands.java
+++ b/redisson-spring-data/redisson-spring-data-30/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStreamCommands.java
@@ -70,7 +70,7 @@ public class RedissonReactiveStreamCommands extends RedissonBaseReactive impleme
             params.add(k);
             params.add(command.getGroupName());
             params.add(command.getNewOwner());
-            params.add(Objects.requireNonNull(command.getOptions().getIdleTime()).toMillis());
+            params.add(Objects.requireNonNull(command.getOptions().getMinIdleTime()).toMillis());
             params.addAll(Arrays.asList(command.getOptions().getIdsAsStringArray()));
             params.add("JUSTID");
 
@@ -95,7 +95,7 @@ public class RedissonReactiveStreamCommands extends RedissonBaseReactive impleme
             params.add(k);
             params.add(command.getGroupName());
             params.add(command.getNewOwner());
-            params.add(Objects.requireNonNull(command.getOptions().getIdleTime()).toMillis());
+            params.add(Objects.requireNonNull(command.getOptions().getMinIdleTime()).toMillis());
             params.addAll(Arrays.asList(command.getOptions().getIdsAsStringArray()));
 
             Mono<Map<StreamMessageId, Map<byte[], byte[]>>> m = write(k, ByteArrayCodec.INSTANCE, RedisCommands.XCLAIM, params.toArray());

--- a/redisson-spring-data/redisson-spring-data-30/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
+++ b/redisson-spring-data/redisson-spring-data-30/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
@@ -80,7 +80,7 @@ public class RedissonStreamCommands implements RedisStreamCommands {
         params.add(key);
         params.add(group);
         params.add(newOwner);
-        params.add(Objects.requireNonNull(options.getIdleTime()).toMillis());
+        params.add(Objects.requireNonNull(options.getMinIdleTime()).toMillis());
         params.addAll(Arrays.asList(options.getIdsAsStringArray()));
         params.add("JUSTID");
 
@@ -98,7 +98,7 @@ public class RedissonStreamCommands implements RedisStreamCommands {
         params.add(key);
         params.add(group);
         params.add(newOwner);
-        params.add(Objects.requireNonNull(options.getIdleTime()).toMillis());
+        params.add(Objects.requireNonNull(options.getMinIdleTime()).toMillis());
         params.addAll(Arrays.asList(options.getIdsAsStringArray()));
 
         return connection.write(key, ByteArrayCodec.INSTANCE, new RedisCommand<List<ByteRecord>>("XCLAIM",

--- a/redisson-spring-data/redisson-spring-data-31/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStreamCommands.java
+++ b/redisson-spring-data/redisson-spring-data-31/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStreamCommands.java
@@ -70,7 +70,7 @@ public class RedissonReactiveStreamCommands extends RedissonBaseReactive impleme
             params.add(k);
             params.add(command.getGroupName());
             params.add(command.getNewOwner());
-            params.add(Objects.requireNonNull(command.getOptions().getIdleTime()).toMillis());
+            params.add(Objects.requireNonNull(command.getOptions().getMinIdleTime()).toMillis());
             params.addAll(Arrays.asList(command.getOptions().getIdsAsStringArray()));
             params.add("JUSTID");
 
@@ -95,7 +95,7 @@ public class RedissonReactiveStreamCommands extends RedissonBaseReactive impleme
             params.add(k);
             params.add(command.getGroupName());
             params.add(command.getNewOwner());
-            params.add(Objects.requireNonNull(command.getOptions().getIdleTime()).toMillis());
+            params.add(Objects.requireNonNull(command.getOptions().getMinIdleTime()).toMillis());
             params.addAll(Arrays.asList(command.getOptions().getIdsAsStringArray()));
 
             Mono<Map<StreamMessageId, Map<byte[], byte[]>>> m = write(k, ByteArrayCodec.INSTANCE, RedisCommands.XCLAIM, params.toArray());

--- a/redisson-spring-data/redisson-spring-data-31/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
+++ b/redisson-spring-data/redisson-spring-data-31/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
@@ -80,7 +80,7 @@ public class RedissonStreamCommands implements RedisStreamCommands {
         params.add(key);
         params.add(group);
         params.add(newOwner);
-        params.add(Objects.requireNonNull(options.getIdleTime()).toMillis());
+        params.add(Objects.requireNonNull(options.getMinIdleTime()).toMillis());
         params.addAll(Arrays.asList(options.getIdsAsStringArray()));
         params.add("JUSTID");
 
@@ -98,7 +98,7 @@ public class RedissonStreamCommands implements RedisStreamCommands {
         params.add(key);
         params.add(group);
         params.add(newOwner);
-        params.add(Objects.requireNonNull(options.getIdleTime()).toMillis());
+        params.add(Objects.requireNonNull(options.getMinIdleTime()).toMillis());
         params.addAll(Arrays.asList(options.getIdsAsStringArray()));
 
         return connection.write(key, ByteArrayCodec.INSTANCE, new RedisCommand<List<ByteRecord>>("XCLAIM",

--- a/redisson-spring-data/redisson-spring-data-32/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStreamCommands.java
+++ b/redisson-spring-data/redisson-spring-data-32/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStreamCommands.java
@@ -70,7 +70,7 @@ public class RedissonReactiveStreamCommands extends RedissonBaseReactive impleme
             params.add(k);
             params.add(command.getGroupName());
             params.add(command.getNewOwner());
-            params.add(Objects.requireNonNull(command.getOptions().getIdleTime()).toMillis());
+            params.add(Objects.requireNonNull(command.getOptions().getMinIdleTime()).toMillis());
             params.addAll(Arrays.asList(command.getOptions().getIdsAsStringArray()));
             params.add("JUSTID");
 
@@ -95,7 +95,7 @@ public class RedissonReactiveStreamCommands extends RedissonBaseReactive impleme
             params.add(k);
             params.add(command.getGroupName());
             params.add(command.getNewOwner());
-            params.add(Objects.requireNonNull(command.getOptions().getIdleTime()).toMillis());
+            params.add(Objects.requireNonNull(command.getOptions().getMinIdleTime()).toMillis());
             params.addAll(Arrays.asList(command.getOptions().getIdsAsStringArray()));
 
             Mono<Map<StreamMessageId, Map<byte[], byte[]>>> m = write(k, ByteArrayCodec.INSTANCE, RedisCommands.XCLAIM, params.toArray());

--- a/redisson-spring-data/redisson-spring-data-32/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
+++ b/redisson-spring-data/redisson-spring-data-32/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
@@ -80,7 +80,7 @@ public class RedissonStreamCommands implements RedisStreamCommands {
         params.add(key);
         params.add(group);
         params.add(newOwner);
-        params.add(Objects.requireNonNull(options.getIdleTime()).toMillis());
+        params.add(Objects.requireNonNull(options.getMinIdleTime()).toMillis());
         params.addAll(Arrays.asList(options.getIdsAsStringArray()));
         params.add("JUSTID");
 
@@ -98,7 +98,7 @@ public class RedissonStreamCommands implements RedisStreamCommands {
         params.add(key);
         params.add(group);
         params.add(newOwner);
-        params.add(Objects.requireNonNull(options.getIdleTime()).toMillis());
+        params.add(Objects.requireNonNull(options.getMinIdleTime()).toMillis());
         params.addAll(Arrays.asList(options.getIdsAsStringArray()));
 
         return connection.write(key, ByteArrayCodec.INSTANCE, new RedisCommand<List<ByteRecord>>("XCLAIM",

--- a/redisson-spring-data/redisson-spring-data-33/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStreamCommands.java
+++ b/redisson-spring-data/redisson-spring-data-33/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStreamCommands.java
@@ -70,7 +70,7 @@ public class RedissonReactiveStreamCommands extends RedissonBaseReactive impleme
             params.add(k);
             params.add(command.getGroupName());
             params.add(command.getNewOwner());
-            params.add(Objects.requireNonNull(command.getOptions().getIdleTime()).toMillis());
+            params.add(Objects.requireNonNull(command.getOptions().getMinIdleTime()).toMillis());
             params.addAll(Arrays.asList(command.getOptions().getIdsAsStringArray()));
             params.add("JUSTID");
 
@@ -95,7 +95,7 @@ public class RedissonReactiveStreamCommands extends RedissonBaseReactive impleme
             params.add(k);
             params.add(command.getGroupName());
             params.add(command.getNewOwner());
-            params.add(Objects.requireNonNull(command.getOptions().getIdleTime()).toMillis());
+            params.add(Objects.requireNonNull(command.getOptions().getMinIdleTime()).toMillis());
             params.addAll(Arrays.asList(command.getOptions().getIdsAsStringArray()));
 
             Mono<Map<StreamMessageId, Map<byte[], byte[]>>> m = write(k, ByteArrayCodec.INSTANCE, RedisCommands.XCLAIM, params.toArray());

--- a/redisson-spring-data/redisson-spring-data-33/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
+++ b/redisson-spring-data/redisson-spring-data-33/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
@@ -80,7 +80,7 @@ public class RedissonStreamCommands implements RedisStreamCommands {
         params.add(key);
         params.add(group);
         params.add(newOwner);
-        params.add(Objects.requireNonNull(options.getIdleTime()).toMillis());
+        params.add(Objects.requireNonNull(options.getMinIdleTime()).toMillis());
         params.addAll(Arrays.asList(options.getIdsAsStringArray()));
         params.add("JUSTID");
 
@@ -98,7 +98,7 @@ public class RedissonStreamCommands implements RedisStreamCommands {
         params.add(key);
         params.add(group);
         params.add(newOwner);
-        params.add(Objects.requireNonNull(options.getIdleTime()).toMillis());
+        params.add(Objects.requireNonNull(options.getMinIdleTime()).toMillis());
         params.addAll(Arrays.asList(options.getIdsAsStringArray()));
 
         return connection.write(key, ByteArrayCodec.INSTANCE, new RedisCommand<List<ByteRecord>>("XCLAIM",


### PR DESCRIPTION
The xClaim command interface in Spring Data Redis takes minIdleTime as an option. However, in the current implementation of xClaim in Redisson, it validates idleTime instead of minIdleTime, which causes a NullPointerException (NPE).

This PR fixes the validation to properly handle minIdleTime.

issue: https://github.com/redisson/redisson/issues/6192