### PR TITLE
Fixed - RPermitExpirableSemaphore.release

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonPermitExpirableSemaphore.java
+++ b/redisson/src/main/java/org/redisson/RedissonPermitExpirableSemaphore.java
@@ -736,12 +736,10 @@ public class RedissonPermitExpirableSemaphore extends RedissonExpirable implemen
                 throw new CompletionException(e);
             }
 
-//            if (res == permitsIds.size()) {
-//                return null;
-//            }
-            if (res != 0) {
+            if (res == permitsIds.size()) {
                 return null;
             }
+
             throw new CompletionException(new IllegalArgumentException("Permits with ids " + permitsIds + " have already been released or don't exist"));
         });
         return new CompletableFutureWrapper<>(f);

--- a/redisson/src/test/java/org/redisson/RedissonPermitExpirableSemaphoreTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonPermitExpirableSemaphoreTest.java
@@ -1,6 +1,5 @@
 package org.redisson;
 
-import net.bytebuddy.utility.RandomString;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/redisson/src/test/java/org/redisson/RedissonPermitExpirableSemaphoreTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonPermitExpirableSemaphoreTest.java
@@ -1,5 +1,6 @@
 package org.redisson;
 
+import net.bytebuddy.utility.RandomString;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -576,6 +577,14 @@ public class RedissonPermitExpirableSemaphoreTest extends BaseConcurrentTest {
         List<String> permitsIdsSecondPart = permitsIds.subList(2, 4);
         permitsIdsSecondPart.addAll(permitsIdsFirstPart);
         Assertions.assertThrows(RedisException.class, () -> s.release(permitsIdsSecondPart));
+        assertThat(s.availablePermits()).isEqualTo(4);
+
+        Assertions.assertThrows(RedisException.class, () -> s.release(List.of("1234")));
+        assertThat(s.availablePermits()).isEqualTo(4);
+
+        List<String> permitsIdsThirdPart = permitsIds.subList(4, 6);
+        permitsIdsThirdPart.add("4567");
+        Assertions.assertThrows(RedisException.class, () -> s.release(permitsIdsThirdPart));
         assertThat(s.availablePermits()).isEqualTo(4);
     }
     

--- a/redisson/src/test/java/org/redisson/RedissonPermitExpirableSemaphoreTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonPermitExpirableSemaphoreTest.java
@@ -556,11 +556,12 @@ public class RedissonPermitExpirableSemaphoreTest extends BaseConcurrentTest {
     }
 
     @Test
-    public void testReleaseManyWithout() throws InterruptedException {
+    public void testReleaseManyNotExistOrExpired() throws InterruptedException {
         RPermitExpirableSemaphore s = redisson.getPermitExpirableSemaphore("test");
         s.trySetPermits(10);
-        List<String> timedPermitsIds = s.acquire(2,100, TimeUnit.MILLISECONDS);
+        List<String> timedPermitsIds = s.acquire(2, 100, TimeUnit.MILLISECONDS);
         List<String> permitsIds = s.tryAcquire(8);
+
         List<String> permitsIdsFirstPart = permitsIds.subList(0, 2);
 
         int released = s.tryRelease(permitsIdsFirstPart);
@@ -572,12 +573,10 @@ public class RedissonPermitExpirableSemaphoreTest extends BaseConcurrentTest {
         Assertions.assertThrows(RedisException.class, () -> s.release(timedPermitsIds));
         assertThat(s.availablePermits()).isEqualTo(4);
 
-        List<String> permitsIdsThirdPart = permitsIds.subList(4, 6);
-        permitsIdsThirdPart.addAll(permitsIdsFirstPart);
-        Assertions.assertThrows(RedisException.class, () -> s.release(permitsIdsThirdPart));
+        List<String> permitsIdsSecondPart = permitsIds.subList(2, 4);
+        permitsIdsSecondPart.addAll(permitsIdsFirstPart);
+        Assertions.assertThrows(RedisException.class, () -> s.release(permitsIdsSecondPart));
         assertThat(s.availablePermits()).isEqualTo(4);
-
-
     }
     
     @Test


### PR DESCRIPTION
[issues/6343](https://github.com/redisson/redisson/issues/6343)
For the caller, if they first acquire 2 permits with leasetime, then acquire 3 permits without leasetime limit , and finally want to release these 5 permits at once, but they fail because the first two permits have expired. It will affect the caller's previous usage logic of this method. Is this okay, or is this something the caller should consider?