### PR TITLE
Support to cache method LocalCacheView.toCacheKey(Object) for CacheProvider.REDISSON

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonLocalCachedMap.java
+++ b/redisson/src/main/java/org/redisson/RedissonLocalCachedMap.java
@@ -79,8 +79,9 @@ public class RedissonLocalCachedMap<K, V> extends RedissonMap<K, V> implements R
     }
 
     private void init(LocalCachedMapOptions<K, V> options, EvictionScheduler evictionScheduler) {
-        if (options.getCacheProvider() == LocalCachedMapOptions.CacheProvider.CAFFEINE) {
-            options.useObjectAsCacheKey(false);
+        if (options.getCacheProvider() == LocalCachedMapOptions.CacheProvider.CAFFEINE
+                && options.isUseObjectAsCacheKey()) {
+            throw new IllegalArgumentException("useObjectAsCacheKey cannot be true if cacheProvider is CAFFEINE");
         }
         syncStrategy = options.getSyncStrategy();
         storeMode = options.getStoreMode();

--- a/redisson/src/main/java/org/redisson/RedissonLocalCachedMap.java
+++ b/redisson/src/main/java/org/redisson/RedissonLocalCachedMap.java
@@ -55,10 +55,12 @@ public class RedissonLocalCachedMap<K, V> extends RedissonMap<K, V> implements R
     private long cacheUpdateLogTime = TimeUnit.MINUTES.toMillis(10);
     private byte[] instanceId;
     private ConcurrentMap<CacheKey, CacheValue> cache;
+    private ConcurrentMap<Object, CacheKey> cacheKeyMap;
     private int invalidateEntryOnChange;
     private SyncStrategy syncStrategy;
     private LocalCachedMapOptions.StoreMode storeMode;
     private boolean storeCacheMiss;
+    private boolean isStoreCacheKey;
 
     private LocalCacheListener listener;
     private LocalCacheView<K, V> localCacheView;
@@ -77,13 +79,17 @@ public class RedissonLocalCachedMap<K, V> extends RedissonMap<K, V> implements R
     }
 
     private void init(LocalCachedMapOptions<K, V> options, EvictionScheduler evictionScheduler) {
+        if (options.getCacheProvider() == LocalCachedMapOptions.CacheProvider.CAFFEINE) {
+            options.storeCacheKey(false);
+        }
         syncStrategy = options.getSyncStrategy();
         storeMode = options.getStoreMode();
         storeCacheMiss = options.isStoreCacheMiss();
-
+        isStoreCacheKey = options.isStoreCacheKey();
         publishCommand = commandExecutor.getConnectionManager().getSubscribeService().getPublishCommand();
         localCacheView = new LocalCacheView<>(options, this);
         cache = localCacheView.getCache();
+        cacheKeyMap = localCacheView.getCacheKeyMap();
         listener = new LocalCacheListener(getRawName(), commandExecutor, this, codec, options, cacheUpdateLogTime, getSubscribeService().isShardingSupported()) {
 
             @Override
@@ -96,7 +102,7 @@ public class RedissonLocalCachedMap<K, V> extends RedissonMap<K, V> implements R
             }
 
         };
-        listener.add(cache);
+        listener.add(cache, cacheKeyMap);
         instanceId = listener.getInstanceId();
 
         if (options.getSyncStrategy() != SyncStrategy.NONE) {
@@ -192,12 +198,17 @@ public class RedissonLocalCachedMap<K, V> extends RedissonMap<K, V> implements R
         if (listener.isDisabled(cacheKey)) {
             return false;
         }
-
+        if (isStoreCacheKey) {
+            cacheKeyMap.remove(key);
+        }
         return cache.remove(cacheKey, new CacheValue(key, value));
     }
 
     private CacheValue cacheRemove(CacheKey cacheKey) {
         CacheValue v = cache.remove(cacheKey);
+        if (isStoreCacheKey && v != null) {
+            cacheKeyMap.remove(v.getKey());
+        }
         listener.notifyInvalidate(v);
         listener.notifyUpdate(v);
         return v;
@@ -395,6 +406,9 @@ public class RedissonLocalCachedMap<K, V> extends RedissonMap<K, V> implements R
     public void destroy() {
         super.destroy();
         cache.clear();
+        if (isStoreCacheKey) {
+            cacheKeyMap.clear();
+        }
         listener.remove();
     }
 
@@ -616,7 +630,9 @@ public class RedissonLocalCachedMap<K, V> extends RedissonMap<K, V> implements R
     @Override
     public RFuture<Boolean> deleteAsync() {
         cache.clear();
-
+        if (isStoreCacheKey) {
+            cacheKeyMap.clear();
+        }
         if (storeMode == LocalCachedMapOptions.StoreMode.LOCALCACHE) {
             CompletionStage<Boolean> f = clearLocalCacheAsync().thenApply(r -> true);
             return new CompletableFutureWrapper<>(f);

--- a/redisson/src/main/java/org/redisson/api/LocalCachedMapOptions.java
+++ b/redisson/src/main/java/org/redisson/api/LocalCachedMapOptions.java
@@ -161,7 +161,7 @@ public class LocalCachedMapOptions<K, V> extends MapOptions<K, V> {
     private StoreMode storeMode;
     private boolean storeCacheMiss;
     private ExpirationEventPolicy expirationEventPolicy;
-    private boolean storeCacheKey;
+    private boolean useObjectAsCacheKey;
 
     protected LocalCachedMapOptions() {
     }
@@ -176,7 +176,7 @@ public class LocalCachedMapOptions<K, V> extends MapOptions<K, V> {
         this.cacheProvider = copy.cacheProvider;
         this.storeMode = copy.storeMode;
         this.storeCacheMiss = copy.storeCacheMiss;
-        this.storeCacheKey = copy.storeCacheKey;
+        this.useObjectAsCacheKey = copy.useObjectAsCacheKey;
     }
     
     /**
@@ -208,7 +208,7 @@ public class LocalCachedMapOptions<K, V> extends MapOptions<K, V> {
                     .storeMode(StoreMode.LOCALCACHE_REDIS)
                     .syncStrategy(SyncStrategy.INVALIDATE)
                     .storeCacheMiss(false)
-                    .storeCacheKey(false)
+                    .useObjectAsCacheKey(false)
                     .expirationEventPolicy(ExpirationEventPolicy.SUBSCRIBE_WITH_KEYEVENT_PATTERN);
     }
 
@@ -392,8 +392,8 @@ public class LocalCachedMapOptions<K, V> extends MapOptions<K, V> {
         return this.storeCacheMiss;
     }
 
-    public boolean isStoreCacheKey() {
-        return storeCacheKey;
+    public boolean isUseObjectAsCacheKey() {
+        return useObjectAsCacheKey;
     }
 
     /**
@@ -411,11 +411,11 @@ public class LocalCachedMapOptions<K, V> extends MapOptions<K, V> {
      * Defines whether to store CacheKey of an object key into the local cache. <br>
      * This indicator only affects when {@link LocalCachedMapOptions#cacheProvider} != {@link CacheProvider#CAFFEINE}
      *
-     * @param storeCacheKey - whether to store CacheKey of an object key into the local cache
+     * @param useObjectAsCacheKey - whether to store CacheKey of an object key into the local cache
      * @return LocalCachedMapOptions instance
      */
-    public LocalCachedMapOptions<K, V> storeCacheKey(boolean storeCacheKey) {
-        this.storeCacheKey = storeCacheKey;
+    public LocalCachedMapOptions<K, V> useObjectAsCacheKey(boolean useObjectAsCacheKey) {
+        this.useObjectAsCacheKey = useObjectAsCacheKey;
         return this;
     }
 

--- a/redisson/src/main/java/org/redisson/api/LocalCachedMapOptions.java
+++ b/redisson/src/main/java/org/redisson/api/LocalCachedMapOptions.java
@@ -161,6 +161,7 @@ public class LocalCachedMapOptions<K, V> extends MapOptions<K, V> {
     private StoreMode storeMode;
     private boolean storeCacheMiss;
     private ExpirationEventPolicy expirationEventPolicy;
+    private boolean storeCacheKey;
 
     protected LocalCachedMapOptions() {
     }
@@ -175,6 +176,7 @@ public class LocalCachedMapOptions<K, V> extends MapOptions<K, V> {
         this.cacheProvider = copy.cacheProvider;
         this.storeMode = copy.storeMode;
         this.storeCacheMiss = copy.storeCacheMiss;
+        this.storeCacheKey = copy.storeCacheKey;
     }
     
     /**
@@ -206,6 +208,7 @@ public class LocalCachedMapOptions<K, V> extends MapOptions<K, V> {
                     .storeMode(StoreMode.LOCALCACHE_REDIS)
                     .syncStrategy(SyncStrategy.INVALIDATE)
                     .storeCacheMiss(false)
+                    .storeCacheKey(false)
                     .expirationEventPolicy(ExpirationEventPolicy.SUBSCRIBE_WITH_KEYEVENT_PATTERN);
     }
 
@@ -389,6 +392,10 @@ public class LocalCachedMapOptions<K, V> extends MapOptions<K, V> {
         return this.storeCacheMiss;
     }
 
+    public boolean isStoreCacheKey() {
+        return storeCacheKey;
+    }
+
     /**
      * Defines whether to store a cache miss into the local cache.
      *
@@ -397,6 +404,18 @@ public class LocalCachedMapOptions<K, V> extends MapOptions<K, V> {
      */
     public LocalCachedMapOptions<K, V> storeCacheMiss(boolean storeCacheMiss) {
         this.storeCacheMiss = storeCacheMiss;
+        return this;
+    }
+
+    /**
+     * Defines whether to store CacheKey of an object key into the local cache. <br>
+     * This indicator only affects when {@link LocalCachedMapOptions#cacheProvider} != {@link CacheProvider#CAFFEINE}
+     *
+     * @param storeCacheKey - whether to store CacheKey of an object key into the local cache
+     * @return LocalCachedMapOptions instance
+     */
+    public LocalCachedMapOptions<K, V> storeCacheKey(boolean storeCacheKey) {
+        this.storeCacheKey = storeCacheKey;
         return this;
     }
 

--- a/redisson/src/main/java/org/redisson/cache/AbstractCacheMap.java
+++ b/redisson/src/main/java/org/redisson/cache/AbstractCacheMap.java
@@ -319,6 +319,12 @@ public abstract class AbstractCacheMap<K, V> implements Cache<K, V> {
             return mapEntry != null;
         }
 
+        public CachedValue<K, V> cursorValue() {
+            if (mapEntry == null) {
+                throw new IllegalStateException();
+            }
+            return mapEntry.getValue();
+        }
     }
 
     final class KeySet extends AbstractSet<K> {

--- a/redisson/src/main/java/org/redisson/cache/LocalCacheListener.java
+++ b/redisson/src/main/java/org/redisson/cache/LocalCacheListener.java
@@ -112,7 +112,7 @@ public abstract class LocalCacheListener {
             expireListenerId = topic.addListener(String.class, (pattern, channel, msg) -> {
                 if (msg.equals(name)) {
                     cache.clear();
-                    if (options.isStoreCacheKey()) {
+                    if (options.isUseObjectAsCacheKey()) {
                         cacheKeyMap.clear();
                     }
                 }
@@ -122,7 +122,7 @@ public abstract class LocalCacheListener {
             expireListenerId = topic.addListener(String.class, (channel, msg) -> {
                 if (msg.equals("expired")) {
                     cache.clear();
-                    if (options.isStoreCacheKey()) {
+                    if (options.isUseObjectAsCacheKey()) {
                         cacheKeyMap.clear();
                     }
                 }
@@ -209,7 +209,7 @@ public abstract class LocalCacheListener {
             LocalCachedMapClear clearMsg = (LocalCachedMapClear) msg;
             if (!Arrays.equals(clearMsg.getExcludedId(), instanceId)) {
                 cache.clear();
-                if (options.isStoreCacheKey()) {
+                if (options.isUseObjectAsCacheKey()) {
                     cacheKeyMap.clear();
                 }
                 if (clearMsg.isReleaseSemaphore()) {
@@ -228,7 +228,7 @@ public abstract class LocalCacheListener {
                     if (value == null) {
                         continue;
                     }
-                    if (options.isStoreCacheKey()) {
+                    if (options.isUseObjectAsCacheKey()) {
                         cacheKeyMap.remove(value.getKey());
                     }
                     notifyInvalidate(value);
@@ -264,7 +264,7 @@ public abstract class LocalCacheListener {
     final void onSubscribe() {
         if (options.getReconnectionStrategy() == ReconnectionStrategy.CLEAR) {
             cache.clear();
-            if (options.isStoreCacheKey()) {
+            if (options.isUseObjectAsCacheKey()) {
                 cacheKeyMap.clear();
             }
         }
@@ -290,7 +290,7 @@ public abstract class LocalCacheListener {
 
     public RFuture<Void> clearLocalCacheAsync() {
         cache.clear();
-        if (options.isStoreCacheKey()) {
+        if (options.isUseObjectAsCacheKey()) {
             cacheKeyMap.clear();
         }
         if (syncListenerId == 0) {
@@ -332,7 +332,7 @@ public abstract class LocalCacheListener {
         for (CacheKey key : keys) {
             disabledKeys.put(key, requestId);
             CacheValue cacheValue = cache.remove(key);
-            if (options.isStoreCacheKey() && cacheValue != null) {
+            if (options.isUseObjectAsCacheKey() && cacheValue != null) {
                 cacheKeyMap.remove(cacheValue.getValue());
             }
         }
@@ -374,7 +374,7 @@ public abstract class LocalCacheListener {
     private void loadAfterReconnection() {
         if (System.currentTimeMillis() - lastInvalidate > cacheUpdateLogTime) {
             cache.clear();
-            if (options.isStoreCacheKey()) {
+            if (options.isUseObjectAsCacheKey()) {
                 cacheKeyMap.clear();
             }
             return;
@@ -388,7 +388,7 @@ public abstract class LocalCacheListener {
 
             if (!res) {
                 cache.clear();
-                if (options.isStoreCacheKey()) {
+                if (options.isUseObjectAsCacheKey()) {
                     cacheKeyMap.clear();
                 }
                 return;
@@ -406,7 +406,7 @@ public abstract class LocalCacheListener {
                             byte[] keyHash = Arrays.copyOf(entry, 16);
                             CacheKey key = new CacheKey(keyHash);
                             CacheValue cacheValue = cache.remove(key);
-                            if (options.isStoreCacheKey() && cacheValue != null) {
+                            if (options.isUseObjectAsCacheKey() && cacheValue != null) {
                                 cacheKeyMap.remove(cacheValue.getValue());
                             }
                         }

--- a/redisson/src/main/java/org/redisson/cache/LocalCacheListener.java
+++ b/redisson/src/main/java/org/redisson/cache/LocalCacheListener.java
@@ -58,6 +58,7 @@ public abstract class LocalCacheListener {
     String name;
     CommandAsyncExecutor commandExecutor;
     private Map<CacheKey, ? extends CacheValue> cache;
+    private Map<Object, CacheKey> cacheKeyMap;
     private RObject object;
     byte[] instanceId;
     private Codec codec;
@@ -101,9 +102,9 @@ public abstract class LocalCacheListener {
         return disabledKeys.containsKey(key);
     }
 
-    public void add(Map<CacheKey, ? extends CacheValue> cache) {
+    public void add(Map<CacheKey, ? extends CacheValue> cache, Map<Object, CacheKey> cacheKeyMap) {
         this.cache = cache;
-
+        this.cacheKeyMap = cacheKeyMap;
         createTopic(name, commandExecutor);
 
         if (options.getExpirationEventPolicy() == LocalCachedMapOptions.ExpirationEventPolicy.SUBSCRIBE_WITH_KEYEVENT_PATTERN) {
@@ -111,6 +112,9 @@ public abstract class LocalCacheListener {
             expireListenerId = topic.addListener(String.class, (pattern, channel, msg) -> {
                 if (msg.equals(name)) {
                     cache.clear();
+                    if (options.isStoreCacheKey()) {
+                        cacheKeyMap.clear();
+                    }
                 }
             });
         } else if (options.getExpirationEventPolicy() == LocalCachedMapOptions.ExpirationEventPolicy.SUBSCRIBE_WITH_KEYSPACE_CHANNEL) {
@@ -118,6 +122,9 @@ public abstract class LocalCacheListener {
             expireListenerId = topic.addListener(String.class, (channel, msg) -> {
                 if (msg.equals("expired")) {
                     cache.clear();
+                    if (options.isStoreCacheKey()) {
+                        cacheKeyMap.clear();
+                    }
                 }
             });
         }
@@ -202,7 +209,9 @@ public abstract class LocalCacheListener {
             LocalCachedMapClear clearMsg = (LocalCachedMapClear) msg;
             if (!Arrays.equals(clearMsg.getExcludedId(), instanceId)) {
                 cache.clear();
-
+                if (options.isStoreCacheKey()) {
+                    cacheKeyMap.clear();
+                }
                 if (clearMsg.isReleaseSemaphore()) {
                     RSemaphore semaphore = getClearSemaphore(clearMsg.getRequestId());
                     semaphore.releaseAsync();
@@ -218,6 +227,9 @@ public abstract class LocalCacheListener {
                     CacheValue value = cache.remove(key);
                     if (value == null) {
                         continue;
+                    }
+                    if (options.isStoreCacheKey()) {
+                        cacheKeyMap.remove(value.getKey());
                     }
                     notifyInvalidate(value);
                 }
@@ -252,6 +264,9 @@ public abstract class LocalCacheListener {
     final void onSubscribe() {
         if (options.getReconnectionStrategy() == ReconnectionStrategy.CLEAR) {
             cache.clear();
+            if (options.isStoreCacheKey()) {
+                cacheKeyMap.clear();
+            }
         }
         if (options.getReconnectionStrategy() == ReconnectionStrategy.LOAD
                 // check if instance has already been used
@@ -275,6 +290,9 @@ public abstract class LocalCacheListener {
 
     public RFuture<Void> clearLocalCacheAsync() {
         cache.clear();
+        if (options.isStoreCacheKey()) {
+            cacheKeyMap.clear();
+        }
         if (syncListenerId == 0) {
             return new CompletableFutureWrapper<>((Void) null);
         }
@@ -313,7 +331,10 @@ public abstract class LocalCacheListener {
     private void disableKeys(final String requestId, final Set<CacheKey> keys, long timeout) {
         for (CacheKey key : keys) {
             disabledKeys.put(key, requestId);
-            cache.remove(key);
+            CacheValue cacheValue = cache.remove(key);
+            if (options.isStoreCacheKey() && cacheValue != null) {
+                cacheKeyMap.remove(cacheValue.getValue());
+            }
         }
 
         commandExecutor.getServiceManager().newTimeout(t -> {
@@ -353,6 +374,9 @@ public abstract class LocalCacheListener {
     private void loadAfterReconnection() {
         if (System.currentTimeMillis() - lastInvalidate > cacheUpdateLogTime) {
             cache.clear();
+            if (options.isStoreCacheKey()) {
+                cacheKeyMap.clear();
+            }
             return;
         }
 
@@ -364,6 +388,9 @@ public abstract class LocalCacheListener {
 
             if (!res) {
                 cache.clear();
+                if (options.isStoreCacheKey()) {
+                    cacheKeyMap.clear();
+                }
                 return;
             }
 
@@ -378,7 +405,10 @@ public abstract class LocalCacheListener {
                         for (byte[] entry : r) {
                             byte[] keyHash = Arrays.copyOf(entry, 16);
                             CacheKey key = new CacheKey(keyHash);
-                            cache.remove(key);
+                            CacheValue cacheValue = cache.remove(key);
+                            if (options.isStoreCacheKey() && cacheValue != null) {
+                                cacheKeyMap.remove(cacheValue.getValue());
+                            }
                         }
                     });
         });

--- a/redisson/src/main/java/org/redisson/cache/LocalCacheView.java
+++ b/redisson/src/main/java/org/redisson/cache/LocalCacheView.java
@@ -39,13 +39,13 @@ public class LocalCacheView<K, V> {
     private final RedissonObject object;
     private final ConcurrentMap<CacheKey, CacheValue> cache;
     private final ConcurrentMap<Object, CacheKey> cacheKeyMap;
-    private final boolean storeCacheKey;
+    private final boolean useObjectAsCacheKey;
 
     public LocalCacheView(LocalCachedMapOptions<?, ?> options, RedissonObject object) {
         this.cache = createCache(options);
         this.object = object;
         this.cacheKeyMap = createCache(options);
-        this.storeCacheKey = options.isStoreCacheKey();
+        this.useObjectAsCacheKey = options.isUseObjectAsCacheKey();
     }
 
     public Set<K> cachedKeySet() {
@@ -72,7 +72,7 @@ public class LocalCacheView<K, V> {
                 
                 @Override
                 public void remove() {
-                    if (storeCacheKey) {
+                    if (useObjectAsCacheKey) {
                         cacheKeyMap.remove(((AbstractCacheMap.MapIterator) iter).cursorValue().getKey());
                     }
                     iter.remove();
@@ -89,7 +89,7 @@ public class LocalCacheView<K, V> {
         @Override
         public boolean remove(Object o) {
             CacheKey cacheKey = toCacheKey(o);
-            if (storeCacheKey) {
+            if (useObjectAsCacheKey) {
                 cacheKeyMap.remove(o);
             }
             return cache.remove(cacheKey) != null;
@@ -102,7 +102,7 @@ public class LocalCacheView<K, V> {
 
         @Override
         public void clear() {
-            if (storeCacheKey) {
+            if (useObjectAsCacheKey) {
                 cacheKeyMap.clear();
             }
             cache.clear();
@@ -134,7 +134,7 @@ public class LocalCacheView<K, V> {
                 
                 @Override
                 public void remove() {
-                    if (storeCacheKey) {
+                    if (useObjectAsCacheKey) {
                         cacheKeyMap.remove(((AbstractCacheMap.MapIterator) iter).cursorValue().getKey());
                     }
                     iter.remove();
@@ -156,7 +156,7 @@ public class LocalCacheView<K, V> {
         @Override
         public void clear() {
             cache.clear();
-            if (storeCacheKey) {
+            if (useObjectAsCacheKey) {
                 cacheKeyMap.clear();
             }
         }
@@ -189,7 +189,7 @@ public class LocalCacheView<K, V> {
                 
                 @Override
                 public void remove() {
-                    if (storeCacheKey) {
+                    if (useObjectAsCacheKey) {
                         cacheKeyMap.remove(((AbstractCacheMap.MapIterator) iter).cursorValue().getKey());
                     }
                     iter.remove();
@@ -212,7 +212,7 @@ public class LocalCacheView<K, V> {
             if (o instanceof Map.Entry) {
                 Map.Entry<?, ?> e = (Map.Entry<?, ?>) o;
                 CacheKey cacheKey = toCacheKey(e.getKey());
-                if (storeCacheKey) {
+                if (useObjectAsCacheKey) {
                     cacheKeyMap.remove(e.getKey());
                 }
                 return cache.remove(cacheKey) != null;
@@ -273,7 +273,7 @@ public class LocalCacheView<K, V> {
 
     public CacheKey toCacheKey(Object key) {
         CacheKey cacheKey;
-        if (storeCacheKey) {
+        if (useObjectAsCacheKey) {
             cacheKey = cacheKeyMap.get(key);
             if (cacheKey != null) {
                 return cacheKey;
@@ -282,7 +282,7 @@ public class LocalCacheView<K, V> {
         ByteBuf encoded = object.encodeMapKey(key);
         try {
             cacheKey = toCacheKey(encoded);
-            if (storeCacheKey) {
+            if (useObjectAsCacheKey) {
                 cacheKeyMap.put(key, cacheKey);
             }
             return cacheKey;


### PR DESCRIPTION
This will help to increase the performance of RedissonLocalCachedMap by introducing a cache synonym on `LocalCacheView.toCacheKey(Object)`  method.

Changes:

- Add new config `LocalCachedMapOptions.storeCacheKey` that defines whether to store CacheKey of an object key into the local cache.
- Create a new local cache for caching CacheKey purpose
- Inside `LocalCacheView.toCacheKey(Object)`:
    - Check if the Object already has Its CacheKey, and return the cached value.
    - If the Object does not have its CacheKey, create a new CacheKey put it into the local cache, and return it.
   