### PR TITLE
Add support for Tomcat SSO

### DIFF
--- a/docs/web-session-management.md
+++ b/docs/web-session-management.md
@@ -84,6 +84,15 @@ Tomcat 11.x - [redisson-tomcat-11-3.45.1.jar](https://repo1.maven.org/maven2/org
 
 [Redisson PRO vs. Community Edition ➜](https://redisson.pro/feature-comparison.html)
 
+**3. (optional) Enable SingleSignOn:**
+
+
+To use Redisson also for SingleSignOn (SSO) within multiple applications on single or multiple Tomcats, add following code into `tomcat/conf/server.xml` in `Host` tag area
+
+```xml
+        <Valve className="org.redisson.tomcat.RedissonSingleSignOn" />
+```
+
 ## Spring Session
 
 For information on using Spring Session implementation, please refer to the [Spring Session](integration-with-spring.md/#spring-session) documentation.

--- a/docs/web-session-management.md
+++ b/docs/web-session-management.md
@@ -70,17 +70,17 @@ Amount of Redisson instances created by Tomcat for multiple contexts could be re
 **2. Copy two jars into `TOMCAT_BASE/lib` directory:**
 
 
-[redisson-all-3.45.1.jar](https://repo1.maven.org/maven2/org/redisson/redisson-all/3.45.1/redisson-all-3.45.1.jar)
+[redisson-all-3.50.0.jar](https://repo1.maven.org/maven2/org/redisson/redisson-all/3.50.0/redisson-all-3.50.0.jar)
 
-Tomcat 7.x - [redisson-tomcat-7-3.45.1.jar](https://repo1.maven.org/maven2/org/redisson/redisson-tomcat-7/3.45.1/redisson-tomcat-7-3.45.1.jar)  
+Tomcat 7.x - [redisson-tomcat-7-3.50.0.jar](https://repo1.maven.org/maven2/org/redisson/redisson-tomcat-7/3.50.0/redisson-tomcat-7-3.50.0.jar)  
 
-Tomcat 8.x - [redisson-tomcat-8-3.45.1.jar](https://repo1.maven.org/maven2/org/redisson/redisson-tomcat-8/3.45.1/redisson-tomcat-8-3.45.1.jar)  
+Tomcat 8.x - [redisson-tomcat-8-3.50.0.jar](https://repo1.maven.org/maven2/org/redisson/redisson-tomcat-8/3.50.0/redisson-tomcat-8-3.50.0.jar)  
 
-Tomcat 9.x - [redisson-tomcat-9-3.45.1.jar](https://repo1.maven.org/maven2/org/redisson/redisson-tomcat-9/3.45.1/redisson-tomcat-9-3.45.1.jar)  
+Tomcat 9.x - [redisson-tomcat-9-3.50.0.jar](https://repo1.maven.org/maven2/org/redisson/redisson-tomcat-9/3.50.0/redisson-tomcat-9-3.50.0.jar)  
 
-Tomcat 10.x - [redisson-tomcat-10-3.45.1.jar](https://repo1.maven.org/maven2/org/redisson/redisson-tomcat-10/3.45.1/redisson-tomcat-10-3.45.1.jar)  
+Tomcat 10.x - [redisson-tomcat-10-3.50.0.jar](https://repo1.maven.org/maven2/org/redisson/redisson-tomcat-10/3.50.0/redisson-tomcat-10-3.50.0.jar)  
 
-Tomcat 11.x - [redisson-tomcat-11-3.45.1.jar](https://repo1.maven.org/maven2/org/redisson/redisson-tomcat-11/3.45.1/redisson-tomcat-11-3.45.1.jar)  
+Tomcat 11.x - [redisson-tomcat-11-3.50.0.jar](https://repo1.maven.org/maven2/org/redisson/redisson-tomcat-11/3.50.0/redisson-tomcat-11-3.50.0.jar)  
 
 [Redisson PRO vs. Community Edition ➜](https://redisson.pro/feature-comparison.html)
 

--- a/redisson-tomcat/redisson-tomcat-10/src/main/java/org/redisson/tomcat/RedissonSingleSignOn.java
+++ b/redisson-tomcat/redisson-tomcat-10/src/main/java/org/redisson/tomcat/RedissonSingleSignOn.java
@@ -1,0 +1,193 @@
+/**
+ * Copyright (c) 2013-2024 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.tomcat;
+
+import java.io.IOException;
+import java.security.Principal;
+import org.apache.catalina.Realm;
+import org.apache.catalina.Session;
+import org.apache.catalina.authenticator.SingleSignOn;
+import org.apache.catalina.authenticator.SingleSignOnEntry;
+import org.apache.catalina.connector.Request;
+import org.apache.catalina.connector.Response;
+import org.apache.tomcat.util.res.StringManager;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+
+/**
+ * Extended implementation of Tomcat SSO valve to use Redis or Valkey as a storage.
+ * This allows to cluster Tomcat without sticky sessions.
+ */
+public class RedissonSingleSignOn extends SingleSignOn {
+
+  private static final StringManager sm = StringManager.getManager(RedissonSingleSignOn.class);
+  private static final String SSO_SESSION_ENTRIES = "redisson:tomcat_sso";
+
+  private RedissonSessionManager manager;
+
+  void setSessionManager(RedissonSessionManager manager) {
+    if (containerLog.isTraceEnabled()) {
+      containerLog.trace(sm.getString("redissonSingleSignOn.trace.setSessionManager", manager));
+  }
+    this.manager = manager;
+  }
+
+  @Override
+  public void invoke(Request request, Response response) throws IOException, ServletException {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.invoke"));
+      }
+      String ssoSessionId = getSsoSessionId(request);
+      if (ssoSessionId != null) {
+        SingleSignOnEntry ssoEntry = getSsoEntry(ssoSessionId);
+        if (ssoEntry != null) {
+          cache.put(ssoSessionId, ssoEntry);
+        }
+      }
+      super.invoke(request, response);
+  }
+
+  @Override
+  public void sessionDestroyed(String ssoId, Session session) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.sessionDestroyed"));
+      }
+      super.sessionDestroyed(ssoId, session);
+      manager.getMap(SSO_SESSION_ENTRIES).fastRemove(ssoId);
+  }
+
+  @Override
+  protected boolean associate(String ssoId, Session session) {
+      if (containerLog.isTraceEnabled()) {
+        containerLog.trace(sm.getString("redissonSingleSignOn.trace.associate", ssoId, session));
+      }
+      SingleSignOnEntry sso = this.getSsoEntry(ssoId);
+      if (sso != null) {
+          cache.put(ssoId, sso);
+      }
+      boolean associated = super.associate(ssoId, session);
+      if (associated) {
+          manager.getMap(SSO_SESSION_ENTRIES).fastPut(ssoId, sso);
+      }
+      return associated;
+  }
+
+  @Override
+  protected boolean reauthenticate(String ssoId, Realm realm, Request request) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.reauthenticate"));
+      }
+      SingleSignOnEntry sso = this.getSsoEntry(ssoId);
+      if (sso != null) {
+          cache.put(ssoId, sso);
+      }
+      return super.reauthenticate(ssoId, realm, request);
+  }
+
+  @Override
+  protected void register(String ssoId, Principal principal, String authType, String username, String password) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.register"));
+      }  
+      super.register(ssoId, principal, authType, username, password);
+      manager.getMap(SSO_SESSION_ENTRIES).fastPut(ssoId, cache.get(ssoId));
+  }
+
+  @Override
+  protected void deregister(String ssoId) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.deregister"));
+      }
+      super.deregister(ssoId);
+      manager.getMap(SSO_SESSION_ENTRIES).fastRemove(ssoId);
+  }
+
+  @Override
+  protected boolean update(String ssoId, Principal principal, String authType, String username, String password) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.update"));
+      }
+      SingleSignOnEntry sso = this.getSsoEntry(ssoId);
+      if (sso != null) {
+          cache.put(ssoId, sso);
+      }
+      boolean updated = super.update(ssoId, principal, authType, username, password);
+      if (updated) {
+          manager.getMap(SSO_SESSION_ENTRIES).fastPut(ssoId, sso);
+      }
+      return updated;
+  }
+
+  @Override
+  protected void removeSession(String ssoId, Session session) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.removeSession", session, ssoId));
+      }
+      SingleSignOnEntry sso = this.getSsoEntry(ssoId);
+      if (sso == null) {
+          return;
+      }
+      cache.put(ssoId, sso);
+      super.removeSession(ssoId, session);
+      if (sso.findSessions().isEmpty()) {
+        deregister(ssoId);
+      }
+  }
+
+  /**
+   * Lookup {@code SingleSignOnEntry} for the given SSO ID.
+   *
+   * @param ssoSessionId SSO session id we are looking for
+   * @return matching {@code SingleSignOnEntry} instance or null when not found
+   */
+  private SingleSignOnEntry getSsoEntry(String ssoSessionId) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.getSsoEntry", ssoSessionId));
+      }
+      SingleSignOnEntry entry = (SingleSignOnEntry) manager.getMap(SSO_SESSION_ENTRIES).get(ssoSessionId);
+      if (entry != null) {
+          this.cache.put(ssoSessionId, entry);
+      }
+      return entry;
+  }
+
+  /**
+   * Retrieve SSO session ID from provided cookies in the request.
+   *
+   * @param request The request that has been sent to the server.
+   * @return SSO session ID provided with the request or null when none provided
+   */
+  private String getSsoSessionId(Request request) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.getSsoSessionId", request.getRequestURI()));
+      }
+      Cookie cookie = null;
+      Cookie[] cookies = request.getCookies();
+      if (cookies != null) {
+          for (Cookie value : cookies) {
+              if (getCookieName().equals(value.getName())) {
+                  cookie = value;
+                  break;
+              }
+          }
+      }
+      if (cookie != null) {
+          return cookie.getValue();
+      }
+      return null;
+  }
+
+}

