### PR TITLE
Fix typo: 'occured' -> 'occurred'

### DIFF
--- a/redisson/src/main/java/org/redisson/client/handler/ErrorsLoggingHandler.java
+++ b/redisson/src/main/java/org/redisson/client/handler/ErrorsLoggingHandler.java
@@ -44,7 +44,7 @@ public class ErrorsLoggingHandler extends ChannelDuplexHandler {
             }
         }
 
-        log.error("Exception occured. Channel: {}", ctx.channel(), cause);
+        log.error("Exception occurred. Channel: {}", ctx.channel(), cause);
     }
 
 }

--- a/redisson/src/main/java/org/redisson/command/RedisExecutor.java
+++ b/redisson/src/main/java/org/redisson/command/RedisExecutor.java
@@ -470,7 +470,7 @@ public class RedisExecutor<V, R> {
 
             int pendingTasks = countPendingTasks();
             attemptPromise.completeExceptionally(
-                    new RedisResponseTimeoutException("Redis server response timeout (" + timeoutAmount + " ms) occured"
+                    new RedisResponseTimeoutException("Redis server response timeout (" + timeoutAmount + " ms) occurred"
                             + " after " + attempt + " of " + attempts + " retry attempts,"
                             + " is non-idempotent command: " + (command != null && command.isNoRetry())
                             + " Check connection with Redis node: " + connection.getRedisClient().getAddr() + " for TCP packet drops or bandwidth limits. "


### PR DESCRIPTION
Fix spelling of 'occurred' in error messages.