### PR TITLE
#6664 Fixed RedissonPermitExpirableSemaphore.tryAcquire will fail when multiple threads acquire multiple permits at the same time. 

### DIFF
--- a/redisson/src/main/java/org/redisson/PubSubEntry.java
+++ b/redisson/src/main/java/org/redisson/PubSubEntry.java
@@ -26,6 +26,8 @@ public interface PubSubEntry<E> {
 
     void acquire();
 
+    void acquire(int permits);
+
     int release();
 
     CompletableFuture<E> getPromise();

--- a/redisson/src/main/java/org/redisson/RedissonCountDownLatchEntry.java
+++ b/redisson/src/main/java/org/redisson/RedissonCountDownLatchEntry.java
@@ -37,6 +37,9 @@ public class RedissonCountDownLatchEntry implements PubSubEntry<RedissonCountDow
     public void acquire() {
         counter++;
     }
+    public void acquire(int permits) {
+        counter+=permits;
+    }
 
     public int release() {
         return --counter;

--- a/redisson/src/main/java/org/redisson/RedissonLockEntry.java
+++ b/redisson/src/main/java/org/redisson/RedissonLockEntry.java
@@ -45,6 +45,9 @@ public class RedissonLockEntry implements PubSubEntry<RedissonLockEntry> {
     public void acquire() {
         counter++;
     }
+    public void acquire(int permits) {
+        counter+=permits;
+    }
 
     public int release() {
         return --counter;

--- a/redisson/src/main/java/org/redisson/RedissonPermitExpirableSemaphore.java
+++ b/redisson/src/main/java/org/redisson/RedissonPermitExpirableSemaphore.java
@@ -80,7 +80,7 @@ public class RedissonPermitExpirableSemaphore extends RedissonExpirable implemen
             return ids;
         }
 
-        CompletableFuture<RedissonLockEntry> future = subscribe();
+        CompletableFuture<RedissonLockEntry> future = subscribe(permits);
         semaphorePubSub.timeout(future);
         RedissonLockEntry entry = commandExecutor.getInterrupted(future);
         try {
@@ -136,7 +136,7 @@ public class RedissonPermitExpirableSemaphore extends RedissonExpirable implemen
                 return CompletableFuture.completedFuture(ids);
             }
 
-            CompletableFuture<RedissonLockEntry> subscribeFuture = subscribe();
+            CompletableFuture<RedissonLockEntry> subscribeFuture = subscribe(permits);
             semaphorePubSub.timeout(subscribeFuture);
             return subscribeFuture.thenCompose(res -> acquireAsync(permits, res, leaseTime, timeUnit));
         });
@@ -464,7 +464,7 @@ public class RedissonPermitExpirableSemaphore extends RedissonExpirable implemen
         }
         
         current = System.currentTimeMillis();
-        CompletableFuture<RedissonLockEntry> future = subscribe();
+        CompletableFuture<RedissonLockEntry> future = subscribe(permits);
         RedissonLockEntry entry;
         try {
             entry = future.get(time, TimeUnit.MILLISECONDS);
@@ -548,7 +548,7 @@ public class RedissonPermitExpirableSemaphore extends RedissonExpirable implemen
             
             long current = System.currentTimeMillis();
             AtomicReference<Timeout> futureRef = new AtomicReference<>();
-            CompletableFuture<RedissonLockEntry> subscribeFuture = subscribe();
+            CompletableFuture<RedissonLockEntry> subscribeFuture = subscribe(permits);
             subscribeFuture.whenComplete((r, ex) -> {
                 if (ex != null) {
                     result.completeExceptionally(ex);
@@ -581,8 +581,8 @@ public class RedissonPermitExpirableSemaphore extends RedissonExpirable implemen
         return new CompletableFutureWrapper<>(result);
     }
 
-    private CompletableFuture<RedissonLockEntry> subscribe() {
-        return semaphorePubSub.subscribe(getRawName(), channelName);
+    private CompletableFuture<RedissonLockEntry> subscribe(int permits) {
+        return semaphorePubSub.subscribe(getRawName(), channelName, permits);
     }
 
     private void unsubscribe(RedissonLockEntry entry) {


### PR DESCRIPTION
Fixed RedissonPermitExpirableSemaphore.tryAcquire will fail when multiple threads acquire multiple permits at the same time.  #6664