### PR TITLE
fix: resolve Sentinel master change through NAT

### DIFF
--- a/redisson/src/main/java/org/redisson/connection/SentinelConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/SentinelConnectionManager.java
@@ -508,7 +508,8 @@ public class SentinelConnectionManager extends MasterSlaveConnectionManager {
         RFuture<RedisURI> masterFuture = connection.async(1, cfg.getRetryInterval(), cfg.getTimeout(),
                                                             StringCodec.INSTANCE, masterHostCommand, cfg.getMasterName());
         return masterFuture
-                .thenCompose(u -> serviceManager.resolveIP(scheme, u))
+                .thenCompose(u -> resolveIP(u.getHost(), "" + u.getPort()))
+                .thenApply(this::toURI)
                 .thenCompose(newMaster -> {
                     RedisURI current = currentMaster.get();
                     if (!newMaster.equals(current)


### PR DESCRIPTION
The Sentinel logic for checking if the `master` has changed (as per `Config#scanInterval`) resolves the URI returned by the `SENTINEL GET-MASTER-ADDR-BY-NAME` to an IP address. This resolution would ignore configured `NatMapper`, thus potentially ignoring changes to the `host`.

Example, if the current master responds with:

```
SENTINEL GET-PRIMARY-ADDR-BY-NAME myprimary
1) "valkey-node-2.valkey-headless.default.svc.cluster.local"
2) "6379"
```

Configured `NatMapper` would map `redis://valkey-node-2.valkey-headless.default.svc.cluster.local:6379` to `redis://localhost:1112`. But because it was not used in the `checkMasterChange` procedure, it would try to resolve hostname `valkey-node-2.valkey-headless.default.svc.cluster.local`, which fails.

`serviceManager.resolveIP(scheme, u)` does not use `NatMapper`. Other uses of `resolveIP` in `SentinelConnectionManager` use `SentinelConnectionManager#resolveIP(host, port)` as a proxy, which does use the `NatMapper`, and this is the one place where the proxy wasn't used (`checkMasterChange`).

Fixes #6397. Tested locally.