### PR TITLE
Fixed - Redis TTL=-1 becomes 0 when using TimeUnit.SECONDS (breaking Redis semantics) #6874

### DIFF
--- a/redisson-spring/redisson-spring-data/redisson-spring-data-18/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-18/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -379,7 +379,15 @@ public class RedissonConnection extends AbstractRedisConnection {
 
     @Override
     public Long ttl(byte[] key, TimeUnit timeUnit) {
-        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("TTL", new SecondsConvertor(timeUnit, TimeUnit.SECONDS)), key);
+        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("TTL", new SecondsConvertor(timeUnit, TimeUnit.SECONDS) {
+            @Override
+            public Long convert(Object obj) {
+                if ((Long) obj < 0) {
+                    return (Long) obj;
+                }
+                return super.convert(obj);
+            }
+        }), key);
     }
 
     @Override
@@ -389,7 +397,15 @@ public class RedissonConnection extends AbstractRedisConnection {
 
     @Override
     public Long pTtl(byte[] key, TimeUnit timeUnit) {
-        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("PTTL", new SecondsConvertor(timeUnit, TimeUnit.MILLISECONDS)), key);
+        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("PTTL", new SecondsConvertor(timeUnit, TimeUnit.MILLISECONDS) {
+            @Override
+            public Long convert(Object obj) {
+                if ((Long) obj < 0) {
+                    return (Long) obj;
+                }
+                return super.convert(obj);
+            }
+        }), key);
     }
 
     @Override

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-18/src/test/java/org/redisson/spring/data/connection/RedissonConnectionTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-18/src/test/java/org/redisson/spring/data/connection/RedissonConnectionTest.java
@@ -8,6 +8,7 @@ import org.springframework.data.redis.connection.RedisGeoCommands;
 import org.springframework.data.redis.core.types.RedisClientInfo;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 public class RedissonConnectionTest extends BaseConnectionTest {
     
@@ -80,6 +81,46 @@ public class RedissonConnectionTest extends BaseConnectionTest {
     public void testGetClientList() {
         List<RedisClientInfo> info = connection.getClientList();
         assertThat(info.size()).isGreaterThan(10);
+    }
+
+    @Test
+    public void testPTtl() {
+        connection.set("key1".getBytes(), "value1".getBytes());
+        connection.set("key2".getBytes(), "value2".getBytes());
+        connection.expire("key1".getBytes(), 10);
+
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.MILLISECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.SECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10L);
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.MINUTES)).isEqualTo(0L);
+        assertThat(connection.pTtl("key1".getBytes())).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+
+        assertThat(connection.pTtl("key2".getBytes(), TimeUnit.SECONDS)).isEqualTo(-1L);
+        assertThat(connection.pTtl("key2".getBytes(), TimeUnit.MINUTES)).isEqualTo(-1L);
+        assertThat(connection.pTtl("key2".getBytes())).isEqualTo(-1L);
+
+        assertThat(connection.pTtl("key3".getBytes(), TimeUnit.SECONDS)).isEqualTo(-2L);
+        assertThat(connection.pTtl("key3".getBytes(), TimeUnit.MINUTES)).isEqualTo(-2L);
+        assertThat(connection.pTtl("key3".getBytes())).isEqualTo(-2L);
+    }
+
+    @Test
+    public void testTtl() {
+        connection.set("key1".getBytes(), "value1".getBytes());
+        connection.set("key2".getBytes(), "value2".getBytes());
+        connection.expire("key1".getBytes(), 10);
+
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.MILLISECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.SECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10L);
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.MINUTES)).isEqualTo(0L);
+        assertThat(connection.ttl("key1".getBytes())).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+
+        assertThat(connection.ttl("key2".getBytes(), TimeUnit.SECONDS)).isEqualTo(-1L);
+        assertThat(connection.ttl("key2".getBytes(), TimeUnit.MINUTES)).isEqualTo(-1L);
+        assertThat(connection.ttl("key2".getBytes())).isEqualTo(-1L);
+
+        assertThat(connection.ttl("key3".getBytes(), TimeUnit.SECONDS)).isEqualTo(-2L);
+        assertThat(connection.ttl("key3".getBytes(), TimeUnit.MINUTES)).isEqualTo(-2L);
+        assertThat(connection.ttl("key3".getBytes())).isEqualTo(-2L);
     }
 
 }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-20/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-20/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -364,7 +364,15 @@ public class RedissonConnection extends AbstractRedisConnection {
 
     @Override
     public Long ttl(byte[] key, TimeUnit timeUnit) {
-        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("TTL", new SecondsConvertor(timeUnit, TimeUnit.SECONDS)), key);
+        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("TTL", new SecondsConvertor(timeUnit, TimeUnit.SECONDS) {
+            @Override
+            public Long convert(Object obj) {
+                if ((Long) obj < 0) {
+                    return (Long) obj;
+                }
+                return super.convert(obj);
+            }
+        }), key);
     }
 
     @Override
@@ -374,7 +382,15 @@ public class RedissonConnection extends AbstractRedisConnection {
 
     @Override
     public Long pTtl(byte[] key, TimeUnit timeUnit) {
-        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("PTTL", new SecondsConvertor(timeUnit, TimeUnit.MILLISECONDS)), key);
+        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("PTTL", new SecondsConvertor(timeUnit, TimeUnit.MILLISECONDS) {
+            @Override
+            public Long convert(Object obj) {
+                if ((Long) obj < 0) {
+                    return (Long) obj;
+                }
+                return super.convert(obj);
+            }
+        }), key);
     }
 
     @Override

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-20/src/test/java/org/redisson/spring/data/connection/RedissonConnectionTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-20/src/test/java/org/redisson/spring/data/connection/RedissonConnectionTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import org.springframework.data.redis.core.types.RedisClientInfo;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 public class RedissonConnectionTest extends BaseConnectionTest {
     
@@ -30,6 +31,46 @@ public class RedissonConnectionTest extends BaseConnectionTest {
     public void testGetClientList() {
         List<RedisClientInfo> info = connection.getClientList();
         assertThat(info.size()).isGreaterThan(10);
+    }
+
+    @Test
+    public void testPTtl() {
+        connection.set("key1".getBytes(), "value1".getBytes());
+        connection.set("key2".getBytes(), "value2".getBytes());
+        connection.expire("key1".getBytes(), 10);
+
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.MILLISECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.SECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10L);
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.MINUTES)).isEqualTo(0L);
+        assertThat(connection.pTtl("key1".getBytes())).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+
+        assertThat(connection.pTtl("key2".getBytes(), TimeUnit.SECONDS)).isEqualTo(-1L);
+        assertThat(connection.pTtl("key2".getBytes(), TimeUnit.MINUTES)).isEqualTo(-1L);
+        assertThat(connection.pTtl("key2".getBytes())).isEqualTo(-1L);
+
+        assertThat(connection.pTtl("key3".getBytes(), TimeUnit.SECONDS)).isEqualTo(-2L);
+        assertThat(connection.pTtl("key3".getBytes(), TimeUnit.MINUTES)).isEqualTo(-2L);
+        assertThat(connection.pTtl("key3".getBytes())).isEqualTo(-2L);
+    }
+
+    @Test
+    public void testTtl() {
+        connection.set("key1".getBytes(), "value1".getBytes());
+        connection.set("key2".getBytes(), "value2".getBytes());
+        connection.expire("key1".getBytes(), 10);
+
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.MILLISECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.SECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10L);
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.MINUTES)).isEqualTo(0L);
+        assertThat(connection.ttl("key1".getBytes())).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+
+        assertThat(connection.ttl("key2".getBytes(), TimeUnit.SECONDS)).isEqualTo(-1L);
+        assertThat(connection.ttl("key2".getBytes(), TimeUnit.MINUTES)).isEqualTo(-1L);
+        assertThat(connection.ttl("key2".getBytes())).isEqualTo(-1L);
+
+        assertThat(connection.ttl("key3".getBytes(), TimeUnit.SECONDS)).isEqualTo(-2L);
+        assertThat(connection.ttl("key3".getBytes(), TimeUnit.MINUTES)).isEqualTo(-2L);
+        assertThat(connection.ttl("key3".getBytes())).isEqualTo(-2L);
     }
 
 }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-21/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-21/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -367,7 +367,15 @@ public class RedissonConnection extends AbstractRedisConnection {
 
     @Override
     public Long ttl(byte[] key, TimeUnit timeUnit) {
-        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("TTL", new SecondsConvertor(timeUnit, TimeUnit.SECONDS)), key);
+        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("TTL", new SecondsConvertor(timeUnit, TimeUnit.SECONDS) {
+            @Override
+            public Long convert(Object obj) {
+                if ((Long) obj < 0) {
+                    return (Long) obj;
+                }
+                return super.convert(obj);
+            }
+        }), key);
     }
 
     @Override
