### PR TITLE
Prevent NPE in Tomcat SSO in specific situations

### DIFF
--- a/redisson-tomcat/redisson-tomcat-10/src/main/java/org/redisson/tomcat/RedissonSingleSignOn.java
+++ b/redisson-tomcat/redisson-tomcat-10/src/main/java/org/redisson/tomcat/RedissonSingleSignOn.java
@@ -39,9 +39,9 @@ public class RedissonSingleSignOn extends SingleSignOn {
   private RedissonSessionManager manager;
 
   void setSessionManager(RedissonSessionManager manager) {
-    if (containerLog.isTraceEnabled()) {
+    if (containerLog != null && containerLog.isTraceEnabled()) {
       containerLog.trace(sm.getString("redissonSingleSignOn.trace.setSessionManager", manager));
-  }
+    }
     this.manager = manager;
   }
 

--- a/redisson-tomcat/redisson-tomcat-11/src/main/java/org/redisson/tomcat/RedissonSingleSignOn.java
+++ b/redisson-tomcat/redisson-tomcat-11/src/main/java/org/redisson/tomcat/RedissonSingleSignOn.java
@@ -39,9 +39,9 @@ public class RedissonSingleSignOn extends SingleSignOn {
   private RedissonSessionManager manager;
 
   void setSessionManager(RedissonSessionManager manager) {
-    if (containerLog.isTraceEnabled()) {
+    if (containerLog != null && containerLog.isTraceEnabled()) {
       containerLog.trace(sm.getString("redissonSingleSignOn.trace.setSessionManager", manager));
-  }
+    }
     this.manager = manager;
   }
 

--- a/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSingleSignOn.java
+++ b/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSingleSignOn.java
@@ -40,9 +40,9 @@ public class RedissonSingleSignOn extends SingleSignOn {
   private RedissonSessionManager manager;
 
   void setSessionManager(RedissonSessionManager manager) {
-    if (containerLog.isTraceEnabled()) {
+    if (containerLog != null && containerLog.isTraceEnabled()) {
       containerLog.trace(sm.getString("redissonSingleSignOn.trace.setSessionManager", manager));
-  }
+    }
     this.manager = manager;
   }
 

--- a/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSingleSignOn.java
+++ b/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSingleSignOn.java
@@ -39,9 +39,9 @@ public class RedissonSingleSignOn extends SingleSignOn {
   private RedissonSessionManager manager;
 
   void setSessionManager(RedissonSessionManager manager) {
-    if (containerLog.isTraceEnabled()) {
+    if (containerLog != null && containerLog.isTraceEnabled()) {
       containerLog.trace(sm.getString("redissonSingleSignOn.trace.setSessionManager", manager));
-  }
+    }
     this.manager = manager;
   }
 

--- a/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/RedissonSingleSignOn.java
+++ b/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/RedissonSingleSignOn.java
@@ -39,9 +39,9 @@ public class RedissonSingleSignOn extends SingleSignOn {
   private RedissonSessionManager manager;
 
   void setSessionManager(RedissonSessionManager manager) {
-    if (containerLog.isTraceEnabled()) {
+    if (containerLog != null && containerLog.isTraceEnabled()) {
       containerLog.trace(sm.getString("redissonSingleSignOn.trace.setSessionManager", manager));
-  }
+    }
     this.manager = manager;
   }
 


### PR DESCRIPTION
In some specific situations session manager might have been set before logger is initialized.

When using changes from https://github.com/redisson/redisson/pull/6639 we have found out that it might fail with NPE.
For example when deployed into TomEE some (not all) applications from EAR triggered it. Confirmed that with following fix it works as expected.
Appearantly `RedissonSingleSignOn.setSessionManager()` may be called before `ValveBase.initInternal()` (super super of RedissonSingleSignOn) is called resulting into `containerLog` not being initialized yet.

Keeping logging in other methods (all of them are overrides or called from those overrides) without changes as it is used exactly the same way also in super class. Which means those methods should not be called before `initInternal()`.