### PR TITLE
Make search available via batch (pipelining). Fixes #6125.

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonBatch.java
+++ b/redisson/src/main/java/org/redisson/RedissonBatch.java
@@ -229,6 +229,16 @@ public class RedissonBatch implements RBatch {
     }
 
     @Override
+    public RSearchAsync getSearch() {
+        return new RedissonSearch(executorService);
+    }
+
+    @Override
+    public RSearchAsync getSearch(Codec codec) {
+        return new RedissonSearch(codec, executorService);
+    }
+
+    @Override
     public <V> RSetCacheAsync<V> getSetCache(String name) {
         return new RedissonSetCache<V>(evictionScheduler, executorService, name, null);
     }

--- a/redisson/src/main/java/org/redisson/RedissonSearch.java
+++ b/redisson/src/main/java/org/redisson/RedissonSearch.java
@@ -49,6 +49,11 @@ public class RedissonSearch implements RSearch {
     private final Codec codec;
     private final CommandAsyncExecutor commandExecutor;
 
+    public RedissonSearch(CommandAsyncExecutor commandExecutor) {
+        this.codec = commandExecutor.getServiceManager().getCfg().getCodec();
+        this.commandExecutor = commandExecutor;
+    }
+
     public RedissonSearch(Codec codec, CommandAsyncExecutor commandExecutor) {
         this.codec = commandExecutor.getServiceManager().getCodec(codec);
         this.commandExecutor = commandExecutor;

--- a/redisson/src/main/java/org/redisson/api/RBatch.java
+++ b/redisson/src/main/java/org/redisson/api/RBatch.java
@@ -555,6 +555,21 @@ public interface RBatch {
     RKeysAsync getKeys();
 
     /**
+     * Returns API for RediSearch module
+     *
+     * @return RSearchAsync object
+     */
+    RSearchAsync getSearch();
+
+    /**
+     * Returns API for RediSearch module using defined codec for attribute values.
+     *
+     * @param codec codec for entry
+     * @return RSearchAsync object
+     */
+    RSearchAsync getSearch(Codec codec);
+
+    /**
      * Executes all operations accumulated during async methods invocations.
      * <p>
      * If cluster configuration used then operations are grouped by slot ids

--- a/redisson/src/main/java/org/redisson/api/RBatchReactive.java
+++ b/redisson/src/main/java/org/redisson/api/RBatchReactive.java
@@ -553,6 +553,21 @@ public interface RBatchReactive {
     RKeysReactive getKeys();
 
     /**
+     * Returns API for RediSearch module
+     *
+     * @return RSearchReactive object
+     */
+    RSearchReactive getSearch();
+
+    /**
+     * Returns API for RediSearch module using defined codec for attribute values.
+     *
+     * @param codec codec for entry
+     * @return RSearchReactive object
+     */
+    RSearchReactive getSearch(Codec codec);
+
+    /**
      * Executes all operations accumulated during Reactive methods invocations Reactivehronously.
      *
      * In cluster configurations operations grouped by slot ids

--- a/redisson/src/main/java/org/redisson/api/RBatchRx.java
+++ b/redisson/src/main/java/org/redisson/api/RBatchRx.java
@@ -555,6 +555,21 @@ public interface RBatchRx {
     RKeysRx getKeys();
 
     /**
+     * Returns API for RediSearch module
+     *
+     * @return RSearchRx object
+     */
+    RSearchRx getSearch();
+
+    /**
+     * Returns API for RediSearch module using defined codec for attribute values.
+     *
+     * @param codec codec for entry
+     * @return RSearchRx object
+     */
+    RSearchRx getSearch(Codec codec);
+
+    /**
      * Executes all operations accumulated during Reactive methods invocations Reactivehronously.
      *
      * In cluster configurations operations grouped by slot ids

--- a/redisson/src/main/java/org/redisson/reactive/RedissonBatchReactive.java
+++ b/redisson/src/main/java/org/redisson/reactive/RedissonBatchReactive.java
@@ -297,6 +297,16 @@ public class RedissonBatchReactive implements RBatchReactive {
     }
 
     @Override
+    public RSearchReactive getSearch() {
+        return ReactiveProxyBuilder.create(executorService, new RedissonSearch(executorService), RSearchReactive.class);
+    }
+
+    @Override
+    public RSearchReactive getSearch(Codec codec) {
+        return ReactiveProxyBuilder.create(executorService, new RedissonSearch(codec, executorService), RSearchReactive.class);
+    }
+
+    @Override
     public Mono<BatchResult<?>> execute() {
         return commandExecutor.reactive(() -> executorService.executeAsync());
     }

--- a/redisson/src/main/java/org/redisson/rx/RedissonBatchRx.java
+++ b/redisson/src/main/java/org/redisson/rx/RedissonBatchRx.java
@@ -308,6 +308,16 @@ public class RedissonBatchRx implements RBatchRx {
     }
 
     @Override
+    public RSearchRx getSearch() {
+        return RxProxyBuilder.create(executorService, new RedissonSearch(executorService), RSearchRx.class);
+    }
+
+    @Override
+    public RSearchRx getSearch(Codec codec) {
+        return RxProxyBuilder.create(executorService, new RedissonSearch(codec, executorService), RSearchRx.class);
+    }
+
+    @Override
     public Maybe<BatchResult<?>> execute() {
         return commandExecutor.flowable(() -> executorService.executeAsync()).singleElement();
     }


### PR DESCRIPTION
Adds the missing `getSearch(...)` methods to `RBatch`, `RBatchReactive` and `RBatchRx` so that search commands can be used with pipelining. Fixes #6125.