### PR TITLE
Connection pool should prioritize recently used connections to ease idle connection discard #5151

### DIFF
--- a/redisson/src/main/java/org/redisson/connection/ConnectionsHolder.java
+++ b/redisson/src/main/java/org/redisson/connection/ConnectionsHolder.java
@@ -23,11 +23,13 @@ import org.redisson.misc.AsyncSemaphore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Deque;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.function.Function;
 
 /**
@@ -40,7 +42,7 @@ public class ConnectionsHolder<T extends RedisConnection> {
     final Logger log = LoggerFactory.getLogger(getClass());
 
     private final Queue<T> allConnections = new ConcurrentLinkedQueue<>();
-    private final Queue<T> freeConnections = new ConcurrentLinkedQueue<>();
+    private final Deque<T> freeConnections = new ConcurrentLinkedDeque<>();
     private final AsyncSemaphore freeConnectionsCounter;
 
     private final RedisClient client;
@@ -108,7 +110,7 @@ public class ConnectionsHolder<T extends RedisConnection> {
         }
 
         connection.setLastUsageTime(System.nanoTime());
-        freeConnections.add(connection);
+        freeConnections.addFirst(connection);
         if (changeUsage) {
             connection.decUsage();
         }


### PR DESCRIPTION
Proposition to solve the issue #5151 (and #6765) by using a deque for free connections to reuse recent connections and allow idle connection release