### PR TITLE
Make RedisURI behavior equal to Redis CLI

### DIFF
--- a/redisson/src/main/java/org/redisson/misc/RedisURI.java
+++ b/redisson/src/main/java/org/redisson/misc/RedisURI.java
@@ -86,7 +86,11 @@ public final class RedisURI {
             URL url = new URL(urlHost);
             if (url.getUserInfo() != null) {
                 String[] details = url.getUserInfo().split(":", 2);
-                if (details.length == 2) {
+                if (details.length == 1) {
+                    // According to RFC 1738 section 3.1, the password can be omitted.
+                    // However, Redis CLI extends this URL semantic and uses the single auth component as password
+                    password = URLDecoder.decode(details[0], StandardCharsets.UTF_8.toString());
+                } else if (details.length == 2) {
                     if (!details[0].isEmpty()) {
                         username = URLDecoder.decode(details[0], StandardCharsets.UTF_8.toString());
                     }

--- a/redisson/src/test/java/org/redisson/misc/RedisURITest.java
+++ b/redisson/src/test/java/org/redisson/misc/RedisURITest.java
@@ -43,4 +43,11 @@ public class RedisURITest {
         assertThat(uri1.getPassword()).isEqualTo("password");
     }
 
+    @Test
+    public void testToken() {
+        RedisURI uri1 = new RedisURI("redis://my-token@compute-1.amazonaws.com:15319");
+        assertThat(uri1.getUsername()).isEqualTo(null);
+        assertThat(uri1.getPassword()).isEqualTo("my-token");
+    }
+
 }


### PR DESCRIPTION
Redis CLI supports URI syntax in form `redis://auth@host:port` and uses single component not as username (as stated in RFC 1738) but as a token, and sends "AUTH auth" command to server. This commit makes the RedisURI parse to accept single auth component in URI as password and, thus, successfully authenticate client