### PR TITLE
Redisearch FT.INFO result decoder throws on infinity values

### DIFF
--- a/redisson/src/main/java/org/redisson/client/protocol/decoder/IndexInfoDecoder.java
+++ b/redisson/src/main/java/org/redisson/client/protocol/decoder/IndexInfoDecoder.java
@@ -77,21 +77,32 @@ public class IndexInfoDecoder implements MultiDecoder<Object> {
 
     private Long toLong(Map<String, Object> result, String prop) {
         Object val = result.getOrDefault(prop, "nan");
-        if (val.toString().contains("nan")) {
+        String valstring = val.toString();
+        if (valstring.contains("nan") || valstring.contains("inf")) {
             return 0L;
         }
+
         if (val instanceof Double) {
             Double d = (Double) val;
             return d.longValue();
         }
-        return Long.valueOf(val.toString());
+
+        return Long.valueOf(valstring);
     }
 
     private Double toDouble(Map<String, Object> result, String prop) {
         Object val = result.getOrDefault(prop, "nan");
-        if (val.toString().contains("nan")) {
+        String valstring = val.toString();
+        if (valstring.contains("nan")) {
             return 0D;
+        } else if (valstring.contains("inf")) {
+            if (valstring.contains("-")) {
+                return Double.NEGATIVE_INFINITY;
+            } else {
+                return Double.POSITIVE_INFINITY;
+            }
         }
-        return Double.valueOf(val.toString());
+
+        return Double.valueOf(valstring);
     }
 }


### PR DESCRIPTION
Follow-up to #6090 and #5950

Redisson 3.37
Redisearch 7.99.00
Redis 8.0-M01 (cluster configuration)

Sometimes FT.INFO returns inf (and -inf might be likely too), causing current parser to throw:
```
java.lang.NumberFormatException: For input string: "inf"
	at java.base/jdk.internal.math.FloatingDecimal.readJavaFormatString(Unknown Source)
	at java.base/jdk.internal.math.FloatingDecimal.parseDouble(Unknown Source)
	at java.base/java.lang.Double.parseDouble(Unknown Source)
	at java.base/java.lang.Double.valueOf(Unknown Source)
	at org.redisson.client.protocol.decoder.IndexInfoDecoder.toDouble(IndexInfoDecoder.java:95)
	at org.redisson.client.protocol.decoder.IndexInfoDecoder.decode(IndexInfoDecoder.java:60)
```