### PR TITLE
Fixed - Run RedissonLockTest.testLockUninterruptibly then run RedissonLockTest.testSubscriptionsPerConnection will test failed.

### DIFF
--- a/redisson/src/test/java/org/redisson/RedissonLockTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonLockTest.java
@@ -235,6 +235,8 @@ public class RedissonLockTest extends BaseConcurrentTest {
         thread_2.interrupt(); // interrupte the thread-2
         boolean res = latch.await(2, TimeUnit.SECONDS);
         assertThat(res).isFalse();
+
+        latch.await();
     }
     
     @Test


### PR DESCRIPTION
[issues/6202](https://github.com/redisson/redisson/issues/6202)