### PR TITLE
Fix GraalVM reflection issue

### DIFF
--- a/redisson-spring/redisson-spring-boot-starter/src/main/java/org/redisson/spring/starter/RedissonAutoConfiguration.java
+++ b/redisson-spring/redisson-spring-boot-starter/src/main/java/org/redisson/spring/starter/RedissonAutoConfiguration.java
@@ -367,6 +367,7 @@ public class RedissonAutoConfiguration {
         return prefix;
     }
 
+    @SuppressWarnings("IllegalCatch")
     private String[] convertNodes(String prefix, List<?> nodesObject) {
         List<String> nodes = new ArrayList<>(nodesObject.size());
         try {
@@ -382,7 +383,7 @@ public class RedissonAutoConfiguration {
 
                 nodes.add(prefix + host + ":" + port);
             }
-        } catch (Exception e) {
+        } catch (Throwable e) {
             throw new IllegalStateException("Failed to convert nodes", e);
         }
         return nodes.toArray(new String[0]);

--- a/redisson-spring/redisson-spring-boot-starter/src/main/java/org/redisson/spring/starter/RedissonAutoConfigurationV4.java
+++ b/redisson-spring/redisson-spring-boot-starter/src/main/java/org/redisson/spring/starter/RedissonAutoConfigurationV4.java
@@ -334,6 +334,7 @@ public class RedissonAutoConfigurationV4 {
         return prefix;
     }
 
+    @SuppressWarnings("IllegalCatch")
     private String[] convertNodes(String prefix, List<?> nodesObject) {
         List<String> nodes = new ArrayList<>(nodesObject.size());
         try {
@@ -349,7 +350,7 @@ public class RedissonAutoConfigurationV4 {
 
                 nodes.add(prefix + host + ":" + port);
             }
-        } catch (Exception e) {
+        } catch (Throwable e) {
             throw new IllegalStateException("Failed to convert nodes", e);
         }
         return nodes.toArray(new String[0]);


### PR DESCRIPTION
Fixes #6830

Remove reflection from convertNodes() to support GraalVM Native Image，Use MethodHandles instead of reflection to dynamically invoke host() and port() methods。