### PR TITLE
Fixed - Redisson Spring Data reactive: XPENDING missing group (syntaxerror) and NPE on empty pending summary #6756

### DIFF
--- a/redisson-spring-data/redisson-spring-data-32/src/test/java/org/redisson/spring/data/connection/RedissonReactiveKeyCommandsTest.java
+++ b/redisson-spring-data/redisson-spring-data-32/src/test/java/org/redisson/spring/data/connection/RedissonReactiveKeyCommandsTest.java
@@ -1,9 +1,15 @@
 package org.redisson.spring.data.connection;
 
 import org.junit.Test;
+import org.springframework.data.domain.Range;
+import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.PendingMessages;
+import org.springframework.data.redis.connection.stream.ReadOffset;
+import org.springframework.data.redis.connection.stream.StreamOffset;
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
 
 import java.time.Duration;
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -16,6 +22,22 @@ public class RedissonReactiveKeyCommandsTest extends BaseConnectionTest {
         t.opsForValue().set("123", "4343").block();
         t.expire("123", Duration.ofMillis(1001)).block();
         assertThat(t.getExpire("123").block().toMillis()).isBetween(900L, 1000L);
+    }
+
+    @Test
+    public void testPending() {
+        RedissonConnectionFactory factory = new RedissonConnectionFactory(redisson);
+        ReactiveStringRedisTemplate t = new ReactiveStringRedisTemplate(factory);
+        t.opsForStream().createGroup("test", ReadOffset.latest(), "testGroup").block();
+
+        t.opsForStream().add("test", Collections.singletonMap("1", "1")).block();
+
+        assertThat(t.opsForStream().pending("test", "testGroup").block().getTotalPendingMessages()).isEqualTo(0);
+
+        t.opsForStream().read(Consumer.from("testGroup", "test1"), StreamOffset.create("test", ReadOffset.from(">"))).single().block();
+
+        PendingMessages msg = t.opsForStream().pending("test", "testGroup", Range.unbounded(), 10).block();
+        assertThat(msg.size()).isEqualTo(1);
     }
 
 }

--- a/redisson-spring-data/redisson-spring-data-33/src/test/java/org/redisson/spring/data/connection/RedissonReactiveKeyCommandsTest.java
+++ b/redisson-spring-data/redisson-spring-data-33/src/test/java/org/redisson/spring/data/connection/RedissonReactiveKeyCommandsTest.java
@@ -1,9 +1,15 @@
 package org.redisson.spring.data.connection;
 
 import org.junit.Test;
+import org.springframework.data.domain.Range;
+import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.PendingMessages;
+import org.springframework.data.redis.connection.stream.ReadOffset;
+import org.springframework.data.redis.connection.stream.StreamOffset;
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
 
 import java.time.Duration;
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -18,4 +24,19 @@ public class RedissonReactiveKeyCommandsTest extends BaseConnectionTest {
         assertThat(t.getExpire("123").block().toMillis()).isBetween(900L, 1000L);
     }
 
+    @Test
+    public void testPending() {
+        RedissonConnectionFactory factory = new RedissonConnectionFactory(redisson);
+        ReactiveStringRedisTemplate t = new ReactiveStringRedisTemplate(factory);
+        t.opsForStream().createGroup("test", ReadOffset.latest(), "testGroup").block();
+
+        t.opsForStream().add("test", Collections.singletonMap("1", "1")).block();
+
+        assertThat(t.opsForStream().pending("test", "testGroup").block().getTotalPendingMessages()).isEqualTo(0);
+
+        t.opsForStream().read(Consumer.from("testGroup", "test1"), StreamOffset.create("test", ReadOffset.from(">"))).single().block();
+
+        PendingMessages msg = t.opsForStream().pending("test", "testGroup", Range.unbounded(), 10).block();
+        assertThat(msg.size()).isEqualTo(1);
+    }
 }

