### PR TITLE
Change return type of RSet.containsEach() list to set

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonSet.java
+++ b/redisson/src/main/java/org/redisson/RedissonSet.java
@@ -26,7 +26,7 @@ import org.redisson.client.codec.Codec;
 import org.redisson.client.codec.LongCodec;
 import org.redisson.client.protocol.RedisCommand;
 import org.redisson.client.protocol.RedisCommands;
-import org.redisson.client.protocol.decoder.ContainsDecoder;
+import org.redisson.client.protocol.decoder.ContainsSetDecoder;
 import org.redisson.command.CommandAsyncExecutor;
 import org.redisson.iterator.BaseAsyncIterator;
 import org.redisson.iterator.RedissonBaseIterator;
@@ -421,9 +421,9 @@ public class RedissonSet<V> extends RedissonExpirable implements RSet<V>, ScanIt
     }
 
     @Override
-    public RFuture<List<V>> containsEachAsync(Collection<V> c) {
+    public RFuture<Set<V>> containsEachAsync(Collection<V> c) {
         if (c.isEmpty()) {
-            return new CompletableFutureWrapper<>(Collections.<V>emptyList());
+            return new CompletableFutureWrapper<>(Collections.<V>emptySet());
         }
 
         List<Object> args = new ArrayList<>(c.size() + 1);
@@ -431,7 +431,7 @@ public class RedissonSet<V> extends RedissonExpirable implements RSet<V>, ScanIt
         encode(args, c);
 
         return commandExecutor.readAsync(getRawName(), LongCodec.INSTANCE,
-                new RedisCommand<>("SMISMEMBER", new ContainsDecoder<>(c)), args.toArray());
+                new RedisCommand<>("SMISMEMBER", new ContainsSetDecoder<>(c)), args.toArray());
     }
 
     @Override
@@ -777,7 +777,7 @@ public class RedissonSet<V> extends RedissonExpirable implements RSet<V>, ScanIt
     }
 
     @Override
-    public List<V> containsEach(Collection<V> c) {
+    public Set<V> containsEach(Collection<V> c) {
         return get(containsEachAsync(c));
     }
 

--- a/redisson/src/main/java/org/redisson/RedissonSetCache.java
+++ b/redisson/src/main/java/org/redisson/RedissonSetCache.java
@@ -624,7 +624,7 @@ public class RedissonSetCache<V> extends RedissonExpirable implements RSetCache<
     }
 
     @Override
-    public List<V> containsEach(Collection<V> c) {
+    public Set<V> containsEach(Collection<V> c) {
         throw new UnsupportedOperationException();
     }
 
@@ -906,7 +906,7 @@ public class RedissonSetCache<V> extends RedissonExpirable implements RSetCache<
     }
 
     @Override
-    public RFuture<List<V>> containsEachAsync(Collection<V> c) {
+    public RFuture<Set<V>> containsEachAsync(Collection<V> c) {
         throw new UnsupportedOperationException();
     }
 

--- a/redisson/src/main/java/org/redisson/RedissonSetMultimapValues.java
+++ b/redisson/src/main/java/org/redisson/RedissonSetMultimapValues.java
@@ -70,7 +70,7 @@ public class RedissonSetMultimapValues<V> extends RedissonExpirable implements R
     }
 
     @Override
-    public List<V> containsEach(Collection<V> c) {
+    public Set<V> containsEach(Collection<V> c) {
         throw new UnsupportedOperationException("This operation is not supported for SetMultimap values");
     }
 
@@ -514,7 +514,7 @@ public class RedissonSetMultimapValues<V> extends RedissonExpirable implements R
     }
 
     @Override
-    public RFuture<List<V>> containsEachAsync(Collection<V> c) {
+    public RFuture<Set<V>> containsEachAsync(Collection<V> c) {
         throw new UnsupportedOperationException("This operation is not supported for SetMultimap values");
     }
 

--- a/redisson/src/main/java/org/redisson/api/RSet.java
+++ b/redisson/src/main/java/org/redisson/api/RSet.java
@@ -19,7 +19,6 @@ import org.redisson.api.mapreduce.RCollectionMapReduce;
 
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -334,7 +333,7 @@ public interface RSet<V> extends Set<V>, RExpirable, RSetAsync<V>, RSortable<Set
      * @param c - collection to check
      * @return contained elements
      */
-    List<V> containsEach(Collection<V> c);
+    Set<V> containsEach(Collection<V> c);
 
     /**
      * Adds object event listener

--- a/redisson/src/main/java/org/redisson/api/RSetAsync.java
+++ b/redisson/src/main/java/org/redisson/api/RSetAsync.java
@@ -16,7 +16,6 @@
 package org.redisson.api;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -189,7 +188,7 @@ public interface RSetAsync<V> extends RCollectionAsync<V>, RSortableAsync<Set<V>
      * @param c - collection to check
      * @return contained elements
      */
-    RFuture<List<V>> containsEachAsync(Collection<V> c);
+    RFuture<Set<V>> containsEachAsync(Collection<V> c);
 
     /**
      * Adds object event listener

--- a/redisson/src/main/java/org/redisson/api/RSetReactive.java
+++ b/redisson/src/main/java/org/redisson/api/RSetReactive.java
@@ -19,7 +19,6 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -258,7 +257,7 @@ public interface RSetReactive<V> extends RCollectionReactive<V>, RSortableReacti
      * @param c - collection to check
      * @return contained elements
      */
-    Mono<List<V>> containsEach(Collection<V> c);
+    Mono<Set<V>> containsEach(Collection<V> c);
 
     /**
      * Adds object event listener

--- a/redisson/src/main/java/org/redisson/api/RSetRx.java
+++ b/redisson/src/main/java/org/redisson/api/RSetRx.java
@@ -16,7 +16,6 @@
 package org.redisson.api;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Set;
 
 import io.reactivex.rxjava3.core.Flowable;
@@ -260,7 +259,7 @@ public interface RSetRx<V> extends RCollectionRx<V>, RSortableRx<Set<V>> {
      * @param c - collection to check
      * @return contained elements
      */
-    Single<List<V>> containsEach(Collection<V> c);
+    Single<Set<V>> containsEach(Collection<V> c);
 
     /**
      * Adds object event listener

--- a/redisson/src/test/java/org/redisson/RedissonSetTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonSetTest.java
@@ -52,7 +52,7 @@ public class RedissonSetTest extends RedisDockerTest {
                 .containsOnly(0, 1);
 
         assertThat(set.containsEach(Arrays.asList(0, 1, 0, 2)))
-                .hasSize(3)
+                .hasSize(2)
                 .containsOnly(0, 1, 0);
 
         assertThat(set.containsEach(Arrays.asList(2, 3, 4)))


### PR DESCRIPTION
Change the return type of `RSet.ContainsEach()` to Set using `ContainsSetDecoder` !
issue : #6951 

