### PR TITLE
Add new LocalCachedMapOptions.readMode setting and new ReconnectionStrategy option RELOAD

### DIFF
--- a/redisson/src/main/java/org/redisson/Redisson.java
+++ b/redisson/src/main/java/org/redisson/Redisson.java
@@ -363,6 +363,7 @@ public final class Redisson implements RedissonClient {
                 .cacheProvider(LocalCachedMapOptions.CacheProvider.valueOf(params.getCacheProvider().toString()))
                 .cacheSize(params.getCacheSize())
                 .storeMode(LocalCachedMapOptions.StoreMode.valueOf(params.getStoreMode().toString()))
+                .readMode(LocalCachedMapOptions.ReadMode.valueOf(params.getReadMode().toString()))
                 .evictionPolicy(LocalCachedMapOptions.EvictionPolicy.valueOf(params.getEvictionPolicy().toString()))
                 .maxIdle(params.getMaxIdleInMillis())
                 .loader(params.getLoader())

--- a/redisson/src/main/java/org/redisson/RedissonLocalCachedMap.java
+++ b/redisson/src/main/java/org/redisson/RedissonLocalCachedMap.java
@@ -58,6 +58,7 @@ public class RedissonLocalCachedMap<K, V> extends RedissonMap<K, V> implements R
     private int invalidateEntryOnChange;
     private SyncStrategy syncStrategy;
     private LocalCachedMapOptions.StoreMode storeMode;
+    private LocalCachedMapOptions.ReadMode readMode;
     private boolean storeCacheMiss;
     private boolean isUseObjectAsCacheKey;
 
@@ -84,6 +85,7 @@ public class RedissonLocalCachedMap<K, V> extends RedissonMap<K, V> implements R
         }
         syncStrategy = options.getSyncStrategy();
         storeMode = options.getStoreMode();
+        readMode = options.getReadMode();
         storeCacheMiss = options.isStoreCacheMiss();
         isUseObjectAsCacheKey = options.isUseObjectAsCacheKey();
         localCacheView = new LocalCacheView<>(options, this);
@@ -98,6 +100,11 @@ public class RedissonLocalCachedMap<K, V> extends RedissonMap<K, V> implements R
                 Object value = codec.getMapValueDecoder().decode(valueBuf, null);
                 cachePut(cacheKey, key, value);
                 return new CacheValue(key, value);
+            }
+
+            @Override
+            protected void reloadCache() {
+                RedissonLocalCachedMap.this.reloadCache();
             }
 
         };