@@ -377,7 +385,15 @@ public class RedissonConnection extends AbstractRedisConnection {
 
     @Override
     public Long pTtl(byte[] key, TimeUnit timeUnit) {
-        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("PTTL", new SecondsConvertor(timeUnit, TimeUnit.MILLISECONDS)), key);
+        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("PTTL", new SecondsConvertor(timeUnit, TimeUnit.MILLISECONDS) {
+            @Override
+            public Long convert(Object obj) {
+                if ((Long) obj < 0) {
+                    return (Long) obj;
+                }
+                return super.convert(obj);
+            }
+        }), key);
     }
 
     @Override

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-21/src/test/java/org/redisson/spring/data/connection/RedissonConnectionTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-21/src/test/java/org/redisson/spring/data/connection/RedissonConnectionTest.java
@@ -3,7 +3,6 @@ package org.redisson.spring.data.connection;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
-import org.redisson.api.RBitSet;
 import org.springframework.data.redis.connection.BitFieldSubCommands;
 import org.springframework.data.redis.connection.RedisStringCommands.SetOption;
 import org.springframework.data.redis.connection.RedisZSetCommands;
@@ -12,8 +11,8 @@ import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.core.types.RedisClientInfo;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 public class RedissonConnectionTest extends BaseConnectionTest {
 
@@ -74,6 +73,46 @@ public class RedissonConnectionTest extends BaseConnectionTest {
     public void testGetClientList() {
         List<RedisClientInfo> info = connection.getClientList();
         assertThat(info.size()).isGreaterThan(10);
+    }
+
+    @Test
+    public void testPTtl() {
+        connection.set("key1".getBytes(), "value1".getBytes());
+        connection.set("key2".getBytes(), "value2".getBytes());
+        connection.expire("key1".getBytes(), 10);
+
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.MILLISECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.SECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10L);
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.MINUTES)).isEqualTo(0L);
+        assertThat(connection.pTtl("key1".getBytes())).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+
+        assertThat(connection.pTtl("key2".getBytes(), TimeUnit.SECONDS)).isEqualTo(-1L);
+        assertThat(connection.pTtl("key2".getBytes(), TimeUnit.MINUTES)).isEqualTo(-1L);
+        assertThat(connection.pTtl("key2".getBytes())).isEqualTo(-1L);
+
+        assertThat(connection.pTtl("key3".getBytes(), TimeUnit.SECONDS)).isEqualTo(-2L);
+        assertThat(connection.pTtl("key3".getBytes(), TimeUnit.MINUTES)).isEqualTo(-2L);
+        assertThat(connection.pTtl("key3".getBytes())).isEqualTo(-2L);
+    }
+
+    @Test
+    public void testTtl() {
+        connection.set("key1".getBytes(), "value1".getBytes());
+        connection.set("key2".getBytes(), "value2".getBytes());
+        connection.expire("key1".getBytes(), 10);
+
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.MILLISECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.SECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10L);
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.MINUTES)).isEqualTo(0L);
+        assertThat(connection.ttl("key1".getBytes())).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+
+        assertThat(connection.ttl("key2".getBytes(), TimeUnit.SECONDS)).isEqualTo(-1L);
+        assertThat(connection.ttl("key2".getBytes(), TimeUnit.MINUTES)).isEqualTo(-1L);
+        assertThat(connection.ttl("key2".getBytes())).isEqualTo(-1L);
+
+        assertThat(connection.ttl("key3".getBytes(), TimeUnit.SECONDS)).isEqualTo(-2L);
+        assertThat(connection.ttl("key3".getBytes(), TimeUnit.MINUTES)).isEqualTo(-2L);
+        assertThat(connection.ttl("key3".getBytes())).isEqualTo(-2L);
     }
 
 }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-22/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-22/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -367,7 +367,15 @@ public class RedissonConnection extends AbstractRedisConnection {
 
     @Override
     public Long ttl(byte[] key, TimeUnit timeUnit) {
-        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("TTL", new SecondsConvertor(timeUnit, TimeUnit.SECONDS)), key);
+        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("TTL", new SecondsConvertor(timeUnit, TimeUnit.SECONDS) {
+            @Override
+            public Long convert(Object obj) {
+                if ((Long) obj < 0) {
+                    return (Long) obj;
+                }
+                return super.convert(obj);
+            }
+        }), key);
     }
 
     @Override
@@ -377,7 +385,15 @@ public class RedissonConnection extends AbstractRedisConnection {
 
     @Override
     public Long pTtl(byte[] key, TimeUnit timeUnit) {
-        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("PTTL", new SecondsConvertor(timeUnit, TimeUnit.MILLISECONDS)), key);
+        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("PTTL", new SecondsConvertor(timeUnit, TimeUnit.MILLISECONDS) {
+            @Override
+            public Long convert(Object obj) {
+                if ((Long) obj < 0) {
+                    return (Long) obj;
+                }
+                return super.convert(obj);
+            }
+        }), key);
     }
 
     @Override

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-22/src/test/java/org/redisson/spring/data/connection/RedissonConnectionTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-22/src/test/java/org/redisson/spring/data/connection/RedissonConnectionTest.java
@@ -9,6 +9,7 @@ import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.core.types.RedisClientInfo;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -71,6 +72,46 @@ public class RedissonConnectionTest extends BaseConnectionTest {
     public void testGetClientList() {
         List<RedisClientInfo> info = connection.getClientList();
         assertThat(info.size()).isGreaterThan(10);
+    }
+
+    @Test
+    public void testPTtl() {
+        connection.set("key1".getBytes(), "value1".getBytes());
+        connection.set("key2".getBytes(), "value2".getBytes());
+        connection.expire("key1".getBytes(), 10);
+
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.MILLISECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.SECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10L);
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.MINUTES)).isEqualTo(0L);
+        assertThat(connection.pTtl("key1".getBytes())).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+
+        assertThat(connection.pTtl("key2".getBytes(), TimeUnit.SECONDS)).isEqualTo(-1L);
+        assertThat(connection.pTtl("key2".getBytes(), TimeUnit.MINUTES)).isEqualTo(-1L);
+        assertThat(connection.pTtl("key2".getBytes())).isEqualTo(-1L);
+
+        assertThat(connection.pTtl("key3".getBytes(), TimeUnit.SECONDS)).isEqualTo(-2L);
+        assertThat(connection.pTtl("key3".getBytes(), TimeUnit.MINUTES)).isEqualTo(-2L);
+        assertThat(connection.pTtl("key3".getBytes())).isEqualTo(-2L);
+    }
+
+    @Test
+    public void testTtl() {
+        connection.set("key1".getBytes(), "value1".getBytes());
+        connection.set("key2".getBytes(), "value2".getBytes());
+        connection.expire("key1".getBytes(), 10);
+
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.MILLISECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.SECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10L);
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.MINUTES)).isEqualTo(0L);
+        assertThat(connection.ttl("key1".getBytes())).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+
+        assertThat(connection.ttl("key2".getBytes(), TimeUnit.SECONDS)).isEqualTo(-1L);
+        assertThat(connection.ttl("key2".getBytes(), TimeUnit.MINUTES)).isEqualTo(-1L);
+        assertThat(connection.ttl("key2".getBytes())).isEqualTo(-1L);
+
+        assertThat(connection.ttl("key3".getBytes(), TimeUnit.SECONDS)).isEqualTo(-2L);
+        assertThat(connection.ttl("key3".getBytes(), TimeUnit.MINUTES)).isEqualTo(-2L);
+        assertThat(connection.ttl("key3".getBytes())).isEqualTo(-2L);
     }
 
 }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-23/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-23/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -367,7 +367,15 @@ public class RedissonConnection extends AbstractRedisConnection {
 
     @Override
     public Long ttl(byte[] key, TimeUnit timeUnit) {
-        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("TTL", new SecondsConvertor(timeUnit, TimeUnit.SECONDS)), key);
+        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("TTL", new SecondsConvertor(timeUnit, TimeUnit.SECONDS) {
+            @Override
+            public Long convert(Object obj) {
+                if ((Long) obj < 0) {
+                    return (Long) obj;
+                }
+                return super.convert(obj);
+            }
+        }), key);
     }
 
     @Override
