### PR TITLE
Fix Quarkus redisson config with sentinel config

### DIFF
--- a/redisson/src/main/java/org/redisson/config/PropertiesConvertor.java
+++ b/redisson/src/main/java/org/redisson/config/PropertiesConvertor.java
@@ -81,7 +81,11 @@ public class PropertiesConvertor {
     }
 
     private static final Set<String> LIST_NODES = new HashSet<>(
-                            Arrays.asList("node-addresses", "nodeaddresses", "slave-addresses", "slaveaddresses", "addresses"));
+            Arrays.asList(
+                    "node-addresses", "nodeaddresses",
+                    "slave-addresses", "slaveaddresses",
+                    "sentinel-addresses", "sentineladdresses",
+                    "addresses"));
 
     private static final Set<String> CLASS_PROPERTIES = new HashSet<>(
             Arrays.asList("codec",


### PR DESCRIPTION
Similar to https://github.com/redisson/redisson/issues/4076 config load
fails for `sentinel-addresses`. This adds sentinel to the LIST_NODES so
that sentinel configuration also works.
