### PR TITLE
Improvement - Add check, The parameter keepAliveTime should be greater than or equal to rateInterval

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonRateLimiter.java
+++ b/redisson/src/main/java/org/redisson/RedissonRateLimiter.java
@@ -322,6 +322,9 @@ public final class RedissonRateLimiter extends RedissonExpirable implements RRat
 
     @Override
     public RFuture<Void> setRateAsync(RateType type, long rate, Duration rateInterval, Duration keepAliveTime) {
+        if (!keepAliveTime.equals(Duration.ZERO) && keepAliveTime.toMillis() < rateInterval.toMillis()) {
+            throw new IllegalArgumentException("The parameter keepAliveTime should be greater than or equal to rateInterval");
+        }
         return commandExecutor.evalWriteAsync(getRawName(), LongCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
                 "local valueName = KEYS[2];"
                     + "local permitsName = KEYS[4];"

--- a/redisson/src/main/java/org/redisson/RedissonRateLimiter.java
+++ b/redisson/src/main/java/org/redisson/RedissonRateLimiter.java
@@ -322,7 +322,7 @@ public final class RedissonRateLimiter extends RedissonExpirable implements RRat
 
     @Override
     public RFuture<Void> setRateAsync(RateType type, long rate, Duration rateInterval, Duration keepAliveTime) {
-        if (!keepAliveTime.equals(Duration.ZERO) && keepAliveTime.toMillis() < rateInterval.toMillis()) {
+        if (!keepAliveTime.isZero() && keepAliveTime.toMillis() < rateInterval.toMillis()) {
             throw new IllegalArgumentException("The parameter keepAliveTime should be greater than or equal to rateInterval");
         }
         return commandExecutor.evalWriteAsync(getRawName(), LongCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,


### PR DESCRIPTION
Improvement - Add check, The parameter keepAliveTime should be greater than or equal to rateInterval
Here are the reasons:
If the expiration time is less than the time window, the data will be deleted in advance, the actual statistical time of the time window will be shortened, and the request cannot be correctly counted, triggering misjudgment or missed judgment.
Example:
Assuming the expiration time is 0.6 seconds, the time window is 1 second, and the limit is 3 times, the first request is at 0 seconds, the second request is at 0.1 seconds, and the third request is at 0.2 seconds. At this time, there is no request until 0.8 seconds, then zset will expire, and the fourth request is at 0.9 seconds. Since zset has been deleted, there is only the fourth request from 0 to 0.9 seconds, so there will be no flow restriction, but it should be limited in reality, which is not as expected! If the expiration time>=time window, there will be no problem.