### PR TITLE
Fixed - slaveDown() freezes master connection during ElastiCache/Valkey upgrade #6997

### DIFF
--- a/redisson/src/main/java/org/redisson/connection/MasterSlaveEntry.java
+++ b/redisson/src/main/java/org/redisson/connection/MasterSlaveEntry.java
@@ -189,16 +189,24 @@ public class MasterSlaveEntry {
 
     public boolean slaveDown(InetSocketAddress address) {
         ClientConnectionsEntry connectionEntry = getEntry(address);
+        if (connectionEntry != null && connectionEntry == masterEntry) {
+            log.warn("slaveDown called with master address {}, ignoring to prevent master freeze", address);
+            return false;
+        }
         ClientConnectionsEntry entry = freeze(connectionEntry, FreezeReason.MANAGER);
         if (entry == null) {
             return false;
         }
-        
+
         return slaveDown(entry);
     }
 
     public boolean slaveDown(RedisURI address) {
         ClientConnectionsEntry connectionEntry = getEntry(address);
+        if (connectionEntry != null && connectionEntry == masterEntry) {
+            log.warn("slaveDown called with master address {}, ignoring to prevent master freeze", address);
+            return false;
+        }
         ClientConnectionsEntry entry = freeze(connectionEntry, FreezeReason.MANAGER);
         if (entry == null) {
             return false;


### PR DESCRIPTION
## Problem

  During ElastiCache or Valkey engine upgrades, `CLUSTER NODES` transiently reports master IPs as their own replicas. When this happens:

  1. `ClusterConnectionManager.addRemoveSlaves()` computes the master URI as a "removed slave"
  2. Calls `MasterSlaveEntry.slaveDown(masterURI)`
  3. `getEntry(masterURI)` resolves to the `masterEntry` itself
  4. `freeze(masterEntry, FreezeReason.MANAGER)` freezes the master — `initialized=false`, all connections destroyed
  5. `FreezeReason.MANAGER` has no automatic recovery path (unlike `RECONNECT` which triggers `scheduleCheck`)

  This causes extended unavailability (minutes to hours) with `RedisTimeoutException: Unable to acquire connection`.

  ### Evidence from logs

  Masters appearing as their own slaves during upgrade:
  added slaves detected for master rediss://10.91.237.124:6379.
    current slaves [rediss://10.91.237.124:6379]
    last slaves [rediss://10.91.237.93:6379, rediss://10.91.237.37:6379, rediss://10.91.237.124:6379]

  removed slaves detected for master rediss://10.91.237.124:6379.
    current slaves [rediss://10.91.237.124:6379]
    last slaves [rediss://10.91.237.93:6379, rediss://10.91.237.37:6379]

  Error state after freeze:
  MasterSlaveEntry [masterEntry=ClientConnectionsEntry{
    allConnections=0, freeConnections=0,
    freezeReason=MANAGER,
    nodeType=MASTER,
    initialized=false}]

  ## Fix

  Add guard clauses to both `slaveDown(InetSocketAddress)` and `slaveDown(RedisURI)` that detect when the resolved entry is the master and skip the freeze. A `slaveDown` call should never freeze the master entry.

  ## Testing

  Verified against live ElastiCache Valkey upgrade (8.0 → 8.1 → 8.2) — upgrade completed without timeout exceptions after applying the patch.

  Fixes #6997