### PR TITLE
Fix potential negative index in load balancers

### DIFF
--- a/redisson/src/main/java/org/redisson/connection/balancer/RoundRobinLoadBalancer.java
+++ b/redisson/src/main/java/org/redisson/connection/balancer/RoundRobinLoadBalancer.java
@@ -36,7 +36,7 @@ public class RoundRobinLoadBalancer extends BaseLoadBalancer {
             return null;
         }
 
-        int ind = Math.abs(index.incrementAndGet() % clientsCopy.size());
+        int ind = Math.floorMod(index.incrementAndGet(), clientsCopy.size());
         return clientsCopy.get(ind);
     }
 

--- a/redisson/src/main/java/org/redisson/connection/balancer/WeightedRoundRobinBalancer.java
+++ b/redisson/src/main/java/org/redisson/connection/balancer/WeightedRoundRobinBalancer.java
@@ -124,7 +124,7 @@ public class WeightedRoundRobinBalancer implements LoadBalancer {
                 clientsCopy = findClients(clients, weightsCopy);
             }
 
-            int ind = Math.abs(index.incrementAndGet() % clientsCopy.size());
+            int ind = Math.floorMod(index.incrementAndGet(), clientsCopy.size());
             ClientConnectionsEntry entry = clientsCopy.get(ind);
             for (Entry<RedisURI, WeightEntry> weightEntry : weightsCopy.entrySet()) {
                 if (weightEntry.getKey().equals(entry.getClient().getAddr())) {


### PR DESCRIPTION
Math.abs(Integer.MIN_VALUE) returns negative value, which may cause ArrayIndexOutOfBoundsException.