### PR TITLE
feature: RRateLimiter add `release` permit

### DIFF
--- a/redisson/src/main/java/org/redisson/api/RRateLimiter.java
+++ b/redisson/src/main/java/org/redisson/api/RRateLimiter.java
@@ -221,6 +221,18 @@ public interface RRateLimiter extends RRateLimiterAsync, RExpirable {
     boolean tryAcquire(long permits, Duration timeout);
 
     /**
+     * Releases the given number of <code>permits</code>.
+     *
+     * <p>Increases the number of available permits by the specified amount and completes
+     * immediately, causing any waiting acquirers that can now obtain permits to proceed.
+     *
+     * <p>The returned future completes when the release has been applied.
+     *
+     * @param permits amount to release; must be greater than or equal to zero
+     */
+    void release(long permits);
+
+    /**
      * Returns current configuration of this RateLimiter object.
      * 
      * @return config object

--- a/redisson/src/main/java/org/redisson/api/RRateLimiterAsync.java
+++ b/redisson/src/main/java/org/redisson/api/RRateLimiterAsync.java
@@ -191,6 +191,18 @@ public interface RRateLimiterAsync extends RExpirableAsync {
     RFuture<Boolean> tryAcquireAsync(long permits, Duration timeout);
 
     /**
+     * Releases the given number of <code>permits</code>.
+     *
+     * <p>Increases the number of available permits by the specified amount and completes
+     * immediately, causing any waiting acquirers that can now obtain permits to proceed.
+     *
+     * <p>The returned future completes when the release has been applied.
+     *
+     * @param permits amount to release; must be greater than or equal to zero
+     */
+    RFuture<Void> releaseAsync(long permits);
+
+    /**
      * Use {@link #setRateAsync(RateType, long, Duration)} instead
      *
      * @param mode rate mode


### PR DESCRIPTION
### Proposed Changes
- Added `reserve(int permits)` (synchronous) and `reserveAsync(int permits)` methods.  
- These methods allow returning unused permits back to the limiter atomically.  
- Improves flexibility for clients that need to adjust acquired permits dynamically.