### PR TITLE
Fixed - RScheduledExecutorService throws exception on deregisterWorkers() #6727

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonRemoteService.java
+++ b/redisson/src/main/java/org/redisson/RedissonRemoteService.java
@@ -391,6 +391,11 @@ public class RedissonRemoteService extends BaseRemoteService implements RRemoteS
             if (commandExecutor.getServiceManager().isShuttingDown(exc)) {
                 return null;
             }
+
+            if (exc.getCause() instanceof CancellationException) {
+                return null;
+            }
+
             log.error("Can't process the remote service request", exc);
             return null;
         });

--- a/redisson/src/main/java/org/redisson/RedissonRemoteService.java
+++ b/redisson/src/main/java/org/redisson/RedissonRemoteService.java
@@ -392,7 +392,7 @@ public class RedissonRemoteService extends BaseRemoteService implements RRemoteS
                 return null;
             }
 
-            if (exc.getCause() instanceof CancellationException) {
+            if (exc instanceof CancellationException || exc.getCause() instanceof CancellationException) {
                 return null;
             }
 


### PR DESCRIPTION
[issues/6727](https://github.com/redisson/redisson/issues/6727)