### PR TITLE
fix LockTask, ReadLockTask

### DIFF
--- a/redisson/src/main/java/org/redisson/renewal/LockTask.java
+++ b/redisson/src/main/java/org/redisson/renewal/LockTask.java
@@ -59,8 +59,13 @@ public class LockTask extends RenewalTask {
                 continue;
             }
 
+            String lockName = entry.getLockName(threadId);
+            if (lockName == null) {
+                continue;
+            }
+
             keys.add(key);
-            args.add(entry.getLockName(threadId));
+            args.add(lockName);
             name2threadId.put(key, threadId);
 
             if (keys.size() == chunkSize) {

--- a/redisson/src/main/java/org/redisson/renewal/ReadLockTask.java
+++ b/redisson/src/main/java/org/redisson/renewal/ReadLockTask.java
@@ -60,10 +60,17 @@ public class ReadLockTask extends LockTask {
                 continue;
             }
 
+            String keyPrefix = entry.getKeyPrefix(threadId);
+            String lockName = entry.getLockName(threadId);
+
+            if (keyPrefix == null || lockName == null) {
+                continue;
+            }
+
             keys.add(key);
             keysArgs.add(key);
-            keysArgs.add(entry.getKeyPrefix(threadId));
-            args.add(entry.getLockName(threadId));
+            keysArgs.add(keyPrefix);
+            args.add(lockName);
             name2lockName.put(key, threadId);
 
             if (keys.size() == chunkSize) {
@@ -92,8 +99,8 @@ public class ReadLockTask extends LockTask {
                             "for n, key in ipairs(keys) do " +
                                 "counter = tonumber(redis.call('hget', KEYS[i], key)); " +
                                 "if type(counter) == 'number' then " +
-                                    "for i=counter, 1, -1 do " +
-                                        "redis.call('pexpire', KEYS[i+1] .. ':' .. key .. ':rwlock_timeout:' .. i, ARGV[1]); " +
+                                    "for c=counter, 1, -1 do " +
+                                        "redis.call('pexpire', KEYS[i+1] .. ':' .. key .. ':rwlock_timeout:' .. c, ARGV[1]); " +
                                     "end; " +
                                 "end; " +
                             "end; " +


### PR DESCRIPTION
We've found issue in Redisson's `ReadLockTask` and `LockTask`.
The 1st change:
Sometimes the task can't find a key prefix and a lock name by thread id because it was already removed (thread completed), and the vars return null, null can't be used in the redis command.
The same is applied for `LockTask`
Exception that is thrown:
`Can't update locks ... expiration`
`java.util.concurrent.CompletionException: org.redisson.client.RedisException: CROSSSLOT Keys in request don't hash to the same slot. channel: [id: 0x72e0a5d9, L:/HIDDEN_IP - R:HIDDEN_IP/HIDDEN_IP] command: (EVALSHA, cached script: local result = {} local j = 1 for i = 1, #KEYS, 2 do j = j + 1; local counter = redis.call('hget', KEYS[i], ARGV[j]); if (counter ~= false) then redis.call('pexpire', KEYS[i], ARGV[1]); if (redis.call...), params: [1affef780a01e1406cb1968c62918f618d10d6a3, 2, rwlock:1, null, 30000, null], promise: java.util.concurrent.CompletableFuture@765adc6a[Not completed, 1 dependents]`

The 2nd change:
When there is more than one argument in `KEYS[i]`, in the inner loop it uses the same iterator var - `i` which is wrong and this exception is thrown:
`Can't update locks ... expiration`
`java.util.concurrent.CompletionException: org.redisson.client.RedisException: ERR user_script:1: attempt to concatenate field '?' (a nil value) script: 1affef780a01e1406cb1968c62918f618d10d6a3, on @user_script:1.. channel: [id: 0xd11a6768, L:/HIDDEN_IP - R:HIDDEN_IP] command: (EVALSHA, cached script: local result = {} local j = 1 for i = 1, #KEYS, 2 do j = j + 1; local counter = redis.call('hget', KEYS[i], ARGV[j]); if (counter ~= false) then redis.call('pexpire', KEYS[i], ARGV[1]); if (redis.call...), params: [1affef780a01e1406cb1968c62918f618d10d6a3, 2, rwlock:2, {rwlock:3}, 30000, 36d23181-9ee3-4bc7-a415-a59378fa4525:1060], promise: java.util.concurrent.CompletableFuture@57faf13a[Not completed, 1 dependents]`

So it's needed to use a separate iterator var.