### PR TITLE
Fixed - LEAK: ByteBuf.release() was not called before it's garbage-collected. #6857

### DIFF
--- a/redisson/src/main/java/org/redisson/command/RedisExecutor.java
+++ b/redisson/src/main/java/org/redisson/command/RedisExecutor.java
@@ -571,6 +571,7 @@ public class RedisExecutor<V, R> {
                 RedisRedirectException ex = (RedisRedirectException) cause;
                 if (source.getRedirect() == Redirect.MOVED
                         && source.getAddr().equals(ex.getUrl())) {
+                    free();
                     mainPromise.completeExceptionally(new RedisException("MOVED redirection loop detected. Node " + source.getAddr() + " has further redirect to " + ex.getUrl()));
                     return;
                 }


### PR DESCRIPTION
[issues/6857](https://github.com/redisson/redisson/issues/6857)