### PR TITLE
Improvement - Change timeToLive to keepAliveTime #6216

### DIFF
--- a/redisson/src/main/java/org/redisson/api/RRateLimiter.java
+++ b/redisson/src/main/java/org/redisson/api/RRateLimiter.java
@@ -57,11 +57,11 @@ public interface RRateLimiter extends RRateLimiterAsync, RExpirable {
      * @param mode rate mode
      * @param rate rate
      * @param rateInterval rate time interval
-     * @param timeToLive time interval before the object will be deleted
+     * @param keepAliveTime this is the maximum time that key will wait for new acquire before delete
      * @return {@code true} if rate was set and {@code false}
      *         otherwise
      */
-    boolean trySetRate(RateType mode, long rate, Duration rateInterval, Duration timeToLive);
+    boolean trySetRate(RateType mode, long rate, Duration rateInterval, Duration keepAliveTime);
 
     /**
      * Use {@link #setRate(RateType, long, Duration)} instead.
@@ -91,9 +91,9 @@ public interface RRateLimiter extends RRateLimiterAsync, RExpirable {
      * @param mode rate mode
      * @param rate rate
      * @param rateInterval rate time interval
-     * @param timeToLive time interval before the object will be deleted
+     * @param keepAliveTime this is the maximum time that key will wait for new acquire before delete
      */
-    void setRate(RateType mode, long rate, Duration rateInterval, Duration timeToLive);
+    void setRate(RateType mode, long rate, Duration rateInterval, Duration keepAliveTime);
 
     /**
      * Acquires a permit only if one is available at the

--- a/redisson/src/test/java/org/redisson/RedissonRateLimiterTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonRateLimiterTest.java
@@ -2,10 +2,8 @@ package org.redisson;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.redisson.api.RRateLimiter;
-import org.redisson.api.RScoredSortedSet;
-import org.redisson.api.RateIntervalUnit;
-import org.redisson.api.RateType;
+import org.redisson.api.*;
+import org.redisson.config.Config;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -17,6 +15,21 @@ import java.util.concurrent.atomic.AtomicLong;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class RedissonRateLimiterTest extends RedisDockerTest {
+
+    @Test
+    public void testKeepAliveTime() throws InterruptedException {
+        RRateLimiter limiter = redisson.getRateLimiter("testKeepAliveTime");
+        limiter.delete();
+        limiter.trySetRate(RateType.OVERALL, 1, Duration.ofSeconds(1), Duration.ofSeconds(1));
+        Thread.sleep(Duration.ofMillis(1100));
+        assertThat(limiter.isExists()).isFalse();
+        limiter.trySetRate(RateType.OVERALL, 10, Duration.ofSeconds(2), Duration.ofSeconds(2));
+        Thread.sleep(Duration.ofSeconds(1));
+        assertThat(limiter.tryAcquire()).isTrue();
+        assertThat(limiter.remainTimeToLive()).isGreaterThan(1500);
+
+
+    }
 
     @Test
     public void testExpire2() throws InterruptedException {


### PR DESCRIPTION
The parameter timeToLive  should be keepAliveTime  in RRateLimiter.
```
 limiter.trySetRate(RateType.OVERALL, 1, Duration.ofMinutes(1), Duration.ofMinutes(5));
```
In this code, if no accquire has been invoked, it will be deleted in 5 miniute, if accquire be invoked it will reset ttl to 5 miniutes.
Just set ttl as timeToLive directly,  that's does not conform with business scenario mostly.


