### PR TITLE
fix typo in BaseMasterSlaveServersConfig docs

### DIFF
--- a/redisson/src/main/java/org/redisson/config/BaseMasterSlaveServersConfig.java
+++ b/redisson/src/main/java/org/redisson/config/BaseMasterSlaveServersConfig.java
@@ -29,7 +29,7 @@ import org.redisson.connection.balancer.RoundRobinLoadBalancer;
 public class BaseMasterSlaveServersConfig<T extends BaseMasterSlaveServersConfig<T>> extends BaseConfig<T> {
 
     /**
-     * Сonnection load balancer for multiple Redis slave servers
+     * Connection load balancer for multiple Redis slave servers
      */
     private LoadBalancer loadBalancer = new RoundRobinLoadBalancer();
 
@@ -174,7 +174,7 @@ public class BaseMasterSlaveServersConfig<T extends BaseMasterSlaveServersConfig
     }
 
     /**
-     * Сonnection load balancer to multiple Redis slave servers.
+     * Connection load balancer to multiple Redis slave servers.
      * Uses Round-robin algorithm by default
      *
      * @param loadBalancer object


### PR DESCRIPTION
Hello, I found that the C in Connection here is not a common Latin letter, which will cause us to be unable to search for it using the Latin letter Connection search. I think maybe we should change it to a common Latin letter.


<img width="852" alt="image" src="https://github.com/user-attachments/assets/3bea7cd0-3ec6-4df3-8cdb-614d9dafa4d6" />
