### PR TITLE
Clarify parameter description in setCleanUpKeysAmount

### DIFF
--- a/redisson/src/main/java/org/redisson/config/Config.java
+++ b/redisson/src/main/java/org/redisson/config/Config.java
@@ -894,7 +894,7 @@ public class Config {
      * <p>
      * Default is <code>100</code>.
      *
-     * @param cleanUpKeysAmount - delay in seconds
+     * @param cleanUpKeysAmount - amount
      * @return config
      */
     public Config setCleanUpKeysAmount(int cleanUpKeysAmount) {


### PR DESCRIPTION
Updated parameter description for the setCleanUpKeysAmount method. 

The param is related to expired keys amount not to a delay in seconds.