### PR TITLE
Potential fix for code scanning alert no. 12: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/redisson/src/main/java/org/redisson/client/handler/CommandDecoder.java
+++ b/redisson/src/main/java/org/redisson/client/handler/CommandDecoder.java
@@ -503,19 +503,19 @@ public class CommandDecoder extends ReplayingDecoder<State> {
             Channel channel, long size, List<Object> respParts, boolean skipConvertor, List<CommandData<?, ?>> commandsData, State state)
                     throws IOException {
         if (parts == null && commandsData != null) {
-            for (int i = respParts.size(); i < size; i++) {
+            for (long i = respParts.size(); i < size; i++) {
                 int suffix = 0;
                 if (RedisCommands.MULTI.getName().equals(commandsData.get(0).getCommand().getName())) {
                     suffix = 1;
                 }
-                CommandData<Object, Object> commandData = (CommandData<Object, Object>) commandsData.get(i+suffix);
+                CommandData<Object, Object> commandData = (CommandData<Object, Object>) commandsData.get((int)(i+suffix));
                 decode(in, commandData, respParts, channel, skipConvertor, commandsData, size, state);
                 if (commandData.getPromise().isDone() && commandData.getPromise().isCompletedExceptionally()) {
                     data.tryFailure(commandData.cause());
                 }
             }
         } else {
-            for (int i = respParts.size(); i < size; i++) {
+            for (long i = respParts.size(); i < size; i++) {
                 decode(in, data, respParts, channel, skipConvertor, null, size, state);
             }
         }


### PR DESCRIPTION
Potential fix for [https://github.com/redisson/redisson/security/code-scanning/12](https://github.com/redisson/redisson/security/code-scanning/12)

To fix the issue, the type of the variable `i` should be widened to match the type of `size`, which is `long`. This ensures that the comparison `i < size` is between two values of the same type, avoiding overflow and ensuring the loop behaves as intended.

**Steps to implement the fix:**
1. Change the type of the loop variable `i` from `int` to `long` in both loops (lines 506 and 518).
2. Ensure that all operations involving `i` within the loop are compatible with the `long` type.

No additional imports, methods, or definitions are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
