### PR TITLE
Fixed - redisson_lock_queue and redisson_lock_timeout in RedissonFairLock not using NameMapper causing key name mismatch #6759

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonFairLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonFairLock.java
@@ -50,8 +50,8 @@ public class RedissonFairLock extends RedissonLock implements RLock {
         super(commandExecutor, name);
         this.commandExecutor = commandExecutor;
         this.threadWaitTime = getServiceManager().getCfg().getFairLockWaitTimeout();
-        threadsQueueName = prefixName("redisson_lock_queue", name);
-        timeoutSetName = prefixName("redisson_lock_timeout", name);
+        threadsQueueName = prefixName("redisson_lock_queue", getRawName());
+        timeoutSetName = prefixName("redisson_lock_timeout", getRawName());
     }
 
     @Override


### PR DESCRIPTION
[issues/6759](https://github.com/redisson/redisson/issues/6759)