### PR TITLE
Fix: RedisLoadingException error on slave burns extra retry attempt in batch commands

### DIFF
--- a/redisson/src/main/java/org/redisson/command/RedisExecutor.java
+++ b/redisson/src/main/java/org/redisson/command/RedisExecutor.java
@@ -593,6 +593,7 @@ public class RedisExecutor<V, R> {
                 if (connection != null) {
                     ClientConnectionsEntry ce = entry.getEntry(connection.getRedisClient());
                     if (ce != null && ce.getNodeType() == NodeType.SLAVE) {
+                        onException();
                         source = new NodeSource(entry.getClient());
                         execute();
                         return;


### PR DESCRIPTION
## Context

When a Redis replica returns a `RedisLoadingException` response during RBatch execution, Redisson retries on master but skips the `onException()` call that clears per-command `retryError` state. This causes the master's successful response to be treated as a failure (because `isSuccess()` checks `retryError.get() == null`), burning an extra retry attempt per LOADING error. In sustained LOADING scenarios (e.g., ElastiCache upgrades), this 2x retry consumption exhausts the retry budget and fails batches that should succeed.

MOVED/ASK handlers correctly call `onException()` (via `handleRedirect()`) before retrying. The LOADING handler is missing this call — an oversight, not a design decision.

## Fix

**File:** `redisson/src/main/java/org/redisson/command/RedisExecutor.java` (line ~596)

Add `onException()` before `execute()` in the LOADING handler:

```java
if (cause instanceof RedisLoadingException) {
    RedisConnection connection = connectionFuture.getNow(null);
    if (connection != null) {
        ClientConnectionsEntry ce = entry.getEntry(connection.getRedisClient());
        if (ce != null && ce.getNodeType() == NodeType.SLAVE) {
            onException();                              // <-- add this line
            source = new NodeSource(entry.getClient());
            execute();
            return;
        }
    }
}
```

This is a one-line change. In the batch executor (`RedisCommonBatchExecutor`), `onException()` calls `entry.clearErrors()` which resets `retryError` on all batch commands, so the master's successful response will be accepted on the first retry.