--- a/redisson-tomcat/redisson-tomcat-11/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-11/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -271,6 +271,7 @@ public class RedissonSessionManager extends ManagerBase {
         
         Pipeline pipeline = getContext().getPipeline();
         synchronized (pipeline) {
+            tryInitSsoValve();
             if (readMode == ReadMode.REDIS) {
                 Optional<Valve> res = Arrays.stream(pipeline.getValves()).filter(v -> v.getClass() == UsageValve.class).findAny();
                 if (res.isPresent()) {
@@ -435,6 +436,27 @@ public class RedissonSessionManager extends ManagerBase {
             sess.superEndAccess();
             sess.save();
         }
+    }
+
+    private void tryInitSsoValve() {
+        Container c = getContext();
+        // SSO valve has to be in defined in Host
+        // it won't be picked up by Catalina from within Context
+        while (c != null && !(c instanceof org.apache.catalina.Host)) {
+            c = c.getParent();
+        }
+        if (c == null) {
+            log.warn("No Catalina Host found for current context. Can't configure Redisson SSO.");
+            return;
+        }
+        for (Valve valve : ((Host) c).getPipeline().getValves()) {
+            if (valve instanceof RedissonSingleSignOn) {
+                log.debug("Found SSO valve, passing RedissionSessionManager to it.");
+                ((RedissonSingleSignOn) valve).setSessionManager(this);
+                return;
+            }
+        }
+        log.trace("No Redisson SSO valve found. Redisson SSO is not configured.");
     }
     
 }

--- a/redisson-tomcat/redisson-tomcat-11/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-11/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -458,5 +458,5 @@ public class RedissonSessionManager extends ManagerBase {
         }
         log.trace("No Redisson SSO valve found. Redisson SSO is not configured.");
     }
-    
+
 }

