### PR TITLE
Fix setAndKeepTTLAsync to add a whitespace after "then"

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonJsonBucket.java
+++ b/redisson/src/main/java/org/redisson/RedissonJsonBucket.java
@@ -518,7 +518,7 @@ public class RedissonJsonBucket<V> extends RedissonExpirable implements RJsonBuc
         return commandExecutor.evalWriteAsync(getRawName(), codec, RedisCommands.EVAL_VOID,
                 "local ttl = redis.call('pttl', KEYS[1]);" +
                       "redis.call('json.set', KEYS[1], '$', ARGV[1]); " +
-                      "if ttl > 0 then" +
+                      "if ttl > 0 then " +
                         "redis.call('pexpire', KEYS[1], ttl); " +
                       "end;",
                 Collections.singletonList(getRawName()), encode(value));


### PR DESCRIPTION
Fix RedissonJsonBucket.setAndKeepTTLAsync to create correct script with space between "then" and "redis.call...."

To fix the issue raised here: https://github.com/redisson/redisson/issues/6947
