### PR TITLE
RRateLimiter update rate, keeps state

### DIFF
--- a/redisson/src/main/java/org/redisson/api/RRateLimiter.java
+++ b/redisson/src/main/java/org/redisson/api/RRateLimiter.java
@@ -96,6 +96,27 @@ public interface RRateLimiter extends RRateLimiterAsync, RExpirable {
     void setRate(RateType mode, long rate, Duration rateInterval, Duration keepAliveTime);
 
     /**
+     * Updates the rate limit.
+     * Keeps state
+     *
+     * @param mode rate mode
+     * @param rate rate
+     * @param rateInterval rate time interval
+     */
+    void updateRate(RateType mode, long rate, Duration rateInterval);
+
+    /**
+     * Updates the rate limit.
+     * Keeps state
+     *
+     * @param mode rate mode
+     * @param rate rate
+     * @param rateInterval rate time interval
+     * @param keepAliveTime this is the maximum time that the limiter will wait for a new acquisition before deletion
+     */
+    void updateRate(RateType mode, long rate, Duration rateInterval, Duration keepAliveTime);
+
+    /**
      * Acquires a permit only if one is available at the
      * time of invocation.
      *

--- a/redisson/src/main/java/org/redisson/api/RRateLimiterAsync.java
+++ b/redisson/src/main/java/org/redisson/api/RRateLimiterAsync.java
@@ -225,6 +225,27 @@ public interface RRateLimiterAsync extends RExpirableAsync {
     RFuture<Void> setRateAsync(RateType mode, long rate, Duration rateInterval, Duration keepAliveTime);
 
     /**
+     * Updates the rate limit.
+     * Keeps both limit and state
+     *
+     * @param mode rate mode
+     * @param rate rate
+     * @param rateInterval rate time interval
+     */
+    RFuture<Void> updateRateAsync(RateType mode, long rate, Duration rateInterval);
+
+    /**
+     * Updates the rate limit.
+     * Keeps both limit and state
+     *
+     * @param mode rate mode
+     * @param rate rate
+     * @param rateInterval rate time interval
+     * @param keepAliveTime this is the maximum time that key will wait for new acquire before delete
+     */
+    RFuture<Void> updateRateAsync(RateType mode, long rate, Duration rateInterval, Duration keepAliveTime);
+
+    /**
      * Returns current configuration of this RateLimiter object.
      * 
      * @return config object

--- a/redisson/src/main/java/org/redisson/api/RRateLimiterReactive.java
+++ b/redisson/src/main/java/org/redisson/api/RRateLimiterReactive.java
@@ -88,6 +88,27 @@ public interface RRateLimiterReactive extends RExpirableReactive {
     Mono<Void> setRate(RateType mode, long rate, Duration rateInterval);
 
     /**
+     * Updates the rate limit.
+     * Keeps state
+     *
+     * @param mode rate mode
+     * @param rate rate
+     * @param rateInterval rate time interval
+     * @param keepAliveTime this is the maximum time that the limiter will wait for a new acquisition before deletion
+     */
+    Mono<Void> updateRate(RateType mode, long rate, Duration rateInterval, Duration keepAliveTime);
+
+    /**
+     * Updates the rate limit.
+     * Keeps state
+     *
+     * @param mode rate mode
+     * @param rate rate
+     * @param rateInterval rate time interval
+     */
+    Mono<Void> updateRate(RateType mode, long rate, Duration rateInterval);
+
+    /**
      * Sets time to live, the rate limit, and clears the state.
      * Overrides both limit and state if they haven't been set before.
      *

--- a/redisson/src/main/java/org/redisson/api/RRateLimiterRx.java
+++ b/redisson/src/main/java/org/redisson/api/RRateLimiterRx.java
@@ -86,6 +86,27 @@ public interface RRateLimiterRx extends RExpirableRx {
      * @param rate rate
      * @param rateInterval rate time interval
      */
+    Single<Void> updateRate(RateType mode, long rate, Duration rateInterval);
+
+    /**
+     * Updates the rate limit.
+     * Keeps state
+     *
+     * @param mode rate mode
+     * @param rate rate
+     * @param rateInterval rate time interval
+     * @param keepAliveTime this is the maximum time that the limiter will wait for a new acquisition before deletion
+     */
+    Single<Void> updateRate(RateType mode, long rate, Duration rateInterval, Duration keepAliveTime);
+
+    /**
+     * Updates the rate limit.
+     * Keeps state
+     *
+     * @param mode rate mode
+     * @param rate rate
+     * @param rateInterval rate time interval
+     */
     Single<Void> setRate(RateType mode, long rate, Duration rateInterval);
 
     /**


### PR DESCRIPTION
[https://github.com/redisson/redisson/issues/6499](https://github.com/redisson/redisson/issues/6499)
The RRateLimiter setRate method does not keep state.
For some reason, we need another method to update the rate while preserving the remaining state (such as tokens).