--- a/redisson-tomcat/redisson-tomcat-11/src/main/java/org/redisson/tomcat/RedissonSingleSignOn.java
+++ b/redisson-tomcat/redisson-tomcat-11/src/main/java/org/redisson/tomcat/RedissonSingleSignOn.java
@@ -12,6 +12,10 @@ import org.apache.tomcat.util.res.StringManager;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 
+/**
+ * Extended implementation of Tomcat SSO valve to use Redis or Valkey as a storage.
+ * This allows to cluster Tomcat without sticky sessions.
+ */
 public class RedissonSingleSignOn extends SingleSignOn {
 
   private static final StringManager sm = StringManager.getManager(RedissonSingleSignOn.class);
@@ -61,7 +65,7 @@ public class RedissonSingleSignOn extends SingleSignOn {
       }
       boolean associated = super.associate(ssoId, session);
       if (associated) {
-          manager.getMap(SSO_SESSION_ENTRIES).put(ssoId, sso);
+          manager.getMap(SSO_SESSION_ENTRIES).fastPut(ssoId, sso);
       }
       return associated;
   }
@@ -84,7 +88,7 @@ public class RedissonSingleSignOn extends SingleSignOn {
           containerLog.trace(sm.getString("redissonSingleSignOn.trace.register"));
       }  
       super.register(ssoId, principal, authType, username, password);
-      manager.getMap(SSO_SESSION_ENTRIES).put(ssoId, cache.get(ssoId));
+      manager.getMap(SSO_SESSION_ENTRIES).fastPut(ssoId, cache.get(ssoId));
   }
 
   @Override
@@ -107,7 +111,7 @@ public class RedissonSingleSignOn extends SingleSignOn {
       }
       boolean updated = super.update(ssoId, principal, authType, username, password);
       if (updated) {
-          manager.getMap(SSO_SESSION_ENTRIES).put(ssoId, sso);
+          manager.getMap(SSO_SESSION_ENTRIES).fastPut(ssoId, sso);
       }
       return updated;
   }

--- a/redisson-tomcat/redisson-tomcat-11/src/main/java/org/redisson/tomcat/RedissonSingleSignOn.java
+++ b/redisson-tomcat/redisson-tomcat-11/src/main/java/org/redisson/tomcat/RedissonSingleSignOn.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (c) 2013-2024 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.redisson.tomcat;
 
 import java.io.IOException;