@@ -216,7 +223,7 @@ public class RedissonLocalCachedMap<K, V> extends RedissonMap<K, V> implements R
 
     @Override
     public RFuture<Integer> sizeAsync() {
-        if (storeMode == LocalCachedMapOptions.StoreMode.LOCALCACHE) {
+        if (storeMode == LocalCachedMapOptions.StoreMode.LOCALCACHE || readMode == LocalCachedMapOptions.ReadMode.LOCALCACHE) {
             return new CompletableFutureWrapper<>(cache.size());
         }
         return super.sizeAsync();
@@ -229,7 +236,7 @@ public class RedissonLocalCachedMap<K, V> extends RedissonMap<K, V> implements R
         CacheKey cacheKey = localCacheView.toCacheKey(key);
         CacheValue cacheValue = cache.get(cacheKey);
         if (cacheValue == null) {
-            if (storeMode == LocalCachedMapOptions.StoreMode.LOCALCACHE) {
+            if (storeMode == LocalCachedMapOptions.StoreMode.LOCALCACHE || readMode == LocalCachedMapOptions.ReadMode.LOCALCACHE) {
                 if (hasNoLoader()) {
                     return new CompletableFutureWrapper<>(false);
                 }
@@ -276,7 +283,7 @@ public class RedissonLocalCachedMap<K, V> extends RedissonMap<K, V> implements R
         
         CacheValue cacheValue = new CacheValue(null, value);
         if (!cache.containsValue(cacheValue)) {
-            if (storeMode == LocalCachedMapOptions.StoreMode.LOCALCACHE) {
+            if (storeMode == LocalCachedMapOptions.StoreMode.LOCALCACHE || readMode == LocalCachedMapOptions.ReadMode.LOCALCACHE) {
                 return new CompletableFutureWrapper<>(false);
             }
 
@@ -295,7 +302,7 @@ public class RedissonLocalCachedMap<K, V> extends RedissonMap<K, V> implements R
             return new CompletableFutureWrapper<>((V) cacheValue.getValue());
         }
 
-        if (storeMode == LocalCachedMapOptions.StoreMode.LOCALCACHE) {
+        if (storeMode == LocalCachedMapOptions.StoreMode.LOCALCACHE || readMode == LocalCachedMapOptions.ReadMode.LOCALCACHE) {
             if (hasNoLoader()) {
                 return new CompletableFutureWrapper((Void) null);
             }
@@ -672,7 +679,7 @@ public class RedissonLocalCachedMap<K, V> extends RedissonMap<K, V> implements R
             }
         }
 
-        if (storeMode == LocalCachedMapOptions.StoreMode.LOCALCACHE) {
+        if (storeMode == LocalCachedMapOptions.StoreMode.LOCALCACHE || readMode == LocalCachedMapOptions.ReadMode.LOCALCACHE) {
             if (hasNoLoader()) {
                 return new CompletableFutureWrapper<>(result);
             }
@@ -889,7 +896,7 @@ public class RedissonLocalCachedMap<K, V> extends RedissonMap<K, V> implements R
             result.add((V) value.getValue());
         }
 
-        if (storeMode == LocalCachedMapOptions.StoreMode.LOCALCACHE) {
+        if (storeMode == LocalCachedMapOptions.StoreMode.LOCALCACHE || readMode == LocalCachedMapOptions.ReadMode.LOCALCACHE) {
             return new CompletableFutureWrapper<>(result);
         }
 
@@ -932,7 +939,7 @@ public class RedissonLocalCachedMap<K, V> extends RedissonMap<K, V> implements R
             result.put((K) value.getKey(), (V) value.getValue());
         }
 
-        if (storeMode == LocalCachedMapOptions.StoreMode.LOCALCACHE) {
+        if (storeMode == LocalCachedMapOptions.StoreMode.LOCALCACHE || readMode == LocalCachedMapOptions.ReadMode.LOCALCACHE) {
             return new CompletableFutureWrapper<>(result);
         }
 
@@ -954,6 +961,19 @@ public class RedissonLocalCachedMap<K, V> extends RedissonMap<K, V> implements R
         for (Entry<K, V> entry : super.entrySet()) {
             CacheKey cacheKey = localCacheView.toCacheKey(entry.getKey());
             cachePut(cacheKey, entry.getKey(), entry.getValue());
+        }
+    }
+
+    @Override
+    public void reloadCache() {
+        Set<CacheKey> existingCacheKeys = new HashSet<>(cache.keySet());
+        for (Entry<K, V> entry : super.entrySet(null, 10)) {
+            CacheKey cacheKey = localCacheView.toCacheKey(entry.getKey());
+            cachePut(cacheKey, entry.getKey(), entry.getValue());
+            existingCacheKeys.remove(cacheKey);
+        }
+        for (CacheKey cacheKey : existingCacheKeys) {
+            cacheRemove(cacheKey);
         }
     }
 
@@ -988,7 +1008,7 @@ public class RedissonLocalCachedMap<K, V> extends RedissonMap<K, V> implements R
             result.add(new AbstractMap.SimpleEntry<K, V>((K) value.getKey(), (V) value.getValue()));
         }
 
-        if (storeMode == LocalCachedMapOptions.StoreMode.LOCALCACHE) {
+        if (storeMode == LocalCachedMapOptions.StoreMode.LOCALCACHE || readMode == LocalCachedMapOptions.ReadMode.LOCALCACHE) {
             return new CompletableFutureWrapper<>(result);
         }
 
@@ -1322,7 +1342,7 @@ public class RedissonLocalCachedMap<K, V> extends RedissonMap<K, V> implements R
 
     @Override
     public Set<K> keySet(String pattern, int count) {
-        if (storeMode == LocalCachedMapOptions.StoreMode.LOCALCACHE) {
+        if (storeMode == LocalCachedMapOptions.StoreMode.LOCALCACHE || readMode == LocalCachedMapOptions.ReadMode.LOCALCACHE) {
             return cachedKeySet();
         }
         return super.keySet(pattern, count);
@@ -1330,7 +1350,7 @@ public class RedissonLocalCachedMap<K, V> extends RedissonMap<K, V> implements R
 
     @Override
     public Collection<V> values(String keyPattern, int count) {
-        if (storeMode == LocalCachedMapOptions.StoreMode.LOCALCACHE) {
+        if (storeMode == LocalCachedMapOptions.StoreMode.LOCALCACHE || readMode == LocalCachedMapOptions.ReadMode.LOCALCACHE) {
             return cachedValues();
         }
         return super.values(keyPattern, count);
@@ -1338,7 +1358,7 @@ public class RedissonLocalCachedMap<K, V> extends RedissonMap<K, V> implements R
 
     @Override
     public Set<Entry<K, V>> entrySet(String keyPattern, int count) {
-        if (storeMode == LocalCachedMapOptions.StoreMode.LOCALCACHE) {
+        if (storeMode == LocalCachedMapOptions.StoreMode.LOCALCACHE || readMode == LocalCachedMapOptions.ReadMode.LOCALCACHE) {
             return cachedEntrySet();
         }
         return super.entrySet(keyPattern, count);

--- a/redisson/src/main/java/org/redisson/RedissonReactive.java
+++ b/redisson/src/main/java/org/redisson/RedissonReactive.java
@@ -1160,6 +1160,7 @@ public class RedissonReactive implements RedissonReactiveClient {
                 .cacheProvider(LocalCachedMapOptions.CacheProvider.valueOf(params.getCacheProvider().toString()))
                 .cacheSize(params.getCacheSize())
                 .storeMode(LocalCachedMapOptions.StoreMode.valueOf(params.getStoreMode().toString()))
+                .readMode(LocalCachedMapOptions.ReadMode.valueOf(params.getReadMode().toString()))
                 .evictionPolicy(LocalCachedMapOptions.EvictionPolicy.valueOf(params.getEvictionPolicy().toString()))
                 .maxIdle(params.getMaxIdleInMillis())
                 .loader(params.getLoader())

--- a/redisson/src/main/java/org/redisson/RedissonRx.java
+++ b/redisson/src/main/java/org/redisson/RedissonRx.java
@@ -1136,6 +1136,7 @@ public class RedissonRx implements RedissonRxClient {
                 .cacheProvider(LocalCachedMapOptions.CacheProvider.valueOf(params.getCacheProvider().toString()))
                 .cacheSize(params.getCacheSize())
                 .storeMode(LocalCachedMapOptions.StoreMode.valueOf(params.getStoreMode().toString()))
+                .readMode(LocalCachedMapOptions.ReadMode.valueOf(params.getReadMode().toString()))
                 .evictionPolicy(LocalCachedMapOptions.EvictionPolicy.valueOf(params.getEvictionPolicy().toString()))
                 .maxIdle(params.getMaxIdleInMillis())
                 .loader(params.getLoader())

--- a/redisson/src/main/java/org/redisson/api/LocalCachedMapOptions.java
+++ b/redisson/src/main/java/org/redisson/api/LocalCachedMapOptions.java
@@ -57,7 +57,12 @@ public class LocalCachedMapOptions<K, V> extends MapOptions<K, V> {
          * if LocalCachedMap instance has been disconnected less than 10 minutes 
          * or whole local cache will be cleaned otherwise.
          */
-        LOAD
+        LOAD,
+
+        /**
+         * Reload local cache if map instance connect/disconnected.
+         */
+        RELOAD
         
     }
     
@@ -132,6 +137,20 @@ public class LocalCachedMapOptions<K, V> extends MapOptions<K, V> {
 
     }
 
+    public enum ReadMode {
+
+        /**
+         * Read data only in local cache.
+         */
+        LOCALCACHE,
+
+        /**
+         * Read data in Redis if not found in local cache.
+         */
+        LOCALCACHE_REDIS
+
+    }
+
     public enum ExpirationEventPolicy {
 
         /**
@@ -159,6 +178,7 @@ public class LocalCachedMapOptions<K, V> extends MapOptions<K, V> {
     private long maxIdleInMillis;
     private CacheProvider cacheProvider;
     private StoreMode storeMode;
+    private ReadMode readMode;
     private boolean storeCacheMiss;
     private ExpirationEventPolicy expirationEventPolicy;
     private boolean useObjectAsCacheKey;
@@ -176,6 +196,7 @@ public class LocalCachedMapOptions<K, V> extends MapOptions<K, V> {
         this.maxIdleInMillis = copy.maxIdleInMillis;
         this.cacheProvider = copy.cacheProvider;
         this.storeMode = copy.storeMode;
+        this.readMode = copy.readMode;
         this.storeCacheMiss = copy.storeCacheMiss;
         this.useObjectAsCacheKey = copy.useObjectAsCacheKey;
     }
@@ -207,6 +228,7 @@ public class LocalCachedMapOptions<K, V> extends MapOptions<K, V> {
                     .reconnectionStrategy(ReconnectionStrategy.NONE)
                     .cacheProvider(CacheProvider.REDISSON)
                     .storeMode(StoreMode.LOCALCACHE_REDIS)
+                    .readMode(ReadMode.LOCALCACHE_REDIS)
                     .syncStrategy(SyncStrategy.INVALIDATE)
                     .storeCacheMiss(false)
                     .useObjectAsCacheKey(false)
@@ -263,6 +285,7 @@ public class LocalCachedMapOptions<K, V> extends MapOptions<K, V> {
      * @param reconnectionStrategy
      *          <p><code>CLEAR</code> - clear local cache if map instance has been disconnected for a while.
      *          <p><code>LOAD</code> - store invalidated entry hash in invalidation log for 10 minutes. Cache keys for stored invalidated entry hashes will be removed if LocalCachedMap instance has been disconnected less than 10 minutes or whole cache will be cleaned otherwise
+     *          <p><code>RELOAD</code> - <p><code>NONE</code> - Reload local cache if map instance connect/disconnected.
      *          <p><code>NONE</code> - Default. No reconnection handling
      * @return LocalCachedMapOptions instance
      */
@@ -364,6 +387,10 @@ public class LocalCachedMapOptions<K, V> extends MapOptions<K, V> {
         return storeMode;
     }
 
+    public ReadMode getReadMode() {
+        return readMode;
+    }
+
     /**
      * Defines store mode of cache data.
      *
@@ -374,6 +401,19 @@ public class LocalCachedMapOptions<K, V> extends MapOptions<K, V> {
      */
     public LocalCachedMapOptions<K, V> storeMode(StoreMode storeMode) {
         this.storeMode = storeMode;
+        return this;
+    }
+
+    /**
+     * Defines read mode of cache data.
+     *
+     * @param readMode
+     *         <p><code>LOCALCACHE</code> - read data in local cache only.
+     *         <p><code>LOCALCACHE_REDIS</code> - read data in Redis if not found in local cache.
+     * @return LocalCachedMapOptions instance
+     */
+    public LocalCachedMapOptions<K, V> readMode(ReadMode readMode) {
+        this.readMode = readMode;
         return this;
     }
 

--- a/redisson/src/main/java/org/redisson/api/RLocalCachedMap.java
+++ b/redisson/src/main/java/org/redisson/api/RLocalCachedMap.java
@@ -40,6 +40,13 @@ public interface RLocalCachedMap<K, V> extends RMap<K, V> {
     void preloadCache();
 
     /**
+     * Reload the cached entries. Not guaranteed to load ALL values, but statistically
+     * will reload approximately all (all if no concurrent mutating activity).
+     * Entries are loaded in a batch with size of 10 elements.
+     */
+    void reloadCache();
+
+    /**
      * Pre-warm the cached entries. Not guaranteed to load ALL values, but statistically
      * will preload approximately all (all if no concurrent mutating activity)
      * Entries are loaded in a batch. Batch size is defined by <code>count</code> param.

--- a/redisson/src/main/java/org/redisson/api/options/LocalCachedMapOptions.java
+++ b/redisson/src/main/java/org/redisson/api/options/LocalCachedMapOptions.java
@@ -50,7 +50,12 @@ public interface LocalCachedMapOptions<K, V> extends ExMapOptions<LocalCachedMap
          * if LocalCachedMap instance has been disconnected less than 10 minutes 
          * or whole local cache will be cleaned otherwise.
          */
-        LOAD
+        LOAD,
+
+        /**
+         * Reload local cache if map instance connect/disconnected.
+         */
+        RELOAD
         
     }
     
@@ -125,6 +130,20 @@ public interface LocalCachedMapOptions<K, V> extends ExMapOptions<LocalCachedMap
 
     }
 
+    enum ReadMode {
+
+        /**
+         * Read data only in local cache.
+         */
+        LOCALCACHE,
+
+        /**
+         * Read data in Redis if not found in local cache.
+         */
+        LOCALCACHE_REDIS
+
+    }
+
     enum ExpirationEventPolicy {
 
         /**
@@ -172,6 +191,7 @@ public interface LocalCachedMapOptions<K, V> extends ExMapOptions<LocalCachedMap
      * @param reconnectionStrategy
      *          <p><code>CLEAR</code> - clear local cache if map instance has been disconnected for a while.
      *          <p><code>LOAD</code> - store invalidated entry hash in invalidation log for 10 minutes. Cache keys for stored invalidated entry hashes will be removed if LocalCachedMap instance has been disconnected less than 10 minutes or whole cache will be cleaned otherwise
+     *          <p><code>RELOAD</code> - Reload local cache if map instance connect/disconnected.
      *          <p><code>NONE</code> - Default. No reconnection handling
      * @return LocalCachedMapOptions instance
      */
@@ -227,6 +247,16 @@ public interface LocalCachedMapOptions<K, V> extends ExMapOptions<LocalCachedMap
      * @return LocalCachedMapOptions instance
      */
     LocalCachedMapOptions<K, V> storeMode(StoreMode storeMode);
+
+    /**
+     * Defines read mode of cache data.
+     *
+     * @param readMode
+     *         <p><code>LOCALCACHE</code> - read data in local cache only.
+     *         <p><code>LOCALCACHE_REDIS</code> - read data in Redis if not found in local cache.
+     * @return LocalCachedMapOptions instance
+     */
+    LocalCachedMapOptions<K, V> readMode(LocalCachedMapOptions.ReadMode readMode);
 
     /**
      * Defines Cache provider used as local cache store.

--- a/redisson/src/main/java/org/redisson/api/options/LocalCachedMapParams.java
+++ b/redisson/src/main/java/org/redisson/api/options/LocalCachedMapParams.java
@@ -36,6 +36,7 @@ public final class LocalCachedMapParams<K, V> extends BaseMapOptions<LocalCached
     private long maxIdleInMillis;
     private CacheProvider cacheProvider = CacheProvider.REDISSON;
     private StoreMode storeMode = StoreMode.LOCALCACHE_REDIS;
+    private ReadMode readMode = ReadMode.LOCALCACHE_REDIS;
     private boolean storeCacheMiss;
 
     private ExpirationEventPolicy expirationEventPolicy = ExpirationEventPolicy.SUBSCRIBE_WITH_KEYEVENT_PATTERN;
@@ -96,6 +97,7 @@ public final class LocalCachedMapParams<K, V> extends BaseMapOptions<LocalCached
      * @param reconnectionStrategy
      *          <p><code>CLEAR</code> - clear local cache if map instance has been disconnected for a while.
      *          <p><code>LOAD</code> - store invalidated entry hash in invalidation log for 10 minutes. Cache keys for stored invalidated entry hashes will be removed if LocalCachedMap instance has been disconnected less than 10 minutes or whole cache will be cleaned otherwise
+     *          <p><code>RELOAD</code> - Reload local cache if map instance connect/disconnected.
      *          <p><code>NONE</code> - Default. No reconnection handling
      * @return LocalCachedMapOptions instance
      */
@@ -173,6 +175,10 @@ public final class LocalCachedMapParams<K, V> extends BaseMapOptions<LocalCached
         return storeMode;
     }
 
+    public ReadMode getReadMode() {
+        return readMode;
+    }
+
     /**
      * Defines store mode of cache data.
      *
@@ -183,6 +189,19 @@ public final class LocalCachedMapParams<K, V> extends BaseMapOptions<LocalCached
      */
     public LocalCachedMapParams<K, V> storeMode(StoreMode storeMode) {
         this.storeMode = storeMode;
+        return this;
+    }
+
+    /**
+     * Defines read mode of cache data.
+     *
+     * @param readMode
+     *         <p><code>LOCALCACHE</code> - read data in local cache only.
+     *         <p><code>LOCALCACHE_REDIS</code> - read data in Redis if not found in local cache.
+     * @return LocalCachedMapOptions instance
+     */
+    public LocalCachedMapParams<K, V> readMode(ReadMode readMode) {
+        this.readMode = readMode;
         return this;
     }
 

--- a/redisson/src/main/java/org/redisson/cache/LocalCacheListener.java
+++ b/redisson/src/main/java/org/redisson/cache/LocalCacheListener.java
@@ -293,6 +293,9 @@ public abstract class LocalCacheListener {
 
             loadAfterReconnection();
         }
+        if (options.getReconnectionStrategy() == ReconnectionStrategy.RELOAD) {
+            reloadCache();
+        }
     }
 
     public void notifyUpdate(CacheValue value) {
@@ -353,6 +356,7 @@ public abstract class LocalCacheListener {
     }
 
     protected abstract CacheValue updateCache(ByteBuf keyBuf, ByteBuf valueBuf) throws IOException;
+    protected abstract void reloadCache();
 
     private void disableKeys(final String requestId, final Set<CacheKey> keys, long timeout) {
         for (CacheKey key : keys) {

--- a/redisson/src/main/java/org/redisson/transaction/RedissonTransactionalLocalCachedMap.java
+++ b/redisson/src/main/java/org/redisson/transaction/RedissonTransactionalLocalCachedMap.java
@@ -51,6 +51,11 @@ public class RedissonTransactionalLocalCachedMap<K, V> extends RedissonTransacti
     }
 
     @Override
+    public void reloadCache() {
+        throw new UnsupportedOperationException("reloadCache method is not supported in transaction");
+    }
+
+    @Override
     public void preloadCache(int count) {
         throw new UnsupportedOperationException("preloadCache method is not supported in transaction");
     }


### PR DESCRIPTION
**The idea of the `readMode` setting comes from `SyncStrategy.UPDATE`**

With the strategy, local cache entries across all LocalCachedMap instances will be the same. When getting data we only need to read from locally and are not required to read from Redis cache. This will help increase speed and reduce CPU use if the value is not in the local cache. 
We have two read modes here with the default `LOCALCACHE_REDIS`.
```
public enum ReadMode {
        /**
         * Read data only in local cache.
         */
        LOCALCACHE,
        /**
         * Read data in Redis if not found in local cache.
         */
        LOCALCACHE_REDIS
    }
```

**New ReconnectionStrategy option RELOAD**

With this `RELOAD` the local cache will be reloaded after the cache is connected or reconnected. `reloadCache` action is basically like `preLoadCache` action but it also removes unavailable keys from the local cache compared with Redis Cache
```
/**
 * Reload local cache if map instance connect/disconnected.
 */
RELOAD
```