### PR TITLE
Add support for atomic objects in Kryo5Codec

### DIFF
--- a/redisson/src/main/java/org/redisson/codec/Kryo5Codec.java
+++ b/redisson/src/main/java/org/redisson/codec/Kryo5Codec.java
@@ -41,6 +41,10 @@ import java.net.InetAddress;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
 import static com.esotericsoftware.kryo.util.Util.className;
@@ -170,6 +174,10 @@ public class Kryo5Codec extends BaseCodec {
         kryo.addDefaultSerializer(Pattern.class, new DefaultSerializers.PatternSerializer());
         kryo.addDefaultSerializer(SocketAddress.class, new JavaSerializer());
         kryo.addDefaultSerializer(InetAddress.class, new JavaSerializer());
+        kryo.addDefaultSerializer(AtomicBoolean.class, new DefaultSerializers.AtomicBooleanSerializer());
+        kryo.addDefaultSerializer(AtomicInteger.class, new DefaultSerializers.AtomicIntegerSerializer());
+        kryo.addDefaultSerializer(AtomicLong.class, new DefaultSerializers.AtomicLongSerializer());
+        kryo.addDefaultSerializer(AtomicReference.class, new DefaultSerializers.AtomicReferenceSerializer());
         return kryo;
     }
 

--- a/redisson/src/test/java/org/redisson/codec/Kryo5CodecTest.java
+++ b/redisson/src/test/java/org/redisson/codec/Kryo5CodecTest.java
@@ -4,10 +4,11 @@ import io.netty.buffer.ByteBuf;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.EnumMap;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.Map;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -71,6 +72,31 @@ public class Kryo5CodecTest {
         ByteBuf r = cc.getValueEncoder().encode(map);
         Map mm = (Map) cc.getValueDecoder().decode(r, null);
         assertThat(mm).isEqualTo(map);
+    }
+
+    @Test
+    public void testAtomicObjects() throws IOException {
+        Kryo5Codec cc = new Kryo5Codec();
+
+        AtomicBoolean v1 = new AtomicBoolean(true);
+        ByteBuf b1 = cc.getValueEncoder().encode(v1);
+        AtomicBoolean v1_1 = (AtomicBoolean)cc.getValueDecoder().decode(b1, null);
+        assertThat(v1_1).isTrue();
+
+        AtomicInteger v2 = new AtomicInteger(3);
+        ByteBuf b2 = cc.getValueEncoder().encode(v2);
+        AtomicInteger v2_1 = (AtomicInteger)cc.getValueDecoder().decode(b2, null);
+        assertThat(v2_1.get()).isEqualTo(3);
+
+        AtomicLong v3 = new AtomicLong(3L);
+        ByteBuf b3 = cc.getValueEncoder().encode(v3);
+        AtomicLong v3_1 = (AtomicLong)cc.getValueDecoder().decode(b3, null);
+        assertThat(v3_1.get()).isEqualTo(3L);
+
+        AtomicReference<String> v4 = new AtomicReference<>("123");
+        ByteBuf b4 = cc.getValueEncoder().encode(v4);
+        AtomicReference<String> v4_1 = (AtomicReference<String>)cc.getValueDecoder().decode(b4, null);
+        assertThat(v4_1.get()).isEqualTo("123");
     }
 
 }


### PR DESCRIPTION
Currently AtomicBoolean, AtomicInteger, AtomicLong and AtomicReference are not supported by the Kryo5Codec. However, the kryo lib supplies serializers for those classes. This patch registers those serializers in Kryo5Codec.