--- a/redisson-tomcat/redisson-tomcat-11/src/main/java/org/redisson/tomcat/RedissonSingleSignOn.java
+++ b/redisson-tomcat/redisson-tomcat-11/src/main/java/org/redisson/tomcat/RedissonSingleSignOn.java
@@ -1,0 +1,174 @@
+package org.redisson.tomcat;
+
+import java.io.IOException;
+import java.security.Principal;
+import org.apache.catalina.Realm;
+import org.apache.catalina.Session;
+import org.apache.catalina.authenticator.SingleSignOn;
+import org.apache.catalina.authenticator.SingleSignOnEntry;
+import org.apache.catalina.connector.Request;
+import org.apache.catalina.connector.Response;
+import org.apache.tomcat.util.res.StringManager;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+
+public class RedissonSingleSignOn extends SingleSignOn {
+
+  private static final StringManager sm = StringManager.getManager(RedissonSingleSignOn.class);
+  private static final String SSO_SESSION_ENTRIES = "redisson:tomcat_sso";
+
+  private RedissonSessionManager manager;
+
+  void setSessionManager(RedissonSessionManager manager) {
+    if (containerLog.isTraceEnabled()) {
+      containerLog.trace(sm.getString("redissonSingleSignOn.trace.setSessionManager", manager));
+  }
+    this.manager = manager;
+  }
+
+  @Override
+  public void invoke(Request request, Response response) throws IOException, ServletException {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.invoke"));
+      }
+      String ssoSessionId = getSsoSessionId(request);
+      if (ssoSessionId != null) {
+        SingleSignOnEntry ssoEntry = getSsoEntry(ssoSessionId);
+        if (ssoEntry != null) {
+          cache.put(ssoSessionId, ssoEntry);
+        }
+      }
+      super.invoke(request, response);
+  }
+
+  @Override
+  public void sessionDestroyed(String ssoId, Session session) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.sessionDestroyed"));
+      }
+      super.sessionDestroyed(ssoId, session);
+      manager.getMap(SSO_SESSION_ENTRIES).fastRemove(ssoId);
+  }
+
+  @Override
+  protected boolean associate(String ssoId, Session session) {
+      if (containerLog.isTraceEnabled()) {
+        containerLog.trace(sm.getString("redissonSingleSignOn.trace.associate", ssoId, session));
+      }
+      SingleSignOnEntry sso = this.getSsoEntry(ssoId);
+      if (sso != null) {
+          cache.put(ssoId, sso);
+      }
+      boolean associated = super.associate(ssoId, session);
+      if (associated) {
+          manager.getMap(SSO_SESSION_ENTRIES).put(ssoId, sso);
+      }
+      return associated;
+  }
+
+  @Override
+  protected boolean reauthenticate(String ssoId, Realm realm, Request request) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.reauthenticate"));
+      }
+      SingleSignOnEntry sso = this.getSsoEntry(ssoId);
+      if (sso != null) {
+          cache.put(ssoId, sso);
+      }
+      return super.reauthenticate(ssoId, realm, request);
+  }
+
+  @Override
+  protected void register(String ssoId, Principal principal, String authType, String username, String password) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.register"));
+      }  
+      super.register(ssoId, principal, authType, username, password);
+      manager.getMap(SSO_SESSION_ENTRIES).put(ssoId, cache.get(ssoId));
+  }
+
+  @Override
+  protected void deregister(String ssoId) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.deregister"));
+      }
+      super.deregister(ssoId);
+      manager.getMap(SSO_SESSION_ENTRIES).fastRemove(ssoId);
+  }
+
+  @Override
+  protected boolean update(String ssoId, Principal principal, String authType, String username, String password) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.update"));
+      }
+      SingleSignOnEntry sso = this.getSsoEntry(ssoId);
+      if (sso != null) {
+          cache.put(ssoId, sso);
+      }
+      boolean updated = super.update(ssoId, principal, authType, username, password);
+      if (updated) {
+          manager.getMap(SSO_SESSION_ENTRIES).put(ssoId, sso);
+      }
+      return updated;
+  }
+
+  @Override
+  protected void removeSession(String ssoId, Session session) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.removeSession", session, ssoId));
+      }
+      SingleSignOnEntry sso = this.getSsoEntry(ssoId);
+      if (sso == null) {
+          return;
+      }
+      cache.put(ssoId, sso);
+      super.removeSession(ssoId, session);
+      if (sso.findSessions().isEmpty()) {
+        deregister(ssoId);
+      }
+  }
+
+  /**
+   * Lookup {@code SingleSignOnEntry} for the given SSO ID.
+   *
+   * @param ssoSessionId SSO session id we are looking for
+   * @return matching {@code SingleSignOnEntry} instance or null when not found
+   */
+  private SingleSignOnEntry getSsoEntry(String ssoSessionId) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.getSsoEntry", ssoSessionId));
+      }
+      SingleSignOnEntry entry = (SingleSignOnEntry) manager.getMap(SSO_SESSION_ENTRIES).get(ssoSessionId);
+      if (entry != null) {
+          this.cache.put(ssoSessionId, entry);
+      }
+      return entry;
+  }
+
+  /**
+   * Retrieve SSO session ID from provided cookies in the request.
+   *
+   * @param request The request that has been sent to the server.
+   * @return SSO session ID provided with the request or null when none provided
+   */
+  private String getSsoSessionId(Request request) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.getSsoSessionId", request.getRequestURI()));
+      }
+      Cookie cookie = null;
+      Cookie[] cookies = request.getCookies();
+      if (cookies != null) {
+          for (Cookie value : cookies) {
+              if (getCookieName().equals(value.getName())) {
+                  cookie = value;
+                  break;
+              }
+          }
+      }
+      if (cookie != null) {
+          return cookie.getValue();
+      }
+      return null;
+  }
+
+}

