### PR TITLE
Fixed - RBucket.setIfAbsent not rolling back on transaction #4804

### DIFF
--- a/redisson/src/main/java/org/redisson/transaction/RedissonTransactionalBucket.java
+++ b/redisson/src/main/java/org/redisson/transaction/RedissonTransactionalBucket.java
@@ -356,6 +356,18 @@ public class RedissonTransactionalBucket<V> extends RedissonBucket<V> {
         return trySet(value, new BucketTrySetOperation<V>(getName(), getLockName(), getCodec(), value, timeToLive, timeUnit, transactionId, currentThreadId));
     }
 
+    @Override
+    public RFuture<Boolean> setIfAbsentAsync(V newValue) {
+        long currentThreadId = Thread.currentThread().getId();
+        return trySet(newValue, new BucketTrySetOperation<V>(getName(), getLockName(), getCodec(), newValue, transactionId, currentThreadId));
+    }
+
+    @Override
+    public RFuture<Boolean> setIfAbsentAsync(V value, Duration duration) {
+        long currentThreadId = Thread.currentThread().getId();
+        return trySet(value, new BucketTrySetOperation<V>(getName(), getLockName(), getCodec(), value, duration.toMillis(), TimeUnit.MILLISECONDS, transactionId, currentThreadId));
+    }
+
     private RFuture<Boolean> trySet(V newValue, BucketTrySetOperation operation) {
         checkState();
         return executeLocked(() -> {

--- a/redisson/src/test/java/org/redisson/transaction/RedissonTransactionalBucketTest.java
+++ b/redisson/src/test/java/org/redisson/transaction/RedissonTransactionalBucketTest.java
@@ -219,5 +219,24 @@ public class RedissonTransactionalBucketTest extends RedisDockerTest {
         assertThat(b.get()).isEqualTo("1234");
     }
 
+    @Test
+    public void testRollback2() {
+        String key = "TRANS_TEST";
+        RBucket<Object> b = redisson.getBucket(key);
+        RTransaction transaction = redisson.createTransaction(TransactionOptions.defaults());
+
+        redisson.getKeys().delete(key);
+
+        RBucket<String> bucket = transaction.getBucket(key);
+        bucket.set("1");
+        bucket.set("2");
+        bucket.set("3");
+        bucket.set("4");
+        bucket.set("5");
+        bucket.setIfAbsent("LAST_VALUE");
+        transaction.rollback();
+
+        assertThat(b.get()).isNull();
+    }
     
 }


### PR DESCRIPTION
[issues/4804](https://github.com/redisson/redisson/issues/4804)