### PR TITLE
RRateLimiter  update rate, keeps state

### DIFF
--- a/redisson/src/main/java/org/redisson/api/RRateLimiter.java
+++ b/redisson/src/main/java/org/redisson/api/RRateLimiter.java
@@ -96,6 +96,27 @@ public interface RRateLimiter extends RRateLimiterAsync, RExpirable {
     void setRate(RateType mode, long rate, Duration rateInterval, Duration keepAliveTime);
 
     /**
+     * Updates the rate limit.
+     * Keeps state
+     *
+     * @param mode rate mode
+     * @param rate rate
+     * @param rateInterval rate time interval
+     */
+    void updateRate(RateType mode, long rate, Duration rateInterval);
+
+    /**
+     * Updates time to live, the rate limit
+     * Keeps state
+     *
+     * @param mode rate mode
+     * @param rate rate
+     * @param rateInterval rate time interval
+     * @param keepAliveTime this is the maximum time that key will wait for new acquire before delete
+     */
+    void updateRate(RateType mode, long rate, Duration rateInterval, Duration keepAliveTime);
+
+    /**
      * Acquires a permit only if one is available at the
      * time of invocation.
      *

--- a/redisson/src/main/java/org/redisson/api/RRateLimiterAsync.java
+++ b/redisson/src/main/java/org/redisson/api/RRateLimiterAsync.java
@@ -225,6 +225,27 @@ public interface RRateLimiterAsync extends RExpirableAsync {
     RFuture<Void> setRateAsync(RateType mode, long rate, Duration rateInterval, Duration keepAliveTime);
 
     /**
+     * Updates the rate limit.
+     * Keeps both limit and state
+     *
+     * @param mode rate mode
+     * @param rate rate
+     * @param rateInterval rate time interval
+     */
+    RFuture<Void> updateRateAsync(RateType mode, long rate, Duration rateInterval);
+
+    /**
+     * Updates time to live, the rate limit
+     * Keeps both limit and state
+     *
+     * @param mode rate mode
+     * @param rate rate
+     * @param rateInterval rate time interval
+     * @param keepAliveTime this is the maximum time that key will wait for new acquire before delete
+     */
+    RFuture<Void> updateRateAsync(RateType mode, long rate, Duration rateInterval, Duration keepAliveTime);
+
+    /**
      * Returns current configuration of this RateLimiter object.
      * 
      * @return config object

--- a/redisson/src/test/java/org/redisson/RedissonRateLimiterTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonRateLimiterTest.java
@@ -366,5 +366,45 @@ public class RedissonRateLimiterTest extends RedisDockerTest {
         //clean all keys in test
         redisson.getKeys().deleteByPattern("*test_change_rate*");
     }
-    
+
+    @Test
+    public void testUpdateRate() {
+        RRateLimiter rr = redisson.getRateLimiter("test_update_rate");
+        rr.setRate(RateType.PER_CLIENT, 1, Duration.ofSeconds(1));
+        assertThat(rr.getConfig().getRate()).isEqualTo(1);
+        long start = System.currentTimeMillis();
+        for (int i = 0; i < 10; i++) {
+            rr.acquire();
+            assertThat(System.currentTimeMillis() - start / 1000).isEqualTo(i);
+        }
+        rr.updateRate(RateType.PER_CLIENT, 2, Duration.ofSeconds(1));
+        assertThat(rr.getConfig().getRate()).isEqualTo(2);
+        start = System.currentTimeMillis();
+        for (int i = 0; i < 10; i++) {
+            rr.acquire();
+            assertThat(System.currentTimeMillis() - start / 1000).isEqualTo(i/2);
+        }
+        rr.updateRate(RateType.PER_CLIENT, 4, Duration.ofSeconds(1));
+        assertThat(rr.getConfig().getRate()).isEqualTo(4);
+        start = System.currentTimeMillis();
+        for (int i = 0; i < 10; i++) {
+            rr.acquire();
+            assertThat(System.currentTimeMillis() - start / 1000).isEqualTo(i/4);
+        }
+        rr.updateRate(RateType.PER_CLIENT, 8, Duration.ofSeconds(1));
+        assertThat(rr.getConfig().getRate()).isEqualTo(8);
+        start = System.currentTimeMillis();
+        for (int i = 0; i < 10; i++) {
+            rr.acquire();
+            assertThat(System.currentTimeMillis() - start / 1000).isEqualTo(i/8);
+        }
+        rr.updateRate(RateType.PER_CLIENT, 1, Duration.ofSeconds(1));
+        assertThat(rr.getConfig().getRate()).isEqualTo(1);
+        start = System.currentTimeMillis();
+        for (int i = 0; i < 10; i++) {
+            rr.acquire();
+            assertThat(System.currentTimeMillis() - start / 1000).isEqualTo(i);
+        }
+    }
+
 }


### PR DESCRIPTION
[https://github.com/redisson/redisson/issues/6499](https://github.com/redisson/redisson/issues/6499)
The RRateLimiter setRate method does not keep state.
For some reason, we need another method to update the rate while preserving the remaining state (such as tokens).