### PR TITLE
Fix unused server config

### DIFF
--- a/redisson/src/main/java/org/redisson/config/Config.java
+++ b/redisson/src/main/java/org/redisson/config/Config.java
@@ -259,7 +259,7 @@ public class Config {
         checkSingleServerConfig();
 
         if (replicatedServersConfig == null) {
-            replicatedServersConfig = new ReplicatedServersConfig();
+            replicatedServersConfig = config;
         }
         return replicatedServersConfig;
     }


### PR DESCRIPTION
Dear Redisson team,

I'm not sure if this was intentional, but the `ReplicatedServersConfig config` parameter passed to the function wasn't being used anywhere else. I've checked the code usage and it was used by `#useReplicatedServers` method only so I think it was supposed to assign to `replicatedServersConfig` property.

If this was designed intentionally by the team, feel free to close this pull request.

Best regards,