### PR TITLE
Add fastReplaceValuesAsync and fastReplaceValues to RMultimap and its implementations.

### DIFF
--- a/redisson/src/main/java/org/redisson/api/RMultimap.java
+++ b/redisson/src/main/java/org/redisson/api/RMultimap.java
@@ -181,6 +181,19 @@ public interface RMultimap<K, V> extends RExpirable, RMultimapAsync<K, V> {
     Collection<V> replaceValues(K key, Iterable<? extends V> values);
 
     /**
+     * Stores a collection of values with the same key, replacing any existing
+     * values for that key. Is faster than {@link #replaceValues} by not returning
+     * the values.
+     *
+     * <p>If {@code values} is empty, this is equivalent to
+     * {@link #removeAll(Object) removeAll(key)}.
+     *
+     * @param key - map key
+     * @param values - map values
+     */
+    void fastReplaceValues(K key, Iterable<? extends V> values);
+
+    /**
      * Removes all values associated with the key {@code key}.
      *
      * <p>Once this method returns, {@code key} will not be mapped to any values

--- a/redisson/src/main/java/org/redisson/api/RMultimapAsync.java
+++ b/redisson/src/main/java/org/redisson/api/RMultimapAsync.java
@@ -128,6 +128,19 @@ public interface RMultimapAsync<K, V> extends RExpirableAsync {
     RFuture<Collection<V>> replaceValuesAsync(K key, Iterable<? extends V> values);
 
     /**
+     * Stores a collection of values with the same key, replacing any existing
+     * values for that key. Is faster than {@link #replaceValuesAsync(Object, Iterable)}
+     * by not returning the values.
+     *
+     * <p>If {@code values} is empty, this is equivalent to
+     * {@link #removeAllAsync(Object)}.
+     *
+     * @param key - map key
+     * @param values - map values
+     */
+    RFuture<Void> fastReplaceValuesAsync(K key, Iterable<? extends V> values);
+
+    /**
      * Removes all values associated with the key {@code key}.
      *
      * <p>Once this method returns, {@code key} will not be mapped to any values.

--- a/redisson/src/main/java/org/redisson/api/RMultimapReactive.java
+++ b/redisson/src/main/java/org/redisson/api/RMultimapReactive.java
@@ -119,6 +119,15 @@ public interface RMultimapReactive<K, V> extends RExpirableReactive {
     Mono<Integer> keySize();
 
     /**
+     * Stores a collection of values with the same key, replacing any existing
+     * values for that key. Is faster by not returning the values.
+     *
+     * @param key - map key
+     * @param values - map values
+     */
+    Mono<Void> fastReplaceValues(K key, Iterable<? extends V> values);
+
+    /**
      * Removes <code>keys</code> from map by one operation
      *
      * Works faster than <code>RMultimap.remove</code> but not returning

--- a/redisson/src/main/java/org/redisson/api/RMultimapRx.java
+++ b/redisson/src/main/java/org/redisson/api/RMultimapRx.java
@@ -119,6 +119,15 @@ public interface RMultimapRx<K, V> extends RExpirableRx {
     Single<Integer> keySize();
 
     /**
+     * Stores a collection of values with the same key, replacing any existing
+     * values for that key. Is faster by not returning the values.
+     *
+     * @param key - map key
+     * @param values - map values
+     */
+    Single<Void> fastReplaceValues(K key, Iterable<? extends V> values);
+
+    /**
      * Removes <code>keys</code> from map by one operation
      *
      * Works faster than <code>RMultimap.remove</code> but not returning

--- a/redisson/src/test/java/org/redisson/RedissonListMultimapTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonListMultimapTest.java
@@ -423,6 +423,26 @@ public class RedissonListMultimapTest extends RedisDockerTest {
     }
 
     @Test
+    public void testFastReplaceValues() {
+        RListMultimap<SimpleKey, SimpleValue> map = redisson.getListMultimap("testFastReplace");
+
+        map.put(new SimpleKey("0"), new SimpleValue("1"));
+        map.put(new SimpleKey("3"), new SimpleValue("4"));
+
+        List<SimpleValue> values = Arrays.asList(new SimpleValue("11"), new SimpleValue("12"), new SimpleValue("12"));
+
+        map.fastReplaceValues(new SimpleKey("0"), values);
+
+        List<SimpleValue> allValues = map.getAll(new SimpleKey("0"));
+        assertThat(allValues).containsExactlyElementsOf(values);
+
+        map.fastReplaceValues(new SimpleKey("0"), Collections.emptyList());
+
+        List<SimpleValue> vals = map.getAll(new SimpleKey("0"));
+        assertThat(vals).isEmpty();
+    }
+
+    @Test
     public void testDistributedIterator() {
         RListMultimap<String, String> map = redisson.getListMultimap("set", StringCodec.INSTANCE);
 

--- a/redisson/src/test/java/org/redisson/RedissonSetMultimapTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonSetMultimapTest.java
@@ -8,7 +8,6 @@ import org.redisson.client.codec.StringCodec;
 import java.io.Serializable;
 import java.time.Duration;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -443,6 +442,26 @@ public class RedissonSetMultimapTest extends RedisDockerTest {
         Set<SimpleValue> vals = map.getAll(new SimpleKey("0"));
         assertThat(vals).isEmpty();
 
+    }
+
+    @Test
+    public void testFastReplaceValues() {
+        RSetMultimap<SimpleKey, SimpleValue> map = redisson.getSetMultimap("testFastReplace");
+
+        map.put(new SimpleKey("0"), new SimpleValue("1"));
+        map.put(new SimpleKey("3"), new SimpleValue("4"));
+
+        List<SimpleValue> values = Arrays.asList(new SimpleValue("11"), new SimpleValue("12"));
+
+        map.fastReplaceValues(new SimpleKey("0"), values);
+
+        Set<SimpleValue> allValues = map.getAll(new SimpleKey("0"));
+        assertThat(allValues).containsExactlyElementsOf(values);
+
+        map.fastReplaceValues(new SimpleKey("0"), Collections.emptyList());
+
+        Set<SimpleValue> vals = map.getAll(new SimpleKey("0"));
+        assertThat(vals).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
Is faster than replaceValues and replaceValuesAsync by not returning the new values.

Closes #6294.