### PR TITLE
Fix shardedSubscriptionMode auto detection

### DIFF
--- a/redisson/src/main/java/org/redisson/pubsub/PublishSubscribeService.java
+++ b/redisson/src/main/java/org/redisson/pubsub/PublishSubscribeService.java
@@ -1169,7 +1169,7 @@ public class PublishSubscribeService {
     public void checkShardingSupport(ShardedSubscriptionMode mode, RedisConnection connection) {
         if (mode == ShardedSubscriptionMode.AUTO) {
             try {
-                connection.sync(RedisCommands.PUBSUB_SHARDNUMSUB);
+                connection.sync(RedisCommands.PUBSUB_SHARDNUMSUB, 0);
                 setShardingSupported(true);
             } catch (Exception e) {
                 // skip


### PR DESCRIPTION
Calling the `PUBSUB SHARDNUMSUB` command without a channel hangs on Azure Managed Redis. Calling with a bogus value works around this issue.

Fixes issue #6487