### PR TITLE
Improvement LFU.onMapFull

### DIFF
--- a/redisson/src/main/java/org/redisson/cache/LFUCacheMap.java
+++ b/redisson/src/main/java/org/redisson/cache/LFUCacheMap.java
@@ -19,6 +19,8 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * LFU (least frequently used) cache.
@@ -72,7 +74,8 @@ public class LFUCacheMap<K, V> extends AbstractCacheMap<K, V> {
         }
         
     }
-    
+
+    private final Lock lock = new ReentrantLock();
     private final AtomicLong idGenerator = new AtomicLong();
     private final ConcurrentNavigableMap<MapKey, LFUCachedValue<K, V>> accessMap = new ConcurrentSkipListMap<>();
     
@@ -141,17 +144,25 @@ public class LFUCacheMap<K, V> extends AbstractCacheMap<K, V> {
             super.onValueRemove(entry.getValue());
         }
 
-        if (entry.getValue().accessCount == 0) {
-            return;
-        }
-
-        // TODO optimize
         // decrease all values
-        for (LFUCachedValue<K, V> value : accessMap.values()) {
-            addAccessCount(value, -entry.getValue().accessCount);
-        }
+        decreaseAll();
     }
 
+    private void decreaseAll() {
+        if (lock.tryLock()) {
+            try {
+                Entry<MapKey, LFUCachedValue<K, V>> entry = accessMap.firstEntry();
+                long accessCount;
+                if (entry != null && (accessCount = entry.getValue().accessCount) != 0) {
+                    for (LFUCachedValue<K, V> value : accessMap.values()) {
+                        addAccessCount(value, accessCount);
+                    }
+                }
+            }finally {
+                lock.unlock();
+            }
+        }
+    }
     @Override
     public void clear() {
         accessMap.clear();


### PR DESCRIPTION
@mrniko 
Hi how about this, use the second entry to decrase all accessCount?
So it could avoid all values becoming 0 in some situations，like https://github.com/redisson/redisson/issues/6663