### PR TITLE
Upgrade kryo version to 5.6.2 for Java 8 compatibility

### DIFF
--- a/redisson/pom.xml
+++ b/redisson/pom.xml
@@ -259,7 +259,7 @@
         <dependency>
             <groupId>com.esotericsoftware</groupId>
             <artifactId>kryo</artifactId>
-            <version>5.6.1</version>
+            <version>5.6.2</version>
         </dependency>
         <dependency>
           <groupId>org.apache.fury</groupId>


### PR DESCRIPTION
### Description:

This PR upgrades the version of kryo from 5.6.1 to 5.6.2 in the project’s pom.xml file. The change is necessary because kryo version 5.6.1 was accidentally compiled for Java 17, which is not compatible with Java 8 environments.

### Changes:
```
<dependency>
    <groupId>com.esotericsoftware</groupId>
    <artifactId>kryo</artifactId>
    <version>5.6.2</version>
</dependency>
```
### Context:

According to the [Kryo release notes](https://github.com/EsotericSoftware/kryo/releases), version 5.6.1 was mistakenly targeted for Java 17, which causes compatibility issues for projects still using Java 8. Upgrading to version 5.6.2 resolves this issue, as it reverts the target Java version to a more compatible setting.

Testing:

	•	Built the project to ensure compatibility with Java 8.
	•	Ran existing tests to confirm no regression or compatibility issues with kryo version 5.6.2.