--- a/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -271,6 +271,7 @@ public class RedissonSessionManager extends ManagerBase {
         
         Pipeline pipeline = getContainer().getPipeline();
         synchronized (pipeline) {
+            tryInitSsoValve();
             if (readMode == ReadMode.REDIS) {
                 Optional<Valve> res = Arrays.stream(pipeline.getValves()).filter(v -> v.getClass() == UsageValve.class).findAny();
                 if (res.isPresent()) {
@@ -436,5 +437,26 @@ public class RedissonSessionManager extends ManagerBase {
             sess.save();
         }
     }
-    
+
+    private void tryInitSsoValve() {
+        Container c = getContainer();
+        // SSO valve has to be in defined in Host
+        // it won't be picked up by Catalina from within Context
+        while (c != null && !(c instanceof org.apache.catalina.Host)) {
+            c = c.getParent();
+        }
+        if (c == null) {
+            log.warn("No Catalina Host found for current context. Can't configure Redisson SSO.");
+            return;
+        }
+        for (Valve valve : ((Host) c).getPipeline().getValves()) {
+            if (valve instanceof RedissonSingleSignOn) {
+                log.debug("Found SSO valve, passing RedissionSessionManager to it.");
+                ((RedissonSingleSignOn) valve).setSessionManager(this);
+                return;
+            }
+        }
+        log.trace("No Redisson SSO valve found. Redisson SSO is not configured.");
+    }
+
 }

--- a/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSingleSignOn.java
+++ b/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSingleSignOn.java
@@ -1,0 +1,194 @@
+/**
+ * Copyright (c) 2013-2024 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.tomcat;
+
+import java.io.IOException;
+import java.security.Principal;
+import org.apache.catalina.Realm;
+import org.apache.catalina.Session;
+import org.apache.catalina.authenticator.Constants;
+import org.apache.catalina.authenticator.SingleSignOn;
+import org.apache.catalina.authenticator.SingleSignOnEntry;
+import org.apache.catalina.connector.Request;
+import org.apache.catalina.connector.Response;
+import org.apache.tomcat.util.res.StringManager;
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+
+/**
+ * Extended implementation of Tomcat SSO valve to use Redis or Valkey as a storage.
+ * This allows to cluster Tomcat without sticky sessions.
+ */
+public class RedissonSingleSignOn extends SingleSignOn {
+
+  private static final StringManager sm = StringManager.getManager(RedissonSingleSignOn.class);
+  private static final String SSO_SESSION_ENTRIES = "redisson:tomcat_sso";
+
+  private RedissonSessionManager manager;
+
+  void setSessionManager(RedissonSessionManager manager) {
+    if (containerLog.isTraceEnabled()) {
+      containerLog.trace(sm.getString("redissonSingleSignOn.trace.setSessionManager", manager));
+  }
+    this.manager = manager;
+  }
+
+  @Override
+  public void invoke(Request request, Response response) throws IOException, ServletException {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.invoke"));
+      }
+      String ssoSessionId = getSsoSessionId(request);
+      if (ssoSessionId != null) {
+        SingleSignOnEntry ssoEntry = getSsoEntry(ssoSessionId);
+        if (ssoEntry != null) {
+          cache.put(ssoSessionId, ssoEntry);
+        }
+      }
+      super.invoke(request, response);
+  }
+
+  @Override
+  public void sessionDestroyed(String ssoId, Session session) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.sessionDestroyed"));
+      }
+      super.sessionDestroyed(ssoId, session);
+      manager.getMap(SSO_SESSION_ENTRIES).fastRemove(ssoId);
+  }
+
+  @Override
+  protected boolean associate(String ssoId, Session session) {
+      if (containerLog.isTraceEnabled()) {
+        containerLog.trace(sm.getString("redissonSingleSignOn.trace.associate", ssoId, session));
+      }
+      SingleSignOnEntry sso = this.getSsoEntry(ssoId);
+      if (sso != null) {
+          cache.put(ssoId, sso);
+      }
+      boolean associated = super.associate(ssoId, session);
+      if (associated) {
+          manager.getMap(SSO_SESSION_ENTRIES).fastPut(ssoId, sso);
+      }
+      return associated;
+  }
+
+  @Override
+  protected boolean reauthenticate(String ssoId, Realm realm, Request request) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.reauthenticate"));
+      }
+      SingleSignOnEntry sso = this.getSsoEntry(ssoId);
+      if (sso != null) {
+          cache.put(ssoId, sso);
+      }
+      return super.reauthenticate(ssoId, realm, request);
+  }
+
+  @Override
+  protected void register(String ssoId, Principal principal, String authType, String username, String password) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.register"));
+      }  
+      super.register(ssoId, principal, authType, username, password);
+      manager.getMap(SSO_SESSION_ENTRIES).fastPut(ssoId, cache.get(ssoId));
+  }
+
+  @Override
+  protected void deregister(String ssoId) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.deregister"));
+      }
+      super.deregister(ssoId);
+      manager.getMap(SSO_SESSION_ENTRIES).fastRemove(ssoId);
+  }
+
+  @Override
+  protected boolean update(String ssoId, Principal principal, String authType, String username, String password) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.update"));
+      }
+      SingleSignOnEntry sso = this.getSsoEntry(ssoId);
+      if (sso != null) {
+          cache.put(ssoId, sso);
+      }
+      boolean updated = super.update(ssoId, principal, authType, username, password);
+      if (updated) {
+          manager.getMap(SSO_SESSION_ENTRIES).fastPut(ssoId, sso);
+      }
+      return updated;
+  }
+
+  @Override
+  protected void removeSession(String ssoId, Session session) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.removeSession", session, ssoId));
+      }
+      SingleSignOnEntry sso = this.getSsoEntry(ssoId);
+      if (sso == null) {
+          return;
+      }
+      cache.put(ssoId, sso);
+      super.removeSession(ssoId, session);
+      if (sso.findSessions().isEmpty()) {
+        deregister(ssoId);
+      }
+  }
+
+  /**
+   * Lookup {@code SingleSignOnEntry} for the given SSO ID.
+   *
+   * @param ssoSessionId SSO session id we are looking for
+   * @return matching {@code SingleSignOnEntry} instance or null when not found
+   */
+  private SingleSignOnEntry getSsoEntry(String ssoSessionId) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.getSsoEntry", ssoSessionId));
+      }
+      SingleSignOnEntry entry = (SingleSignOnEntry) manager.getMap(SSO_SESSION_ENTRIES).get(ssoSessionId);
+      if (entry != null) {
+          this.cache.put(ssoSessionId, entry);
+      }
+      return entry;
+  }
+
+  /**
+   * Retrieve SSO session ID from provided cookies in the request.
+   *
+   * @param request The request that has been sent to the server.
+   * @return SSO session ID provided with the request or null when none provided
+   */
+  private String getSsoSessionId(Request request) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.getSsoSessionId", request.getRequestURI()));
+      }
+      Cookie cookie = null;
+      Cookie[] cookies = request.getCookies();
+      if (cookies != null) {
+          for (Cookie value : cookies) {
+              if (Constants.SINGLE_SIGN_ON_COOKIE.equals(value.getName())) {
+                  cookie = value;
+                  break;
+              }
+          }
+      }
+      if (cookie != null) {
+          return cookie.getValue();
+      }
+      return null;
+  }
+
+}

