### PR TITLE
Support custom tasksInjector

### DIFF
--- a/redisson/src/main/java/org/redisson/api/WorkerOptions.java
+++ b/redisson/src/main/java/org/redisson/api/WorkerOptions.java
@@ -83,6 +83,11 @@ public final class WorkerOptions {
         return this;
     }
 
+    public WorkerOptions tasksInjector(TasksInjector tasksInjector) {
+        this.tasksInjector = tasksInjector;
+        return this;
+    }
+
     public TasksInjector getTasksInjector() {
         return tasksInjector;
     }


### PR DESCRIPTION
As mentioned in #6525, there may be some injection scenarios for non-Spring, but WorkerOptions.beanFactory() is bound to SpringTasksInjector.