### PR TITLE
add missing get/set config object for tomcat 10 & 11

### DIFF
--- a/redisson-tomcat/redisson-tomcat-10/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-10/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -109,6 +109,14 @@ public class RedissonSessionManager extends ManagerBase {
         return configPath;
     }
 
+    public void setConfig(Config config) {
+        this.config = config;
+    }
+
+    public Config getConfig() {
+        return config;
+    }
+
     public String getKeyPrefix() {
         return keyPrefix;
     }

--- a/redisson-tomcat/redisson-tomcat-11/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-11/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -109,6 +109,14 @@ public class RedissonSessionManager extends ManagerBase {
         return configPath;
     }
 
+    public void setConfig(Config config) {
+        this.config = config;
+    }
+
+    public Config getConfig() {
+        return config;
+    }
+
     public String getKeyPrefix() {
         return keyPrefix;
     }


### PR DESCRIPTION
a follow up for https://github.com/redisson/redisson/pull/6179 where get/setConfig methods were not added for tomcat 10 & 11