--- a/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSingleSignOn.java
+++ b/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSingleSignOn.java
@@ -1,0 +1,193 @@
+/**
+ * Copyright (c) 2013-2024 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.tomcat;
+
+import java.io.IOException;
+import java.security.Principal;
+import org.apache.catalina.Realm;
+import org.apache.catalina.Session;
+import org.apache.catalina.authenticator.SingleSignOn;
+import org.apache.catalina.authenticator.SingleSignOnEntry;
+import org.apache.catalina.connector.Request;
+import org.apache.catalina.connector.Response;
+import org.apache.tomcat.util.res.StringManager;
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+
+/**
+ * Extended implementation of Tomcat SSO valve to use Redis or Valkey as a storage.
+ * This allows to cluster Tomcat without sticky sessions.
+ */
+public class RedissonSingleSignOn extends SingleSignOn {
+
+  private static final StringManager sm = StringManager.getManager(RedissonSingleSignOn.class);
+  private static final String SSO_SESSION_ENTRIES = "redisson:tomcat_sso";
+
+  private RedissonSessionManager manager;
+
+  void setSessionManager(RedissonSessionManager manager) {
+    if (containerLog.isTraceEnabled()) {
+      containerLog.trace(sm.getString("redissonSingleSignOn.trace.setSessionManager", manager));
+  }
+    this.manager = manager;
+  }
+
+  @Override
+  public void invoke(Request request, Response response) throws IOException, ServletException {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.invoke"));
+      }
+      String ssoSessionId = getSsoSessionId(request);
+      if (ssoSessionId != null) {
+        SingleSignOnEntry ssoEntry = getSsoEntry(ssoSessionId);
+        if (ssoEntry != null) {
+          cache.put(ssoSessionId, ssoEntry);
+        }
+      }
+      super.invoke(request, response);
+  }
+
+  @Override
+  public void sessionDestroyed(String ssoId, Session session) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.sessionDestroyed"));
+      }
+      super.sessionDestroyed(ssoId, session);
+      manager.getMap(SSO_SESSION_ENTRIES).fastRemove(ssoId);
+  }
+
+  @Override
+  protected boolean associate(String ssoId, Session session) {
+      if (containerLog.isTraceEnabled()) {
+        containerLog.trace(sm.getString("redissonSingleSignOn.trace.associate", ssoId, session));
+      }
+      SingleSignOnEntry sso = this.getSsoEntry(ssoId);
+      if (sso != null) {
+          cache.put(ssoId, sso);
+      }
+      boolean associated = super.associate(ssoId, session);
+      if (associated) {
+          manager.getMap(SSO_SESSION_ENTRIES).fastPut(ssoId, sso);
+      }
+      return associated;
+  }
+
+  @Override
+  protected boolean reauthenticate(String ssoId, Realm realm, Request request) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.reauthenticate"));
+      }
+      SingleSignOnEntry sso = this.getSsoEntry(ssoId);
+      if (sso != null) {
+          cache.put(ssoId, sso);
+      }
+      return super.reauthenticate(ssoId, realm, request);
+  }
+
+  @Override
+  protected void register(String ssoId, Principal principal, String authType, String username, String password) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.register"));
+      }  
+      super.register(ssoId, principal, authType, username, password);
+      manager.getMap(SSO_SESSION_ENTRIES).fastPut(ssoId, cache.get(ssoId));
+  }
+
+  @Override
+  protected void deregister(String ssoId) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.deregister"));
+      }
+      super.deregister(ssoId);
+      manager.getMap(SSO_SESSION_ENTRIES).fastRemove(ssoId);
+  }
+
+  @Override
+  protected boolean update(String ssoId, Principal principal, String authType, String username, String password) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.update"));
+      }
+      SingleSignOnEntry sso = this.getSsoEntry(ssoId);
+      if (sso != null) {
+          cache.put(ssoId, sso);
+      }
+      boolean updated = super.update(ssoId, principal, authType, username, password);
+      if (updated) {
+          manager.getMap(SSO_SESSION_ENTRIES).fastPut(ssoId, sso);
+      }
+      return updated;
+  }
+
+  @Override
+  protected void removeSession(String ssoId, Session session) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.removeSession", session, ssoId));
+      }
+      SingleSignOnEntry sso = this.getSsoEntry(ssoId);
+      if (sso == null) {
+          return;
+      }
+      cache.put(ssoId, sso);
+      super.removeSession(ssoId, session);
+      if (sso.findSessions().isEmpty()) {
+        deregister(ssoId);
+      }
+  }
+
+  /**
+   * Lookup {@code SingleSignOnEntry} for the given SSO ID.
+   *
+   * @param ssoSessionId SSO session id we are looking for
+   * @return matching {@code SingleSignOnEntry} instance or null when not found
+   */
+  private SingleSignOnEntry getSsoEntry(String ssoSessionId) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.getSsoEntry", ssoSessionId));
+      }
+      SingleSignOnEntry entry = (SingleSignOnEntry) manager.getMap(SSO_SESSION_ENTRIES).get(ssoSessionId);
+      if (entry != null) {
+          this.cache.put(ssoSessionId, entry);
+      }
+      return entry;
+  }
+
+  /**
+   * Retrieve SSO session ID from provided cookies in the request.
+   *
+   * @param request The request that has been sent to the server.
+   * @return SSO session ID provided with the request or null when none provided
+   */
+  private String getSsoSessionId(Request request) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.getSsoSessionId", request.getRequestURI()));
+      }
+      Cookie cookie = null;
+      Cookie[] cookies = request.getCookies();
+      if (cookies != null) {
+          for (Cookie value : cookies) {
+              if (getCookieName().equals(value.getName())) {
+                  cookie = value;
+                  break;
+              }
+          }
+      }
+      if (cookie != null) {
+          return cookie.getValue();
+      }
+      return null;
+  }
+
+}

