### PR TITLE
Execute FT.SEARCH on read connections. Fixes #6654.

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonSearch.java
+++ b/redisson/src/main/java/org/redisson/RedissonSearch.java
@@ -524,7 +524,7 @@ public class RedissonSearch implements RSearch {
                                             new ObjectListReplayDecoder()));
         }
 
-        return commandExecutor.writeAsync(indexName, StringCodec.INSTANCE, command, args.toArray());
+        return commandExecutor.readAsync(indexName, StringCodec.INSTANCE, command, args.toArray());
     }
 
     private String value(double score, boolean exclusive) {


### PR DESCRIPTION
FT.SEARCH is read only and can benefit from having a possibility to read from slaves.

Similar improvement can be made to FT.AGGREGATE, but it's a slightly more complicated issue not touched in this PR. Theoretically one could probably do something like this:

```
        if(options.isWithCursor()) {
            return commandExecutor.writeAsync(indexName, StringCodec.INSTANCE, command, args.toArray());    
        } else {
            return commandExecutor.readAsync(indexName, StringCodec.INSTANCE, command, args.toArray());
        }
```

... but this is not obvious behavior and would need to be documented.