@@ -377,7 +385,15 @@ public class RedissonConnection extends AbstractRedisConnection {
 
     @Override
     public Long pTtl(byte[] key, TimeUnit timeUnit) {
-        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("PTTL", new SecondsConvertor(timeUnit, TimeUnit.MILLISECONDS)), key);
+        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("PTTL", new SecondsConvertor(timeUnit, TimeUnit.MILLISECONDS) {
+            @Override
+            public Long convert(Object obj) {
+                if ((Long) obj < 0) {
+                    return (Long) obj;
+                }
+                return super.convert(obj);
+            }
+        }), key);
     }
 
     @Override

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-23/src/test/java/org/redisson/spring/data/connection/RedissonConnectionTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-23/src/test/java/org/redisson/spring/data/connection/RedissonConnectionTest.java
@@ -16,6 +16,7 @@ import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.core.types.RedisClientInfo;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 public class RedissonConnectionTest extends BaseConnectionTest {
 
@@ -91,4 +92,44 @@ public class RedissonConnectionTest extends BaseConnectionTest {
         assertThat(info.size()).isGreaterThan(10);
     }
 
+    @Test
+    public void testPTtl() {
+        connection.set("key1".getBytes(), "value1".getBytes());
+        connection.set("key2".getBytes(), "value2".getBytes());
+        connection.expire("key1".getBytes(), 10);
+
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.MILLISECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.SECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10L);
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.MINUTES)).isEqualTo(0L);
+        assertThat(connection.pTtl("key1".getBytes())).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+
+        assertThat(connection.pTtl("key2".getBytes(), TimeUnit.SECONDS)).isEqualTo(-1L);
+        assertThat(connection.pTtl("key2".getBytes(), TimeUnit.MINUTES)).isEqualTo(-1L);
+        assertThat(connection.pTtl("key2".getBytes())).isEqualTo(-1L);
+
+        assertThat(connection.pTtl("key3".getBytes(), TimeUnit.SECONDS)).isEqualTo(-2L);
+        assertThat(connection.pTtl("key3".getBytes(), TimeUnit.MINUTES)).isEqualTo(-2L);
+        assertThat(connection.pTtl("key3".getBytes())).isEqualTo(-2L);
+    }
+
+    @Test
+    public void testTtl() {
+        connection.set("key1".getBytes(), "value1".getBytes());
+        connection.set("key2".getBytes(), "value2".getBytes());
+        connection.expire("key1".getBytes(), 10);
+
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.MILLISECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.SECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10L);
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.MINUTES)).isEqualTo(0L);
+        assertThat(connection.ttl("key1".getBytes())).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+
+        assertThat(connection.ttl("key2".getBytes(), TimeUnit.SECONDS)).isEqualTo(-1L);
+        assertThat(connection.ttl("key2".getBytes(), TimeUnit.MINUTES)).isEqualTo(-1L);
+        assertThat(connection.ttl("key2".getBytes())).isEqualTo(-1L);
+
+        assertThat(connection.ttl("key3".getBytes(), TimeUnit.SECONDS)).isEqualTo(-2L);
+        assertThat(connection.ttl("key3".getBytes(), TimeUnit.MINUTES)).isEqualTo(-2L);
+        assertThat(connection.ttl("key3".getBytes())).isEqualTo(-2L);
+    }
+    
 }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-24/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-24/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -383,7 +383,15 @@ public class RedissonConnection extends AbstractRedisConnection {
 
     @Override
     public Long ttl(byte[] key, TimeUnit timeUnit) {
-        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("TTL", new SecondsConvertor(timeUnit, TimeUnit.SECONDS)), key);
+        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("TTL", new SecondsConvertor(timeUnit, TimeUnit.SECONDS) {
+            @Override
+            public Long convert(Object obj) {
+                if ((Long) obj < 0) {
+                    return (Long) obj;
+                }
+                return super.convert(obj);
+            }
+        }), key);
     }
 
     @Override
@@ -393,7 +401,15 @@ public class RedissonConnection extends AbstractRedisConnection {
 
     @Override
     public Long pTtl(byte[] key, TimeUnit timeUnit) {
-        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("PTTL", new SecondsConvertor(timeUnit, TimeUnit.MILLISECONDS)), key);
+        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("PTTL", new SecondsConvertor(timeUnit, TimeUnit.MILLISECONDS) {
+            @Override
+            public Long convert(Object obj) {
+                if ((Long) obj < 0) {
+                    return (Long) obj;
+                }
+                return super.convert(obj);
+            }
+        }), key);
     }
 
     @Override

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-24/src/test/java/org/redisson/spring/data/connection/RedissonConnectionTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-24/src/test/java/org/redisson/spring/data/connection/RedissonConnectionTest.java
@@ -18,6 +18,7 @@ import org.springframework.data.redis.core.types.RedisClientInfo;
 
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 public class RedissonConnectionTest extends BaseConnectionTest {
 
@@ -121,4 +122,44 @@ public class RedissonConnectionTest extends BaseConnectionTest {
         assertThat(info.size()).isGreaterThan(10);
     }
 
+    @Test
+    public void testPTtl() {
+        connection.set("key1".getBytes(), "value1".getBytes());
+        connection.set("key2".getBytes(), "value2".getBytes());
+        connection.expire("key1".getBytes(), 10);
+
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.MILLISECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.SECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10L);
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.MINUTES)).isEqualTo(0L);
+        assertThat(connection.pTtl("key1".getBytes())).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+
+        assertThat(connection.pTtl("key2".getBytes(), TimeUnit.SECONDS)).isEqualTo(-1L);
+        assertThat(connection.pTtl("key2".getBytes(), TimeUnit.MINUTES)).isEqualTo(-1L);
+        assertThat(connection.pTtl("key2".getBytes())).isEqualTo(-1L);
+
+        assertThat(connection.pTtl("key3".getBytes(), TimeUnit.SECONDS)).isEqualTo(-2L);
+        assertThat(connection.pTtl("key3".getBytes(), TimeUnit.MINUTES)).isEqualTo(-2L);
+        assertThat(connection.pTtl("key3".getBytes())).isEqualTo(-2L);
+    }
+
+    @Test
+    public void testTtl() {
+        connection.set("key1".getBytes(), "value1".getBytes());
+        connection.set("key2".getBytes(), "value2".getBytes());
+        connection.expire("key1".getBytes(), 10);
+
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.MILLISECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.SECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10L);
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.MINUTES)).isEqualTo(0L);
+        assertThat(connection.ttl("key1".getBytes())).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+
+        assertThat(connection.ttl("key2".getBytes(), TimeUnit.SECONDS)).isEqualTo(-1L);
+        assertThat(connection.ttl("key2".getBytes(), TimeUnit.MINUTES)).isEqualTo(-1L);
+        assertThat(connection.ttl("key2".getBytes())).isEqualTo(-1L);
+
+        assertThat(connection.ttl("key3".getBytes(), TimeUnit.SECONDS)).isEqualTo(-2L);
+        assertThat(connection.ttl("key3".getBytes(), TimeUnit.MINUTES)).isEqualTo(-2L);
+        assertThat(connection.ttl("key3".getBytes())).isEqualTo(-2L);
+    }
+    
 }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-25/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-25/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -383,7 +383,15 @@ public class RedissonConnection extends AbstractRedisConnection {
 
     @Override
     public Long ttl(byte[] key, TimeUnit timeUnit) {
-        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("TTL", new SecondsConvertor(timeUnit, TimeUnit.SECONDS)), key);
+        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("TTL", new SecondsConvertor(timeUnit, TimeUnit.SECONDS) {
+            @Override
+            public Long convert(Object obj) {
+                if ((Long) obj < 0) {
+                    return (Long) obj;
+                }
+                return super.convert(obj);
+            }
+        }), key);
     }
 
     @Override
