### PR TITLE
Increase cache maxSize

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonMapCache.java
+++ b/redisson/src/main/java/org/redisson/RedissonMapCache.java
@@ -104,20 +104,20 @@ public class RedissonMapCache<K, V> extends RedissonMap<K, V> implements RMapCac
     }
 
     @Override
-    public boolean trySetMaxSize(int maxSize) {
+    public boolean trySetMaxSize(long maxSize) {
         return get(trySetMaxSizeAsync(maxSize));
     }
 
-    public boolean trySetMaxSize(int maxSize, EvictionMode mode) {
+    public boolean trySetMaxSize(long maxSize, EvictionMode mode) {
         return get(trySetMaxSizeAsync(maxSize, mode));
     }
 
     @Override
-    public RFuture<Boolean> trySetMaxSizeAsync(int maxSize) {
+    public RFuture<Boolean> trySetMaxSizeAsync(long maxSize) {
         return trySetMaxSizeAsync(maxSize, EvictionMode.LRU);
     }
 
-    public RFuture<Boolean> trySetMaxSizeAsync(int maxSize, EvictionMode mode) {
+    public RFuture<Boolean> trySetMaxSizeAsync(long maxSize, EvictionMode mode) {
         if (maxSize < 0) {
             throw new IllegalArgumentException("maxSize should be greater than zero");
         }
@@ -198,20 +198,20 @@ public class RedissonMapCache<K, V> extends RedissonMap<K, V> implements RMapCac
     }
 
     @Override
-    public void setMaxSize(int maxSize) {
+    public void setMaxSize(long maxSize) {
         get(setMaxSizeAsync(maxSize));
     }
 
-    public void setMaxSize(int maxSize, EvictionMode mode) {
+    public void setMaxSize(long maxSize, EvictionMode mode) {
         get(setMaxSizeAsync(maxSize, mode));
     }
 
     @Override
-    public RFuture<Void> setMaxSizeAsync(int maxSize) {
+    public RFuture<Void> setMaxSizeAsync(long maxSize) {
         return setMaxSizeAsync(maxSize, EvictionMode.LRU);
     }
 
-    public RFuture<Void> setMaxSizeAsync(int maxSize, EvictionMode mode) {
+    public RFuture<Void> setMaxSizeAsync(long maxSize, EvictionMode mode) {
         if (maxSize < 0) {
             throw new IllegalArgumentException("maxSize should be greater than zero");
         }

--- a/redisson/src/main/java/org/redisson/api/RMapCache.java
+++ b/redisson/src/main/java/org/redisson/api/RMapCache.java
@@ -52,7 +52,7 @@ public interface RMapCache<K, V> extends RMap<K, V>, RMapCacheAsync<K, V> {
      * @param maxSize - max size
      *                  If <code>0</code> the cache is unbounded (default).
      */
-    void setMaxSize(int maxSize);
+    void setMaxSize(long maxSize);
 
     /**
      * Sets max size of the map and overrides current value.
@@ -61,7 +61,7 @@ public interface RMapCache<K, V> extends RMap<K, V>, RMapCacheAsync<K, V> {
      * @param maxSize - max size
      * @param mode - eviction mode
      */
-    void setMaxSize(int maxSize, EvictionMode mode);
+    void setMaxSize(long maxSize, EvictionMode mode);
 
     /**
      * Tries to set max size of the map. 
@@ -71,7 +71,7 @@ public interface RMapCache<K, V> extends RMap<K, V>, RMapCacheAsync<K, V> {
      * @return <code>true</code> if max size has been successfully set, otherwise <code>false</code>.
      *         If <code>0</code> the cache is unbounded (default).
      */
-    boolean trySetMaxSize(int maxSize);
+    boolean trySetMaxSize(long maxSize);
 
     /**
      * Tries to set max size of the map.
@@ -81,7 +81,7 @@ public interface RMapCache<K, V> extends RMap<K, V>, RMapCacheAsync<K, V> {
      * @param mode - eviction mode
      * @return <code>true</code> if max size has been successfully set, otherwise <code>false</code>.
      */
-    boolean trySetMaxSize(int maxSize, EvictionMode mode);
+    boolean trySetMaxSize(long maxSize, EvictionMode mode);
     /**
      * If the specified key is not already associated
      * with a value, attempts to compute its value using the given mapping function and enters it into this map .

--- a/redisson/src/main/java/org/redisson/api/RMapCacheAsync.java
+++ b/redisson/src/main/java/org/redisson/api/RMapCacheAsync.java
@@ -52,7 +52,7 @@ public interface RMapCacheAsync<K, V> extends RMapAsync<K, V> {
      * @param maxSize - max size
      * @return void
      */
-    RFuture<Void> setMaxSizeAsync(int maxSize);
+    RFuture<Void> setMaxSizeAsync(long maxSize);
 
     /**
      * Sets max size of the map and overrides current value.
@@ -62,7 +62,7 @@ public interface RMapCacheAsync<K, V> extends RMapAsync<K, V> {
      * @param mode - eviction mode
      * @return void
      */
-    RFuture<Void> setMaxSizeAsync(int maxSize, EvictionMode mode);
+    RFuture<Void> setMaxSizeAsync(long maxSize, EvictionMode mode);
 
     /**
      * Tries to set max size of the map. 
@@ -71,7 +71,7 @@ public interface RMapCacheAsync<K, V> extends RMapAsync<K, V> {
      * @param maxSize - max size
      * @return <code>true</code> if max size has been successfully set, otherwise <code>false</code>.
      */
-    RFuture<Boolean> trySetMaxSizeAsync(int maxSize);
+    RFuture<Boolean> trySetMaxSizeAsync(long maxSize);
 
     /**
      * Tries to set max size of the map.
@@ -81,7 +81,7 @@ public interface RMapCacheAsync<K, V> extends RMapAsync<K, V> {
      * @param mode - eviction mode
      * @return <code>true</code> if max size has been successfully set, otherwise <code>false</code>.
      */
-    RFuture<Boolean> trySetMaxSizeAsync(int maxSize, EvictionMode mode);
+    RFuture<Boolean> trySetMaxSizeAsync(long maxSize, EvictionMode mode);
 
     /**
      * If the specified key is not already associated

--- a/redisson/src/main/java/org/redisson/spring/cache/CacheConfig.java
+++ b/redisson/src/main/java/org/redisson/spring/cache/CacheConfig.java
@@ -38,7 +38,7 @@ public class CacheConfig {
 
     private long maxIdleTime;
     
-    private int maxSize;
+    private long maxSize;
     
     private final List<MapEntryListener> listeners = new ArrayList<>();
 
@@ -81,7 +81,7 @@ public class CacheConfig {
     }
 
     
-    public int getMaxSize() {
+    public long getMaxSize() {
         return maxSize;
     }
 
@@ -91,7 +91,7 @@ public class CacheConfig {
      * @param maxSize - max size
      *                  If <code>0</code> the cache is unbounded (default).
      */
-    public void setMaxSize(int maxSize) {
+    public void setMaxSize(long maxSize) {
         this.maxSize = maxSize;
     }
 

--- a/redisson/src/main/java/org/redisson/transaction/RedissonTransactionalMapCache.java
+++ b/redisson/src/main/java/org/redisson/transaction/RedissonTransactionalMapCache.java
@@ -132,12 +132,12 @@ public class RedissonTransactionalMapCache<K, V> extends RedissonMapCache<K, V> 
     }
     
     @Override
-    public RFuture<Void> setMaxSizeAsync(int maxSize) {
+    public RFuture<Void> setMaxSizeAsync(long maxSize) {
         throw new UnsupportedOperationException("setMaxSize method is not supported in transaction");
     }
     
     @Override
-    public RFuture<Boolean> trySetMaxSizeAsync(int maxSize) {
+    public RFuture<Boolean> trySetMaxSizeAsync(long maxSize) {
         throw new UnsupportedOperationException("trySetMaxSize method is not supported in transaction");
     }
 


### PR DESCRIPTION
Important code update to allow for larger cache size. Currently, the maximum value you can set is only Integer.MAX_VALUE. This causes problems in larger cache sizes.