### PR TITLE
fix close DataInputStream to prevent resource leak in getClassBody

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonExecutorService.java
+++ b/redisson/src/main/java/org/redisson/RedissonExecutorService.java
@@ -426,11 +426,9 @@ public class RedissonExecutorService implements RScheduledExecutorService {
             byte[] lambdaBody = null;
             if (classStream == null) {
                 ByteArrayOutputStream os = new ByteArrayOutputStream();
-                try {
-                    ObjectOutput oo = new ObjectOutputStream(os);
+                try (ObjectOutput oo = new ObjectOutputStream(os)) {
                     oo.writeObject(task);
                     oo.flush();
-                    oo.close();
                 } catch (Exception e) {
                     throw new IllegalArgumentException("Unable to serialize lambda", e);
                 }
@@ -450,18 +448,11 @@ public class RedissonExecutorService implements RScheduledExecutorService {
             }
             
             byte[] classBody;
-            try {
-                DataInputStream s = new DataInputStream(classStream);
+            try (DataInputStream s = new DataInputStream(classStream)) {
                 classBody = new byte[s.available()];
                 s.readFully(classBody);
             } catch (IOException e) {
                 throw new IllegalArgumentException(e);
-            } finally {
-                try {
-                    classStream.close();
-                } catch (IOException e) {
-                    // skip
-                }
             }
             
             result = new ClassBody(lambdaBody, classBody, className);


### PR DESCRIPTION
Hi,

This PR fixes a potential resource leak in the getClassBody method.
Previously, only the underlying InputStream was closed, while the wrapping DataInputStream was not explicitly closed.

Summary of your change
Changed the resource management in getClassBody to call DataInputStream.close() instead of only closing the underlying InputStream.

Ensured that all resources are safely released, even in case of an exception.

Thank you for reviewing!