--- a/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -279,6 +279,7 @@ public class RedissonSessionManager extends ManagerBase {
         
         Pipeline pipeline = getContext().getPipeline();
         synchronized (pipeline) {
+            tryInitSsoValve();
             if (readMode == ReadMode.REDIS) {
                 Optional<Valve> res = Arrays.stream(pipeline.getValves()).filter(v -> v.getClass() == UsageValve.class).findAny();
                 if (res.isPresent()) {
@@ -444,5 +445,26 @@ public class RedissonSessionManager extends ManagerBase {
             sess.save();
         }
     }
-    
+
+    private void tryInitSsoValve() {
+        Container c = getContext();
+        // SSO valve has to be in defined in Host
+        // it won't be picked up by Catalina from within Context
+        while (c != null && !(c instanceof org.apache.catalina.Host)) {
+            c = c.getParent();
+        }
+        if (c == null) {
+            log.warn("No Catalina Host found for current context. Can't configure Redisson SSO.");
+            return;
+        }
+        for (Valve valve : ((Host) c).getPipeline().getValves()) {
+            if (valve instanceof RedissonSingleSignOn) {
+                log.debug("Found SSO valve, passing RedissionSessionManager to it.");
+                ((RedissonSingleSignOn) valve).setSessionManager(this);
+                return;
+            }
+        }
+        log.trace("No Redisson SSO valve found. Redisson SSO is not configured.");
+    }
+
 }

--- a/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/RedissonSingleSignOn.java
+++ b/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/RedissonSingleSignOn.java
@@ -1,0 +1,193 @@
+/**
+ * Copyright (c) 2013-2024 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.tomcat;
+
+import java.io.IOException;
+import java.security.Principal;
+import org.apache.catalina.Realm;
+import org.apache.catalina.Session;
+import org.apache.catalina.authenticator.SingleSignOn;
+import org.apache.catalina.authenticator.SingleSignOnEntry;
+import org.apache.catalina.connector.Request;
+import org.apache.catalina.connector.Response;
+import org.apache.tomcat.util.res.StringManager;
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+
+/**
+ * Extended implementation of Tomcat SSO valve to use Redis or Valkey as a storage.
+ * This allows to cluster Tomcat without sticky sessions.
+ */
+public class RedissonSingleSignOn extends SingleSignOn {
+
+  private static final StringManager sm = StringManager.getManager(RedissonSingleSignOn.class);
+  private static final String SSO_SESSION_ENTRIES = "redisson:tomcat_sso";
+
+  private RedissonSessionManager manager;
+
+  void setSessionManager(RedissonSessionManager manager) {
+    if (containerLog.isTraceEnabled()) {
+      containerLog.trace(sm.getString("redissonSingleSignOn.trace.setSessionManager", manager));
+  }
+    this.manager = manager;
+  }
+
+  @Override
+  public void invoke(Request request, Response response) throws IOException, ServletException {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.invoke"));
+      }
+      String ssoSessionId = getSsoSessionId(request);
+      if (ssoSessionId != null) {
+        SingleSignOnEntry ssoEntry = getSsoEntry(ssoSessionId);
+        if (ssoEntry != null) {
+          cache.put(ssoSessionId, ssoEntry);
+        }
+      }
+      super.invoke(request, response);
+  }
+
+  @Override
+  public void sessionDestroyed(String ssoId, Session session) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.sessionDestroyed"));
+      }
+      super.sessionDestroyed(ssoId, session);
+      manager.getMap(SSO_SESSION_ENTRIES).fastRemove(ssoId);
+  }
+
+  @Override
+  protected boolean associate(String ssoId, Session session) {
+      if (containerLog.isTraceEnabled()) {
+        containerLog.trace(sm.getString("redissonSingleSignOn.trace.associate", ssoId, session));
+      }
+      SingleSignOnEntry sso = this.getSsoEntry(ssoId);
+      if (sso != null) {
+          cache.put(ssoId, sso);
+      }
+      boolean associated = super.associate(ssoId, session);
+      if (associated) {
+          manager.getMap(SSO_SESSION_ENTRIES).fastPut(ssoId, sso);
+      }
+      return associated;
+  }
+
+  @Override
+  protected boolean reauthenticate(String ssoId, Realm realm, Request request) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.reauthenticate"));
+      }
+      SingleSignOnEntry sso = this.getSsoEntry(ssoId);
+      if (sso != null) {
+          cache.put(ssoId, sso);
+      }
+      return super.reauthenticate(ssoId, realm, request);
+  }
+
+  @Override
+  protected void register(String ssoId, Principal principal, String authType, String username, String password) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.register"));
+      }  
+      super.register(ssoId, principal, authType, username, password);
+      manager.getMap(SSO_SESSION_ENTRIES).fastPut(ssoId, cache.get(ssoId));
+  }
+
+  @Override
+  protected void deregister(String ssoId) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.deregister"));
+      }
+      super.deregister(ssoId);
+      manager.getMap(SSO_SESSION_ENTRIES).fastRemove(ssoId);
+  }
+
+  @Override
+  protected boolean update(String ssoId, Principal principal, String authType, String username, String password) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.update"));
+      }
+      SingleSignOnEntry sso = this.getSsoEntry(ssoId);
+      if (sso != null) {
+          cache.put(ssoId, sso);
+      }
+      boolean updated = super.update(ssoId, principal, authType, username, password);
+      if (updated) {
+          manager.getMap(SSO_SESSION_ENTRIES).fastPut(ssoId, sso);
+      }
+      return updated;
+  }
+
+  @Override
+  protected void removeSession(String ssoId, Session session) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.removeSession", session, ssoId));
+      }
+      SingleSignOnEntry sso = this.getSsoEntry(ssoId);
+      if (sso == null) {
+          return;
+      }
+      cache.put(ssoId, sso);
+      super.removeSession(ssoId, session);
+      if (sso.findSessions().isEmpty()) {
+        deregister(ssoId);
+      }
+  }
+
+  /**
+   * Lookup {@code SingleSignOnEntry} for the given SSO ID.
+   *
+   * @param ssoSessionId SSO session id we are looking for
+   * @return matching {@code SingleSignOnEntry} instance or null when not found
+   */
+  private SingleSignOnEntry getSsoEntry(String ssoSessionId) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.getSsoEntry", ssoSessionId));
+      }
+      SingleSignOnEntry entry = (SingleSignOnEntry) manager.getMap(SSO_SESSION_ENTRIES).get(ssoSessionId);
+      if (entry != null) {
+          this.cache.put(ssoSessionId, entry);
+      }
+      return entry;
+  }
+
+  /**
+   * Retrieve SSO session ID from provided cookies in the request.
+   *
+   * @param request The request that has been sent to the server.
+   * @return SSO session ID provided with the request or null when none provided
+   */
+  private String getSsoSessionId(Request request) {
+      if (containerLog.isTraceEnabled()) {
+          containerLog.trace(sm.getString("redissonSingleSignOn.trace.getSsoSessionId", request.getRequestURI()));
+      }
+      Cookie cookie = null;
+      Cookie[] cookies = request.getCookies();
+      if (cookies != null) {
+          for (Cookie value : cookies) {
+              if (getCookieName().equals(value.getName())) {
+                  cookie = value;
+                  break;
+              }
+          }
+      }
+      if (cookie != null) {
+          return cookie.getValue();
+      }
+      return null;
+  }
+
+}