@@ -393,7 +401,15 @@ public class RedissonConnection extends AbstractRedisConnection {
 
     @Override
     public Long pTtl(byte[] key, TimeUnit timeUnit) {
-        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("PTTL", new SecondsConvertor(timeUnit, TimeUnit.MILLISECONDS)), key);
+        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("PTTL", new SecondsConvertor(timeUnit, TimeUnit.MILLISECONDS) {
+            @Override
+            public Long convert(Object obj) {
+                if ((Long) obj < 0) {
+                    return (Long) obj;
+                }
+                return super.convert(obj);
+            }
+        }), key);
     }
 
     @Override

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-25/src/test/java/org/redisson/spring/data/connection/RedissonConnectionTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-25/src/test/java/org/redisson/spring/data/connection/RedissonConnectionTest.java
@@ -18,6 +18,7 @@ import org.springframework.data.redis.core.types.RedisClientInfo;
 
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 public class RedissonConnectionTest extends BaseConnectionTest {
 
@@ -119,6 +120,46 @@ public class RedissonConnectionTest extends BaseConnectionTest {
     public void testGetClientList() {
         List<RedisClientInfo> info = connection.getClientList();
         assertThat(info.size()).isGreaterThan(10);
+    }
+
+    @Test
+    public void testPTtl() {
+        connection.set("key1".getBytes(), "value1".getBytes());
+        connection.set("key2".getBytes(), "value2".getBytes());
+        connection.expire("key1".getBytes(), 10);
+
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.MILLISECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.SECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10L);
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.MINUTES)).isEqualTo(0L);
+        assertThat(connection.pTtl("key1".getBytes())).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+
+        assertThat(connection.pTtl("key2".getBytes(), TimeUnit.SECONDS)).isEqualTo(-1L);
+        assertThat(connection.pTtl("key2".getBytes(), TimeUnit.MINUTES)).isEqualTo(-1L);
+        assertThat(connection.pTtl("key2".getBytes())).isEqualTo(-1L);
+
+        assertThat(connection.pTtl("key3".getBytes(), TimeUnit.SECONDS)).isEqualTo(-2L);
+        assertThat(connection.pTtl("key3".getBytes(), TimeUnit.MINUTES)).isEqualTo(-2L);
+        assertThat(connection.pTtl("key3".getBytes())).isEqualTo(-2L);
+    }
+
+    @Test
+    public void testTtl() {
+        connection.set("key1".getBytes(), "value1".getBytes());
+        connection.set("key2".getBytes(), "value2".getBytes());
+        connection.expire("key1".getBytes(), 10);
+
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.MILLISECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.SECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10L);
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.MINUTES)).isEqualTo(0L);
+        assertThat(connection.ttl("key1".getBytes())).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+
+        assertThat(connection.ttl("key2".getBytes(), TimeUnit.SECONDS)).isEqualTo(-1L);
+        assertThat(connection.ttl("key2".getBytes(), TimeUnit.MINUTES)).isEqualTo(-1L);
+        assertThat(connection.ttl("key2".getBytes())).isEqualTo(-1L);
+
+        assertThat(connection.ttl("key3".getBytes(), TimeUnit.SECONDS)).isEqualTo(-2L);
+        assertThat(connection.ttl("key3".getBytes(), TimeUnit.MINUTES)).isEqualTo(-2L);
+        assertThat(connection.ttl("key3".getBytes())).isEqualTo(-2L);
     }
 
 }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-26/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-26/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -388,7 +388,15 @@ public class RedissonConnection extends AbstractRedisConnection {
 
     @Override
     public Long ttl(byte[] key, TimeUnit timeUnit) {
-        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("TTL", new SecondsConvertor(timeUnit, TimeUnit.SECONDS)), key);
+        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("TTL", new SecondsConvertor(timeUnit, TimeUnit.SECONDS) {
+            @Override
+            public Long convert(Object obj) {
+                if ((Long) obj < 0) {
+                    return (Long) obj;
+                }
+                return super.convert(obj);
+            }
+        }), key);
     }
 
     @Override
@@ -398,7 +406,15 @@ public class RedissonConnection extends AbstractRedisConnection {
 
     @Override
     public Long pTtl(byte[] key, TimeUnit timeUnit) {
-        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("PTTL", new SecondsConvertor(timeUnit, TimeUnit.MILLISECONDS)), key);
+        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("PTTL", new SecondsConvertor(timeUnit, TimeUnit.MILLISECONDS) {
+            @Override
+            public Long convert(Object obj) {
+                if ((Long) obj < 0) {
+                    return (Long) obj;
+                }
+                return super.convert(obj);
+            }
+        }), key);
     }
 
     @Override

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-26/src/test/java/org/redisson/spring/data/connection/RedissonConnectionTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-26/src/test/java/org/redisson/spring/data/connection/RedissonConnectionTest.java
@@ -16,6 +16,7 @@ import org.springframework.data.redis.serializer.RedisSerializer;
 
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 public class RedissonConnectionTest extends BaseConnectionTest {
 
@@ -182,5 +183,45 @@ public class RedissonConnectionTest extends BaseConnectionTest {
         assertThat(filteredResults.get(0)).isEqualTo("value3");
         assertThat(filteredResults.get(1)).isEqualTo("value4");
     }
-    
+
+    @Test
+    public void testPTtl() {
+        connection.set("key1".getBytes(), "value1".getBytes());
+        connection.set("key2".getBytes(), "value2".getBytes());
+        connection.expire("key1".getBytes(), 10);
+
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.MILLISECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.SECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10L);
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.MINUTES)).isEqualTo(0L);
+        assertThat(connection.pTtl("key1".getBytes())).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+
+        assertThat(connection.pTtl("key2".getBytes(), TimeUnit.SECONDS)).isEqualTo(-1L);
+        assertThat(connection.pTtl("key2".getBytes(), TimeUnit.MINUTES)).isEqualTo(-1L);
+        assertThat(connection.pTtl("key2".getBytes())).isEqualTo(-1L);
+
+        assertThat(connection.pTtl("key3".getBytes(), TimeUnit.SECONDS)).isEqualTo(-2L);
+        assertThat(connection.pTtl("key3".getBytes(), TimeUnit.MINUTES)).isEqualTo(-2L);
+        assertThat(connection.pTtl("key3".getBytes())).isEqualTo(-2L);
+    }
+
+    @Test
+    public void testTtl() {
+        connection.set("key1".getBytes(), "value1".getBytes());
+        connection.set("key2".getBytes(), "value2".getBytes());
+        connection.expire("key1".getBytes(), 10);
+
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.MILLISECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.SECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10L);
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.MINUTES)).isEqualTo(0L);
+        assertThat(connection.ttl("key1".getBytes())).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+
+        assertThat(connection.ttl("key2".getBytes(), TimeUnit.SECONDS)).isEqualTo(-1L);
+        assertThat(connection.ttl("key2".getBytes(), TimeUnit.MINUTES)).isEqualTo(-1L);
+        assertThat(connection.ttl("key2".getBytes())).isEqualTo(-1L);
+
+        assertThat(connection.ttl("key3".getBytes(), TimeUnit.SECONDS)).isEqualTo(-2L);
+        assertThat(connection.ttl("key3".getBytes(), TimeUnit.MINUTES)).isEqualTo(-2L);
+        assertThat(connection.ttl("key3".getBytes())).isEqualTo(-2L);
+    }
+
 }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-27/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-27/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -388,7 +388,15 @@ public class RedissonConnection extends AbstractRedisConnection {
 
     @Override
     public Long ttl(byte[] key, TimeUnit timeUnit) {
-        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("TTL", new SecondsConvertor(timeUnit, TimeUnit.SECONDS)), key);
+        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("TTL", new SecondsConvertor(timeUnit, TimeUnit.SECONDS) {
+            @Override
+            public Long convert(Object obj) {
+                if ((Long) obj < 0) {
+                    return (Long) obj;
+                }
+                return super.convert(obj);
+            }
+        }), key);
     }
 
     @Override
