### PR TITLE
Fix replicated node timeout handling and add regression test.

### DIFF
--- a/redisson/src/test/java/org/redisson/connection/ReplicatedConnectionManagerTest.java
+++ b/redisson/src/test/java/org/redisson/connection/ReplicatedConnectionManagerTest.java
@@ -1,0 +1,184 @@
+package org.redisson.connection;
+
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.assertj.core.api.Assertions;
+import org.joor.Reflect;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.redisson.api.RFuture;
+import org.redisson.client.RedisClient;
+import org.redisson.client.RedisClientConfig;
+import org.redisson.client.RedisConnection;
+import org.redisson.client.RedisTimeoutException;
+import org.redisson.client.codec.Codec;
+import org.redisson.client.protocol.RedisCommand;
+import org.redisson.config.Config;
+import org.redisson.config.DelayStrategy;
+import org.redisson.config.ReplicatedServersConfig;
+import org.redisson.misc.CompletableFutureWrapper;
+import org.redisson.misc.RedisURI;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+public class ReplicatedConnectionManagerTest {
+
+    private ReplicatedConnectionManager manager;
+
+    @AfterEach
+    public void cleanup() {
+        if (manager != null) {
+            for (RedisURI uri : new ArrayList<>(nodeConnections(manager).keySet())) {
+                manager.disconnectNode(uri);
+            }
+            manager.shutdown(0, 0, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    public void testRemovesCachedConnectionOnTimeout() {
+        manager = createManager();
+        RedisURI uri = new RedisURI("redis://127.0.0.1:6379");
+        DummyRedisConnection connection = new DummyRedisConnection();
+        registerNodeConnection(manager, uri, connection);
+
+        manager.handleNodeCheckError(uri, CompletableFuture.completedFuture(connection),
+                new CompletionException(new RedisTimeoutException("timeout")));
+
+        Assertions.assertThat(nodeConnections(manager)).isEmpty();
+        Assertions.assertThat(connection.isClosed()).isTrue();
+    }
+
+    @Test
+    public void testKeepsConnectionForNonTimeoutErrors() {
+        manager = createManager();
+        RedisURI uri = new RedisURI("redis://127.0.0.1:6379");
+        DummyRedisConnection connection = new DummyRedisConnection();
+        registerNodeConnection(manager, uri, connection);
+
+        manager.handleNodeCheckError(uri, CompletableFuture.completedFuture(connection),
+                new CompletionException(new IllegalArgumentException("bad role")));
+
+        Assertions.assertThat(nodeConnections(manager)).containsEntry(uri, connection);
+        Assertions.assertThat(connection.isClosed()).isFalse();
+    }
+
+    @Test
+    public void testDisconnectsConnectionWhenNodeCheckFailsWithTimeout() throws Exception {
+        manager = createManager();
+        RedisURI uri = new RedisURI("redis://127.0.0.1:6379");
+        TimeoutRedisConnection connection = TimeoutRedisConnection.create(uri);
+        registerNodeConnection(manager, uri, connection);
+
+        try {
+            ReplicatedServersConfig serversConfig = new ReplicatedServersConfig();
+            serversConfig.addNodeAddress(uri.toString());
+
+            Set<InetSocketAddress> slaveIPs = Collections.newSetFromMap(new ConcurrentHashMap<>());
+            CompletableFuture<?> future = manager.checkNode(uri, serversConfig, slaveIPs);
+
+            Assertions.assertThatThrownBy(future::join)
+                    .isInstanceOf(CompletionException.class)
+                    .hasCauseInstanceOf(RedisTimeoutException.class);
+
+            Assertions.assertThat(nodeConnections(manager)).isEmpty();
+            Assertions.assertThat(connection.isClosed()).isTrue();
+        } finally {
+            connection.shutdownClient();
+        }
+    }
+
+    private ReplicatedConnectionManager createManager() {
+        Config config = new Config();
+        ReplicatedServersConfig serversConfig = new ReplicatedServersConfig();
+        serversConfig.addNodeAddress("redis://127.0.0.1:6379");
+        return new ReplicatedConnectionManager(serversConfig, config);
+    }
+
+    private static Map<RedisURI, RedisConnection> nodeConnections(ReplicatedConnectionManager manager) {
+        return Reflect.on(manager).field("nodeConnections").<Map<RedisURI, RedisConnection>>get();
+    }
+
+    private static void registerNodeConnection(ReplicatedConnectionManager manager, RedisURI uri, RedisConnection connection) {
+        nodeConnections(manager).put(uri, connection);
+    }
+
+    private static final class DummyRedisConnection extends RedisConnection {
+        private boolean closed;
+
+        private DummyRedisConnection() {
+            super(null);
+            updateChannel(new EmbeddedChannel());
+        }
+
+        @Override
+        public ChannelFuture closeAsync() {
+            closed = true;
+            return super.closeAsync();
+        }
+
+        @Override
+        public boolean isClosed() {
+            return closed;
+        }
+
+        @Override
+        public boolean isActive() {
+            return true;
+        }
+    }
+
+    private static final class TimeoutRedisConnection extends RedisConnection {
+        private boolean closed;
+
+        private TimeoutRedisConnection(RedisClient client) {
+            super(client);
+            updateChannel(new EmbeddedChannel());
+        }
+
+        static TimeoutRedisConnection create(RedisURI uri) {
+            RedisClientConfig clientConfig = new RedisClientConfig();
+            InetSocketAddress address = new InetSocketAddress(uri.getHost(), uri.getPort());
+            clientConfig.setAddress(address, uri);
+            RedisClient client = RedisClient.create(clientConfig);
+            return new TimeoutRedisConnection(client);
+        }
+
+        @Override
+        public ChannelFuture closeAsync() {
+            closed = true;
+            getRedisClient().shutdownAsync();
+            return super.closeAsync();
+        }
+
+        @Override
+        public boolean isClosed() {
+            return closed;
+        }
+
+        @Override
+        public boolean isActive() {
+            return true;
+        }
+
+        @Override
+        public <T, R> RFuture<R> async(int retryAttempts, DelayStrategy delayStrategy, long timeout,
+                                       Codec codec, RedisCommand<T> command, Object... params) {
+            CompletableFuture<R> failure = new CompletableFuture<>();
+            failure.completeExceptionally(new RedisTimeoutException("timeout"));
+            return new CompletableFutureWrapper<>(failure);
+        }
+
+        void shutdownClient() {
+            getRedisClient().shutdown();
+        }
+    }
+}


### PR DESCRIPTION
Hi @mrniko , hope all is well!

We ran into a situation in production where after a failover the application was unable to recover, for over half an hour it was not able to correctly determine the master, in our setup we are using elastic cache with four nodes (we specify all of them in the config, not just the writer / reader hosts), cluster mode is disabled.

Here is how our Redisson clients are bootstrapped https://gist.github.com/johnou/ce9000a8233750aff040bc9858d590e2

The exceptions we were seeing in production looked like this

```
(org.redisson.connection.ReplicatedConnectionManager) Unable to update node redis://xxxuse1.cache.amazonaws.com:6379 status. A new attempt will be made.
java.util.concurrent.CompletionException: io.netty.channel.StacklessClosedChannelException
	at java.util.concurrent.CompletableFuture.encodeRelay(CompletableFuture.java:367) ~[?:?]
	at java.util.concurrent.CompletableFuture.completeRelay(CompletableFuture.java:376) ~[?:?]
	at java.util.concurrent.CompletableFuture$UniRelay.tryFire(CompletableFuture.java:1019) ~[?:?]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506) ~[?:?]
	at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2094) ~[?:?]
	at org.redisson.client.RedisConnection.lambda$async$1(RedisConnection.java:274) ~[redisson-3.39.0.jar:3.39.0]
	at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:859) ~[?:?]
	at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:837) ~[?:?]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506) ~[?:?]
	at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2094) ~[?:?]
	at org.redisson.client.RedisConnection.lambda$async$4(RedisConnection.java:306) ~[redisson-3.39.0.jar:3.39.0]
	at io.netty.util.concurrent.DefaultPromise.notifyListener0(DefaultPromise.java:590) ~[netty-common-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.util.concurrent.DefaultPromise.notifyListenersNow(DefaultPromise.java:557) ~[netty-common-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.util.concurrent.DefaultPromise.notifyListeners(DefaultPromise.java:492) ~[netty-common-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.util.concurrent.DefaultPromise.setValue0(DefaultPromise.java:636) ~[netty-common-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.util.concurrent.DefaultPromise.setFailure0(DefaultPromise.java:629) ~[netty-common-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.util.concurrent.DefaultPromise.tryFailure(DefaultPromise.java:118) ~[netty-common-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.channel.AbstractChannel$AbstractUnsafe.safeSetFailure(AbstractChannel.java:997) ~[netty-transport-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.channel.AbstractChannel$AbstractUnsafe.write(AbstractChannel.java:858) ~[netty-transport-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.channel.DefaultChannelPipeline$HeadContext.write(DefaultChannelPipeline.java:1314) ~[netty-transport-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:889) ~[netty-transport-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeWriteAndFlush(AbstractChannelHandlerContext.java:956) ~[netty-transport-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.channel.AbstractChannelHandlerContext$WriteTask.run(AbstractChannelHandlerContext.java:1263) ~[netty-transport-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173) ~[netty-common-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166) ~[netty-common-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472) ~[netty-common-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:405) ~[netty-transport-classes-epoll-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:998) ~[netty-common-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[netty-common-4.1.119.Final.jar:4.1.119.Final]
	at com.sulake.h4k.common.util.io.NonBlockingIOThreadFactory.lambda$newThread$0(NonBlockingIOThreadFactory.java:18) ~[h4k-common-3.67.1.jar:?]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-common-4.1.119.Final.jar:4.1.119.Final]
	at com.sulake.h4k.common.util.io.NonBlockingIOThreadFactory.lambda$newThread$1(NonBlockingIOThreadFactory.java:26) ~[h4k-common-3.67.1.jar:?]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-common-4.1.119.Final.jar:4.1.119.Final]
	at java.lang.Thread.run(Thread.java:829) ~[?:?]
Caused by: io.netty.channel.StacklessClosedChannelException
	at io.netty.channel.AbstractChannel$AbstractUnsafe.write(Object, ChannelPromise)(Unknown Source) ~[netty-transport-4.1.119.Final.jar:4.1.119.Final]

org.redisson.client.WriteRedisConnectionException: Unable to write command into connection! Check CPU usage of the JVM. Try to increase nettyThreads setting. Node source: NodeSource [slot=0, addr=null, redisClient=null, redirect=null, entry=null], connection: RedisConnection@1072867253 [redisClient=[addr=redis://xxxcache.amazonaws.com:6379], channel=[id: 0xda53188b, L:/xxx:56398 ! R:xxxuse1.cache.amazonaws.com/xxx:6379], currentCommand=null, usage=1], command: (ZREVRANK), params: [xxxx, PooledUnsafeDirectByteBuf(ridx: 0, widx: 8, cap: 256)] after 1 retry attempts
	at org.redisson.command.RedisExecutor.checkWriteFuture(RedisExecutor.java:370) ~[redisson-3.39.0.jar:3.39.0]
	at org.redisson.command.RedisExecutor.lambda$execute$3(RedisExecutor.java:200) ~[redisson-3.39.0.jar:3.39.0]
	at io.netty.util.concurrent.DefaultPromise.notifyListener0(DefaultPromise.java:590) ~[netty-common-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.util.concurrent.DefaultPromise.notifyListenersNow(DefaultPromise.java:557) ~[netty-common-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.util.concurrent.DefaultPromise.notifyListeners(DefaultPromise.java:492) ~[netty-common-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.util.concurrent.DefaultPromise.setValue0(DefaultPromise.java:636) ~[netty-common-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.util.concurrent.DefaultPromise.setFailure0(DefaultPromise.java:629) ~[netty-common-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.util.concurrent.DefaultPromise.tryFailure(DefaultPromise.java:118) ~[netty-common-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.channel.AbstractChannel$AbstractUnsafe.safeSetFailure(AbstractChannel.java:997) ~[netty-transport-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.channel.AbstractChannel$AbstractUnsafe.write(AbstractChannel.java:858) ~[netty-transport-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.channel.DefaultChannelPipeline$HeadContext.write(DefaultChannelPipeline.java:1314) ~[netty-transport-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:889) ~[netty-transport-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeWriteAndFlush(AbstractChannelHandlerContext.java:956) ~[netty-transport-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.channel.AbstractChannelHandlerContext$WriteTask.run(AbstractChannelHandlerContext.java:1263) ~[netty-transport-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173) ~[netty-common-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166) ~[netty-common-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472) ~[netty-common-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:405) ~[netty-transport-classes-epoll-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:998) ~[netty-common-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[netty-common-4.1.119.Final.jar:4.1.119.Final]
	at com.sulake.h4k.common.util.io.NonBlockingIOThreadFactory.lambda$newThread$0(NonBlockingIOThreadFactory.java:18) ~[h4k-common-3.67.1.jar:?]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-common-4.1.119.Final.jar:4.1.119.Final]
	at com.sulake.h4k.common.util.io.NonBlockingIOThreadFactory.lambda$newThread$1(NonBlockingIOThreadFactory.java:26) ~[h4k-common-3.67.1.jar:?]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-common-4.1.119.Final.jar:4.1.119.Final]
	at java.lang.Thread.run(Thread.java:829) ~[?:?]
Caused by: io.netty.channel.StacklessClosedChannelException
	at io.netty.channel.AbstractChannel$AbstractUnsafe.write(Object, ChannelPromise)(Unknown Source) ~[netty-transport-4.1.119.Final.jar:4.1.119.Final]
```

The fix addresses what we believe is the "stale cached connection after an INFO timeout" edge case during the replication monitor loop. Previously, if checkNode(...) threw a RedisTimeoutException, the failure was logged but the cached RedisConnection remained in nodeConnections. This meant that on subsequent monitor passes, the same half-closed connection could be reused - skipping IP-change checks, causing repeated INFO failures, and preventing reconnection..

With handleNodeCheckError(...) now wired in, any timeout triggers disconnectNode, removing the cached entry. The next health check (or any operation touching that URI) will call connectToNode and create a fresh connection, allowing clean recovery from temporary timeouts instead of looping indefinitely on a dead one.

That said, this is still a theory - it’s only been verified via a unit test so far. We’d really like to get your opinion on whether this reasoning makes sense and if you see any potential gaps or unintended side effects.