### PR TITLE
Spring Application Freezes When Redis Connection Fails in Redisson

### DIFF
--- a/redisson/src/main/java/org/redisson/spring/cache/RedissonCache.java
+++ b/redisson/src/main/java/org/redisson/spring/cache/RedissonCache.java
@@ -113,7 +113,6 @@ public class RedissonCache implements Cache {
             } else {
                 value = map.get(key);
             }
-
             if (value == null) {
                 addCacheMiss();
             } else {


### PR DESCRIPTION
When using Redisson with Spring for caching, if Redis is unavailable during a call to get(Object key, Class type) in the RedissonCache class, the application becomes unresponsive because connection problems are not properly caught. Specifically, in the line value = map.get(key);, no exception is handled when a connection issue occurs, causing the application to freeze or fail to start. This behavior prevents the application from handling Redis outages gracefully and violates resilience principles. To resolve this, the map.get(key) call should be wrapped in a try-catch block to handle exceptions like RedisConnectionException and allow the application to log a warning and continue operation.