--- a/redisson-spring-data/redisson-spring-data-34/src/test/java/org/redisson/spring/data/connection/RedissonReactiveKeyCommandsTest.java
+++ b/redisson-spring-data/redisson-spring-data-34/src/test/java/org/redisson/spring/data/connection/RedissonReactiveKeyCommandsTest.java
@@ -1,9 +1,15 @@
 package org.redisson.spring.data.connection;
 
 import org.junit.Test;
+import org.springframework.data.domain.Range;
+import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.PendingMessages;
+import org.springframework.data.redis.connection.stream.ReadOffset;
+import org.springframework.data.redis.connection.stream.StreamOffset;
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
 
 import java.time.Duration;
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -16,6 +22,22 @@ public class RedissonReactiveKeyCommandsTest extends BaseConnectionTest {
         t.opsForValue().set("123", "4343").block();
         t.expire("123", Duration.ofMillis(1001)).block();
         assertThat(t.getExpire("123").block().toMillis()).isBetween(900L, 1000L);
+    }
+
+    @Test
+    public void testPending() {
+        RedissonConnectionFactory factory = new RedissonConnectionFactory(redisson);
+        ReactiveStringRedisTemplate t = new ReactiveStringRedisTemplate(factory);
+        t.opsForStream().createGroup("test", ReadOffset.latest(), "testGroup").block();
+
+        t.opsForStream().add("test", Collections.singletonMap("1", "1")).block();
+
+        assertThat(t.opsForStream().pending("test", "testGroup").block().getTotalPendingMessages()).isEqualTo(0);
+
+        t.opsForStream().read(Consumer.from("testGroup", "test1"), StreamOffset.create("test", ReadOffset.from(">"))).single().block();
+
+        PendingMessages msg = t.opsForStream().pending("test", "testGroup", Range.unbounded(), 10).block();
+        assertThat(msg.size()).isEqualTo(1);
     }
 
 }

--- a/redisson-spring-data/redisson-spring-data-35/src/test/java/org/redisson/spring/data/connection/RedissonReactiveKeyCommandsTest.java
+++ b/redisson-spring-data/redisson-spring-data-35/src/test/java/org/redisson/spring/data/connection/RedissonReactiveKeyCommandsTest.java
@@ -1,9 +1,15 @@
 package org.redisson.spring.data.connection;
 
 import org.junit.Test;
+import org.springframework.data.domain.Range;
+import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.PendingMessages;
+import org.springframework.data.redis.connection.stream.ReadOffset;
+import org.springframework.data.redis.connection.stream.StreamOffset;
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
 
 import java.time.Duration;
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -16,6 +22,22 @@ public class RedissonReactiveKeyCommandsTest extends BaseConnectionTest {
         t.opsForValue().set("123", "4343").block();
         t.expire("123", Duration.ofMillis(1001)).block();
         assertThat(t.getExpire("123").block().toMillis()).isBetween(900L, 1000L);
+    }
+
+    @Test
+    public void testPending() {
+        RedissonConnectionFactory factory = new RedissonConnectionFactory(redisson);
+        ReactiveStringRedisTemplate t = new ReactiveStringRedisTemplate(factory);
+        t.opsForStream().createGroup("test", ReadOffset.latest(), "testGroup").block();
+
+        t.opsForStream().add("test", Collections.singletonMap("1", "1")).block();
+
+        assertThat(t.opsForStream().pending("test", "testGroup").block().getTotalPendingMessages()).isEqualTo(0);
+
+        t.opsForStream().read(Consumer.from("testGroup", "test1"), StreamOffset.create("test", ReadOffset.from(">"))).single().block();
+
+        PendingMessages msg = t.opsForStream().pending("test", "testGroup", Range.unbounded(), 10).block();
+        assertThat(msg.size()).isEqualTo(1);
     }
 
 }


### PR DESCRIPTION
[issues/6756](https://github.com/redisson/redisson/issues/6756)