@@ -398,7 +406,15 @@ public class RedissonConnection extends AbstractRedisConnection {
 
     @Override
     public Long pTtl(byte[] key, TimeUnit timeUnit) {
-        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("PTTL", new SecondsConvertor(timeUnit, TimeUnit.MILLISECONDS)), key);
+        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("PTTL", new SecondsConvertor(timeUnit, TimeUnit.MILLISECONDS) {
+            @Override
+            public Long convert(Object obj) {
+                if ((Long) obj < 0) {
+                    return (Long) obj;
+                }
+                return super.convert(obj);
+            }
+        }), key);
     }
 
     @Override

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-27/src/test/java/org/redisson/spring/data/connection/RedissonConnectionTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-27/src/test/java/org/redisson/spring/data/connection/RedissonConnectionTest.java
@@ -16,6 +16,7 @@ import org.springframework.data.redis.serializer.RedisSerializer;
 
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 public class RedissonConnectionTest extends BaseConnectionTest {
 
@@ -169,4 +170,45 @@ public class RedissonConnectionTest extends BaseConnectionTest {
         assertThat(filteredResults.get(0)).isEqualTo("value3");
         assertThat(filteredResults.get(1)).isEqualTo("value4");
     }
+
+    @Test
+    public void testPTtl() {
+        connection.set("key1".getBytes(), "value1".getBytes());
+        connection.set("key2".getBytes(), "value2".getBytes());
+        connection.expire("key1".getBytes(), 10);
+
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.MILLISECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.SECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10L);
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.MINUTES)).isEqualTo(0L);
+        assertThat(connection.pTtl("key1".getBytes())).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+
+        assertThat(connection.pTtl("key2".getBytes(), TimeUnit.SECONDS)).isEqualTo(-1L);
+        assertThat(connection.pTtl("key2".getBytes(), TimeUnit.MINUTES)).isEqualTo(-1L);
+        assertThat(connection.pTtl("key2".getBytes())).isEqualTo(-1L);
+
+        assertThat(connection.pTtl("key3".getBytes(), TimeUnit.SECONDS)).isEqualTo(-2L);
+        assertThat(connection.pTtl("key3".getBytes(), TimeUnit.MINUTES)).isEqualTo(-2L);
+        assertThat(connection.pTtl("key3".getBytes())).isEqualTo(-2L);
+    }
+
+    @Test
+    public void testTtl() {
+        connection.set("key1".getBytes(), "value1".getBytes());
+        connection.set("key2".getBytes(), "value2".getBytes());
+        connection.expire("key1".getBytes(), 10);
+
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.MILLISECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.SECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10L);
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.MINUTES)).isEqualTo(0L);
+        assertThat(connection.ttl("key1".getBytes())).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+
+        assertThat(connection.ttl("key2".getBytes(), TimeUnit.SECONDS)).isEqualTo(-1L);
+        assertThat(connection.ttl("key2".getBytes(), TimeUnit.MINUTES)).isEqualTo(-1L);
+        assertThat(connection.ttl("key2".getBytes())).isEqualTo(-1L);
+
+        assertThat(connection.ttl("key3".getBytes(), TimeUnit.SECONDS)).isEqualTo(-2L);
+        assertThat(connection.ttl("key3".getBytes(), TimeUnit.MINUTES)).isEqualTo(-2L);
+        assertThat(connection.ttl("key3".getBytes())).isEqualTo(-2L);
+    }
+
 }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-30/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-30/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -392,7 +392,15 @@ public class RedissonConnection extends AbstractRedisConnection {
 
     @Override
     public Long ttl(byte[] key, TimeUnit timeUnit) {
-        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("TTL", new SecondsConvertor(timeUnit, TimeUnit.SECONDS)), key);
+        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("TTL", new SecondsConvertor(timeUnit, TimeUnit.SECONDS) {
+            @Override
+            public Long convert(Object obj) {
+                if ((Long) obj < 0) {
+                    return (Long) obj;
+                }
+                return super.convert(obj);
+            }
+        }), key);
     }
 
     @Override
@@ -402,7 +410,15 @@ public class RedissonConnection extends AbstractRedisConnection {
 
     @Override
     public Long pTtl(byte[] key, TimeUnit timeUnit) {
-        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("PTTL", new SecondsConvertor(timeUnit, TimeUnit.MILLISECONDS)), key);
+        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("PTTL", new SecondsConvertor(timeUnit, TimeUnit.MILLISECONDS) {
+            @Override
+            public Long convert(Object obj) {
+                if ((Long) obj < 0) {
+                    return (Long) obj;
+                }
+                return super.convert(obj);
+            }
+        }), key);
     }
 
     @Override

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-30/src/test/java/org/redisson/spring/data/connection/RedissonConnectionTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-30/src/test/java/org/redisson/spring/data/connection/RedissonConnectionTest.java
@@ -18,6 +18,7 @@ import org.springframework.data.redis.serializer.RedisSerializer;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 public class RedissonConnectionTest extends BaseConnectionTest {
 
@@ -187,5 +188,45 @@ public class RedissonConnectionTest extends BaseConnectionTest {
         assertThat(filteredResults.get(0)).isEqualTo("value3");
         assertThat(filteredResults.get(1)).isEqualTo("value4");
     }
-    
+
+    @Test
+    public void testPTtl() {
+        connection.set("key1".getBytes(), "value1".getBytes());
+        connection.set("key2".getBytes(), "value2".getBytes());
+        connection.expire("key1".getBytes(), 10);
+
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.MILLISECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.SECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10L);
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.MINUTES)).isEqualTo(0L);
+        assertThat(connection.pTtl("key1".getBytes())).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+
+        assertThat(connection.pTtl("key2".getBytes(), TimeUnit.SECONDS)).isEqualTo(-1L);
+        assertThat(connection.pTtl("key2".getBytes(), TimeUnit.MINUTES)).isEqualTo(-1L);
+        assertThat(connection.pTtl("key2".getBytes())).isEqualTo(-1L);
+
+        assertThat(connection.pTtl("key3".getBytes(), TimeUnit.SECONDS)).isEqualTo(-2L);
+        assertThat(connection.pTtl("key3".getBytes(), TimeUnit.MINUTES)).isEqualTo(-2L);
+        assertThat(connection.pTtl("key3".getBytes())).isEqualTo(-2L);
+    }
+
+    @Test
+    public void testTtl() {
+        connection.set("key1".getBytes(), "value1".getBytes());
+        connection.set("key2".getBytes(), "value2".getBytes());
+        connection.expire("key1".getBytes(), 10);
+
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.MILLISECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.SECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10L);
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.MINUTES)).isEqualTo(0L);
+        assertThat(connection.ttl("key1".getBytes())).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+
+        assertThat(connection.ttl("key2".getBytes(), TimeUnit.SECONDS)).isEqualTo(-1L);
+        assertThat(connection.ttl("key2".getBytes(), TimeUnit.MINUTES)).isEqualTo(-1L);
+        assertThat(connection.ttl("key2".getBytes())).isEqualTo(-1L);
+
+        assertThat(connection.ttl("key3".getBytes(), TimeUnit.SECONDS)).isEqualTo(-2L);
+        assertThat(connection.ttl("key3".getBytes(), TimeUnit.MINUTES)).isEqualTo(-2L);
+        assertThat(connection.ttl("key3".getBytes())).isEqualTo(-2L);
+    }
+
 }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-31/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-31/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -392,7 +392,15 @@ public class RedissonConnection extends AbstractRedisConnection {
 
     @Override
     public Long ttl(byte[] key, TimeUnit timeUnit) {
-        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("TTL", new SecondsConvertor(timeUnit, TimeUnit.SECONDS)), key);
+        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("TTL", new SecondsConvertor(timeUnit, TimeUnit.SECONDS) {
+            @Override
+            public Long convert(Object obj) {
+                if ((Long) obj < 0) {
+                    return (Long) obj;
+                }
+                return super.convert(obj);
+            }
+        }), key);
     }
 
     @Override
