### PR TITLE
Potential fix for code scanning alert no. 13: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/redisson/src/main/java/org/redisson/jcache/JCache.java
+++ b/redisson/src/main/java/org/redisson/jcache/JCache.java
@@ -1668,7 +1668,7 @@ public class JCache<K, V> extends RedissonObject implements Cache<K, V>, CacheAs
             }
 
             cacheManager.getStatBean(this).addPuts(res);
-            for (int i = 0; i < res; i++) {
+            for (long i = 0; i < res; i++) {
                 cacheManager.getStatBean(this).addPutTime((currentNanoTime() - startTime) / res);
             }
         });


### PR DESCRIPTION
Potential fix for [https://github.com/redisson/redisson/security/code-scanning/13](https://github.com/redisson/redisson/security/code-scanning/13)

To fix the issue, the type of the loop variable `i` should be changed from `int` to `long`, ensuring that it matches the type of `res`. This eliminates the risk of overflow and ensures that the comparison is valid. The change should be made in the loop declaration on line 1671, and any subsequent usage of `i` within the loop should be updated to reflect the new type.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