### PR DESCRIPTION
Add support for Tomcat SSO. Solves https://github.com/redisson/redisson/issues/5603.
Currently when you try to use SSO available in Tomcat it is stored only locally, not through Redisson within Redis.
This adds custom Valve that extends the one provided by Tomcat to use Redis storage instead.

It is based on previous PR for the same functionality: https://github.com/redisson/redisson/pull/6404.
In comparison to previous PR it tries to make the least possible duplication of code with Tomcat's `SingleSignOn` implementation.
Also replaced `redissonClient.getMap()` with `RedissonSessionManager.getMap()` as recommended in  https://github.com/redisson/redisson/discussions/5657#discussioncomment-8618158.

Confirmed locally that with those changes SSO works when different applications are deployed on different Tomcats both configured the same way.
When no SSO is configured, previous behavior is preserved.

SSO valve has to be defined within the `Host` tag in `server.xml`. When added into `Context` it is not picked up by Tomcat, ie. not used.
Because I haven't found a way how to retrieve the `RedissonSessionManager` instance within the `startInternal()` method of the SSO as recommended in https://github.com/redisson/redisson/pull/6404#issuecomment-2604470992 because there is no access to contexts from the host when Redisson is defined within `tomcat/conf/context.xml`. Instead of that it is passed into the SSO valve from `startInternal()` of `RedissonSessionManager` instance.

For now it was implemented for Tomcat 11, but exactly the same should be able to be used for all other Tomcat versions. Would be happy to do the changes also for other Tomcat versions once the code is reviewed for one version.

Please let me know your opinion.