@@ -402,7 +410,15 @@ public class RedissonConnection extends AbstractRedisConnection {
 
     @Override
     public Long pTtl(byte[] key, TimeUnit timeUnit) {
-        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("PTTL", new SecondsConvertor(timeUnit, TimeUnit.MILLISECONDS)), key);
+        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("PTTL", new SecondsConvertor(timeUnit, TimeUnit.MILLISECONDS) {
+            @Override
+            public Long convert(Object obj) {
+                if ((Long) obj < 0) {
+                    return (Long) obj;
+                }
+                return super.convert(obj);
+            }
+        }), key);
     }
 
     @Override

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-31/src/test/java/org/redisson/spring/data/connection/RedissonConnectionTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-31/src/test/java/org/redisson/spring/data/connection/RedissonConnectionTest.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -335,5 +336,45 @@ public class RedissonConnectionTest extends BaseConnectionTest {
         assertThat(filteredResults.get(0)).isEqualTo("value3");
         assertThat(filteredResults.get(1)).isEqualTo("value4");
     }
-    
+
+    @Test
+    public void testPTtl() {
+        connection.set("key1".getBytes(), "value1".getBytes());
+        connection.set("key2".getBytes(), "value2".getBytes());
+        connection.expire("key1".getBytes(), 10);
+
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.MILLISECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.SECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10L);
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.MINUTES)).isEqualTo(0L);
+        assertThat(connection.pTtl("key1".getBytes())).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+
+        assertThat(connection.pTtl("key2".getBytes(), TimeUnit.SECONDS)).isEqualTo(-1L);
+        assertThat(connection.pTtl("key2".getBytes(), TimeUnit.MINUTES)).isEqualTo(-1L);
+        assertThat(connection.pTtl("key2".getBytes())).isEqualTo(-1L);
+
+        assertThat(connection.pTtl("key3".getBytes(), TimeUnit.SECONDS)).isEqualTo(-2L);
+        assertThat(connection.pTtl("key3".getBytes(), TimeUnit.MINUTES)).isEqualTo(-2L);
+        assertThat(connection.pTtl("key3".getBytes())).isEqualTo(-2L);
+    }
+
+    @Test
+    public void testTtl() {
+        connection.set("key1".getBytes(), "value1".getBytes());
+        connection.set("key2".getBytes(), "value2".getBytes());
+        connection.expire("key1".getBytes(), 10);
+
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.MILLISECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.SECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10L);
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.MINUTES)).isEqualTo(0L);
+        assertThat(connection.ttl("key1".getBytes())).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+
+        assertThat(connection.ttl("key2".getBytes(), TimeUnit.SECONDS)).isEqualTo(-1L);
+        assertThat(connection.ttl("key2".getBytes(), TimeUnit.MINUTES)).isEqualTo(-1L);
+        assertThat(connection.ttl("key2".getBytes())).isEqualTo(-1L);
+
+        assertThat(connection.ttl("key3".getBytes(), TimeUnit.SECONDS)).isEqualTo(-2L);
+        assertThat(connection.ttl("key3".getBytes(), TimeUnit.MINUTES)).isEqualTo(-2L);
+        assertThat(connection.ttl("key3".getBytes())).isEqualTo(-2L);
+    }
+
 }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-32/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-32/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -392,7 +392,15 @@ public class RedissonConnection extends AbstractRedisConnection {
 
     @Override
     public Long ttl(byte[] key, TimeUnit timeUnit) {
-        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("TTL", new SecondsConvertor(timeUnit, TimeUnit.SECONDS)), key);
+        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("TTL", new SecondsConvertor(timeUnit, TimeUnit.SECONDS) {
+            @Override
+            public Long convert(Object obj) {
+                if ((Long) obj < 0) {
+                    return (Long) obj;
+                }
+                return super.convert(obj);
+            }
+        }), key);
     }
 
     @Override
@@ -402,7 +410,15 @@ public class RedissonConnection extends AbstractRedisConnection {
 
     @Override
     public Long pTtl(byte[] key, TimeUnit timeUnit) {
-        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("PTTL", new SecondsConvertor(timeUnit, TimeUnit.MILLISECONDS)), key);
+        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("PTTL", new SecondsConvertor(timeUnit, TimeUnit.MILLISECONDS) {
+            @Override
+            public Long convert(Object obj) {
+                if ((Long) obj < 0) {
+                    return (Long) obj;
+                }
+                return super.convert(obj);
+            }
+        }), key);
     }
 
     @Override

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-32/src/test/java/org/redisson/spring/data/connection/RedissonConnectionTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-32/src/test/java/org/redisson/spring/data/connection/RedissonConnectionTest.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -334,6 +335,46 @@ public class RedissonConnectionTest extends BaseConnectionTest {
         assertThat(filteredResults).hasSize(2);
         assertThat(filteredResults.get(0)).isEqualTo("value3");
         assertThat(filteredResults.get(1)).isEqualTo("value4");
+    }
+
+    @Test
+    public void testPTtl() {
+        connection.set("key1".getBytes(), "value1".getBytes());
+        connection.set("key2".getBytes(), "value2".getBytes());
+        connection.expire("key1".getBytes(), 10);
+
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.MILLISECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.SECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10L);
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.MINUTES)).isEqualTo(0L);
+        assertThat(connection.pTtl("key1".getBytes())).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+
+        assertThat(connection.pTtl("key2".getBytes(), TimeUnit.SECONDS)).isEqualTo(-1L);
+        assertThat(connection.pTtl("key2".getBytes(), TimeUnit.MINUTES)).isEqualTo(-1L);
+        assertThat(connection.pTtl("key2".getBytes())).isEqualTo(-1L);
+
+        assertThat(connection.pTtl("key3".getBytes(), TimeUnit.SECONDS)).isEqualTo(-2L);
+        assertThat(connection.pTtl("key3".getBytes(), TimeUnit.MINUTES)).isEqualTo(-2L);
+        assertThat(connection.pTtl("key3".getBytes())).isEqualTo(-2L);
+    }
+
+    @Test
+    public void testTtl() {
+        connection.set("key1".getBytes(), "value1".getBytes());
+        connection.set("key2".getBytes(), "value2".getBytes());
+        connection.expire("key1".getBytes(), 10);
+
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.MILLISECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.SECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10L);
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.MINUTES)).isEqualTo(0L);
+        assertThat(connection.ttl("key1".getBytes())).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+
+        assertThat(connection.ttl("key2".getBytes(), TimeUnit.SECONDS)).isEqualTo(-1L);
+        assertThat(connection.ttl("key2".getBytes(), TimeUnit.MINUTES)).isEqualTo(-1L);
+        assertThat(connection.ttl("key2".getBytes())).isEqualTo(-1L);
+
+        assertThat(connection.ttl("key3".getBytes(), TimeUnit.SECONDS)).isEqualTo(-2L);
+        assertThat(connection.ttl("key3".getBytes(), TimeUnit.MINUTES)).isEqualTo(-2L);
+        assertThat(connection.ttl("key3".getBytes())).isEqualTo(-2L);
     }
     
 }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-33/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-33/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -392,7 +392,15 @@ public class RedissonConnection extends AbstractRedisConnection {
 
     @Override
     public Long ttl(byte[] key, TimeUnit timeUnit) {
-        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("TTL", new SecondsConvertor(timeUnit, TimeUnit.SECONDS)), key);
+        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("TTL", new SecondsConvertor(timeUnit, TimeUnit.SECONDS) {
+            @Override
+            public Long convert(Object obj) {
+                if ((Long) obj < 0) {
+                    return (Long) obj;
+                }
+                return super.convert(obj);
+            }
+        }), key);
     }
 
     @Override
@@ -402,7 +410,15 @@ public class RedissonConnection extends AbstractRedisConnection {
 
     @Override
     public Long pTtl(byte[] key, TimeUnit timeUnit) {
-        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("PTTL", new SecondsConvertor(timeUnit, TimeUnit.MILLISECONDS)), key);
+        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("PTTL", new SecondsConvertor(timeUnit, TimeUnit.MILLISECONDS) {
+            @Override
+            public Long convert(Object obj) {
+                if ((Long) obj < 0) {
+                    return (Long) obj;
+                }
+                return super.convert(obj);
+            }
+        }), key);
     }
 
     @Override

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-33/src/test/java/org/redisson/spring/data/connection/RedissonConnectionTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-33/src/test/java/org/redisson/spring/data/connection/RedissonConnectionTest.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -315,6 +316,46 @@ public class RedissonConnectionTest extends BaseConnectionTest {
         assertThat(filteredResults).hasSize(2);
         assertThat(filteredResults.get(0)).isEqualTo("value3");
         assertThat(filteredResults.get(1)).isEqualTo("value4");
+    }
+
+    @Test
+    public void testPTtl() {
+        connection.set("key1".getBytes(), "value1".getBytes());
+        connection.set("key2".getBytes(), "value2".getBytes());
+        connection.expire("key1".getBytes(), 10);
+
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.MILLISECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.SECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10L);
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.MINUTES)).isEqualTo(0L);
+        assertThat(connection.pTtl("key1".getBytes())).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+
+        assertThat(connection.pTtl("key2".getBytes(), TimeUnit.SECONDS)).isEqualTo(-1L);
+        assertThat(connection.pTtl("key2".getBytes(), TimeUnit.MINUTES)).isEqualTo(-1L);
+        assertThat(connection.pTtl("key2".getBytes())).isEqualTo(-1L);
+
+        assertThat(connection.pTtl("key3".getBytes(), TimeUnit.SECONDS)).isEqualTo(-2L);
+        assertThat(connection.pTtl("key3".getBytes(), TimeUnit.MINUTES)).isEqualTo(-2L);
+        assertThat(connection.pTtl("key3".getBytes())).isEqualTo(-2L);
+    }
+
+    @Test
+    public void testTtl() {
+        connection.set("key1".getBytes(), "value1".getBytes());
+        connection.set("key2".getBytes(), "value2".getBytes());
+        connection.expire("key1".getBytes(), 10);
+
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.MILLISECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.SECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10L);
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.MINUTES)).isEqualTo(0L);
+        assertThat(connection.ttl("key1".getBytes())).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+
+        assertThat(connection.ttl("key2".getBytes(), TimeUnit.SECONDS)).isEqualTo(-1L);
+        assertThat(connection.ttl("key2".getBytes(), TimeUnit.MINUTES)).isEqualTo(-1L);
+        assertThat(connection.ttl("key2".getBytes())).isEqualTo(-1L);
+
+        assertThat(connection.ttl("key3".getBytes(), TimeUnit.SECONDS)).isEqualTo(-2L);
+        assertThat(connection.ttl("key3".getBytes(), TimeUnit.MINUTES)).isEqualTo(-2L);
+        assertThat(connection.ttl("key3".getBytes())).isEqualTo(-2L);
     }
     
 }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-34/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-34/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -392,7 +392,15 @@ public class RedissonConnection extends AbstractRedisConnection {
 
     @Override
     public Long ttl(byte[] key, TimeUnit timeUnit) {
-        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("TTL", new SecondsConvertor(timeUnit, TimeUnit.SECONDS)), key);
+        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("TTL", new SecondsConvertor(timeUnit, TimeUnit.SECONDS) {
+            @Override
+            public Long convert(Object obj) {
+                if ((Long) obj < 0) {
+                    return (Long) obj;
+                }
+                return super.convert(obj);
+            }
+        }), key);
     }
 
     @Override
@@ -402,7 +410,15 @@ public class RedissonConnection extends AbstractRedisConnection {
 
     @Override
     public Long pTtl(byte[] key, TimeUnit timeUnit) {
-        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("PTTL", new SecondsConvertor(timeUnit, TimeUnit.MILLISECONDS)), key);
+        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("PTTL", new SecondsConvertor(timeUnit, TimeUnit.MILLISECONDS) {
+            @Override
+            public Long convert(Object obj) {
+                if ((Long) obj < 0) {
+                    return (Long) obj;
+                }
+                return super.convert(obj);
+            }
+        }), key);
     }
 
     @Override

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-34/src/test/java/org/redisson/spring/data/connection/RedissonConnectionTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-34/src/test/java/org/redisson/spring/data/connection/RedissonConnectionTest.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -315,6 +316,46 @@ public class RedissonConnectionTest extends BaseConnectionTest {
         assertThat(filteredResults).hasSize(2);
         assertThat(filteredResults.get(0)).isEqualTo("value3");
         assertThat(filteredResults.get(1)).isEqualTo("value4");
+    }
+
+    @Test
+    public void testPTtl() {
+        connection.set("key1".getBytes(), "value1".getBytes());
+        connection.set("key2".getBytes(), "value2".getBytes());
+        connection.expire("key1".getBytes(), 10);
+
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.MILLISECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.SECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10L);
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.MINUTES)).isEqualTo(0L);
+        assertThat(connection.pTtl("key1".getBytes())).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+
+        assertThat(connection.pTtl("key2".getBytes(), TimeUnit.SECONDS)).isEqualTo(-1L);
+        assertThat(connection.pTtl("key2".getBytes(), TimeUnit.MINUTES)).isEqualTo(-1L);
+        assertThat(connection.pTtl("key2".getBytes())).isEqualTo(-1L);
+
+        assertThat(connection.pTtl("key3".getBytes(), TimeUnit.SECONDS)).isEqualTo(-2L);
+        assertThat(connection.pTtl("key3".getBytes(), TimeUnit.MINUTES)).isEqualTo(-2L);
+        assertThat(connection.pTtl("key3".getBytes())).isEqualTo(-2L);
+    }
+
+    @Test
+    public void testTtl() {
+        connection.set("key1".getBytes(), "value1".getBytes());
+        connection.set("key2".getBytes(), "value2".getBytes());
+        connection.expire("key1".getBytes(), 10);
+
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.MILLISECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.SECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10L);
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.MINUTES)).isEqualTo(0L);
+        assertThat(connection.ttl("key1".getBytes())).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+
+        assertThat(connection.ttl("key2".getBytes(), TimeUnit.SECONDS)).isEqualTo(-1L);
+        assertThat(connection.ttl("key2".getBytes(), TimeUnit.MINUTES)).isEqualTo(-1L);
+        assertThat(connection.ttl("key2".getBytes())).isEqualTo(-1L);
+
+        assertThat(connection.ttl("key3".getBytes(), TimeUnit.SECONDS)).isEqualTo(-2L);
+        assertThat(connection.ttl("key3".getBytes(), TimeUnit.MINUTES)).isEqualTo(-2L);
+        assertThat(connection.ttl("key3".getBytes())).isEqualTo(-2L);
     }
     
 }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-35/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-35/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -392,7 +392,15 @@ public class RedissonConnection extends AbstractRedisConnection {
 
     @Override
     public Long ttl(byte[] key, TimeUnit timeUnit) {
-        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("TTL", new SecondsConvertor(timeUnit, TimeUnit.SECONDS)), key);
+        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("TTL", new SecondsConvertor(timeUnit, TimeUnit.SECONDS) {
+            @Override
+            public Long convert(Object obj) {
+                if ((Long) obj < 0) {
+                    return (Long) obj;
+                }
+                return super.convert(obj);
+            }
+        }), key);
     }
 
     @Override
@@ -402,7 +410,15 @@ public class RedissonConnection extends AbstractRedisConnection {
 
     @Override
     public Long pTtl(byte[] key, TimeUnit timeUnit) {
-        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("PTTL", new SecondsConvertor(timeUnit, TimeUnit.MILLISECONDS)), key);
+        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("PTTL", new SecondsConvertor(timeUnit, TimeUnit.MILLISECONDS) {
+            @Override
+            public Long convert(Object obj) {
+                if ((Long) obj < 0) {
+                    return (Long) obj;
+                }
+                return super.convert(obj);
+            }
+        }), key);
     }
 
     @Override

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-35/src/test/java/org/redisson/spring/data/connection/RedissonConnectionTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-35/src/test/java/org/redisson/spring/data/connection/RedissonConnectionTest.java
@@ -396,5 +396,45 @@ public class RedissonConnectionTest extends BaseConnectionTest {
         assertThat(filteredResults.get(0)).isEqualTo("value3");
         assertThat(filteredResults.get(1)).isEqualTo("value4");
     }
-    
+
+    @Test
+    public void testPTtl() {
+        connection.set("key1".getBytes(), "value1".getBytes());
+        connection.set("key2".getBytes(), "value2".getBytes());
+        connection.expire("key1".getBytes(), Duration.ofSeconds(10));
+
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.MILLISECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.SECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10L);
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.MINUTES)).isEqualTo(0L);
+        assertThat(connection.pTtl("key1".getBytes())).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+
+        assertThat(connection.pTtl("key2".getBytes(), TimeUnit.SECONDS)).isEqualTo(-1L);
+        assertThat(connection.pTtl("key2".getBytes(), TimeUnit.MINUTES)).isEqualTo(-1L);
+        assertThat(connection.pTtl("key2".getBytes())).isEqualTo(-1L);
+
+        assertThat(connection.pTtl("key3".getBytes(), TimeUnit.SECONDS)).isEqualTo(-2L);
+        assertThat(connection.pTtl("key3".getBytes(), TimeUnit.MINUTES)).isEqualTo(-2L);
+        assertThat(connection.pTtl("key3".getBytes())).isEqualTo(-2L);
+    }
+
+    @Test
+    public void testTtl() {
+        connection.set("key1".getBytes(), "value1".getBytes());
+        connection.set("key2".getBytes(), "value2".getBytes());
+        connection.expire("key1".getBytes(), Duration.ofSeconds(10));
+
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.MILLISECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.SECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10L);
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.MINUTES)).isEqualTo(0L);
+        assertThat(connection.ttl("key1".getBytes())).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+
+        assertThat(connection.ttl("key2".getBytes(), TimeUnit.SECONDS)).isEqualTo(-1L);
+        assertThat(connection.ttl("key2".getBytes(), TimeUnit.MINUTES)).isEqualTo(-1L);
+        assertThat(connection.ttl("key2".getBytes())).isEqualTo(-1L);
+
+        assertThat(connection.ttl("key3".getBytes(), TimeUnit.SECONDS)).isEqualTo(-2L);
+        assertThat(connection.ttl("key3".getBytes(), TimeUnit.MINUTES)).isEqualTo(-2L);
+        assertThat(connection.ttl("key3".getBytes())).isEqualTo(-2L);
+    }
+
 }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-40/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-40/src/main/java/org/redisson/spring/data/connection/RedissonConnection.java
@@ -392,7 +392,15 @@ public class RedissonConnection extends AbstractRedisConnection {
 
     @Override
     public Long ttl(byte[] key, TimeUnit timeUnit) {
-        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("TTL", new SecondsConvertor(timeUnit, TimeUnit.SECONDS)), key);
+        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("TTL", new SecondsConvertor(timeUnit, TimeUnit.SECONDS) {
+            @Override
+            public Long convert(Object obj) {
+                if ((Long) obj < 0) {
+                    return (Long) obj;
+                }
+                return super.convert(obj);
+            }
+        }), key);
     }
 
     @Override
@@ -402,7 +410,15 @@ public class RedissonConnection extends AbstractRedisConnection {
 
     @Override
     public Long pTtl(byte[] key, TimeUnit timeUnit) {
-        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("PTTL", new SecondsConvertor(timeUnit, TimeUnit.MILLISECONDS)), key);
+        return read(key, StringCodec.INSTANCE, new RedisStrictCommand<Long>("PTTL", new SecondsConvertor(timeUnit, TimeUnit.MILLISECONDS) {
+            @Override
+            public Long convert(Object obj) {
+                if ((Long) obj < 0) {
+                    return (Long) obj;
+                }
+                return super.convert(obj);
+            }
+        }), key);
     }
 
     @Override

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-40/src/test/java/org/redisson/spring/data/connection/RedissonConnectionTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-40/src/test/java/org/redisson/spring/data/connection/RedissonConnectionTest.java
@@ -9,7 +9,6 @@ import org.springframework.data.redis.connection.Limit;
 import org.springframework.data.redis.connection.ReactiveRedisConnection;
 import org.springframework.data.redis.connection.RedisGeoCommands;
 import org.springframework.data.redis.connection.RedisStringCommands.SetOption;
-import org.springframework.data.redis.connection.RedisZSetCommands;
 import org.springframework.data.redis.connection.zset.Tuple;
 import org.springframework.data.redis.core.*;
 import org.springframework.data.redis.core.types.Expiration;
@@ -417,5 +416,44 @@ public class RedissonConnectionTest extends BaseConnectionTest {
         assertThat(r2).isEqualTo(1);
     }
 
-    
+    @Test
+    public void testPTtl() {
+        connection.set("key1".getBytes(), "value1".getBytes());
+        connection.set("key2".getBytes(), "value2".getBytes());
+        connection.expire("key1".getBytes(), Duration.ofSeconds(10));
+
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.MILLISECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.SECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10L);
+        assertThat(connection.pTtl("key1".getBytes(), TimeUnit.MINUTES)).isEqualTo(0L);
+        assertThat(connection.pTtl("key1".getBytes())).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+
+        assertThat(connection.pTtl("key2".getBytes(), TimeUnit.SECONDS)).isEqualTo(-1L);
+        assertThat(connection.pTtl("key2".getBytes(), TimeUnit.MINUTES)).isEqualTo(-1L);
+        assertThat(connection.pTtl("key2".getBytes())).isEqualTo(-1L);
+
+        assertThat(connection.pTtl("key3".getBytes(), TimeUnit.SECONDS)).isEqualTo(-2L);
+        assertThat(connection.pTtl("key3".getBytes(), TimeUnit.MINUTES)).isEqualTo(-2L);
+        assertThat(connection.pTtl("key3".getBytes())).isEqualTo(-2L);
+    }
+
+    @Test
+    public void testTtl() {
+        connection.set("key1".getBytes(), "value1".getBytes());
+        connection.set("key2".getBytes(), "value2".getBytes());
+        connection.expire("key1".getBytes(), Duration.ofSeconds(10));
+
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.MILLISECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.SECONDS)).isGreaterThan(0L).isLessThanOrEqualTo(10L);
+        assertThat(connection.ttl("key1".getBytes(), TimeUnit.MINUTES)).isEqualTo(0L);
+        assertThat(connection.ttl("key1".getBytes())).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+
+        assertThat(connection.ttl("key2".getBytes(), TimeUnit.SECONDS)).isEqualTo(-1L);
+        assertThat(connection.ttl("key2".getBytes(), TimeUnit.MINUTES)).isEqualTo(-1L);
+        assertThat(connection.ttl("key2".getBytes())).isEqualTo(-1L);
+
+        assertThat(connection.ttl("key3".getBytes(), TimeUnit.SECONDS)).isEqualTo(-2L);
+        assertThat(connection.ttl("key3".getBytes(), TimeUnit.MINUTES)).isEqualTo(-2L);
+        assertThat(connection.ttl("key3".getBytes())).isEqualTo(-2L);
+    }
+
 }


### PR DESCRIPTION
[issues/6874](https://github.com/redisson/redisson/issues/6874)