### PR TITLE
Add support for connecting via Redis proxy

### DIFF
--- a/redisson/src/main/java/org/redisson/config/Config.java
+++ b/redisson/src/main/java/org/redisson/config/Config.java
@@ -206,6 +206,7 @@ public class Config {
         setSslKeyManagerFactory(oldConf.getSslKeyManagerFactory());
         setSslTrustManagerFactory(oldConf.getSslTrustManagerFactory());
         setSslVerificationMode(oldConf.getSslVerificationMode());
+        setConnectViaRedisProxy(oldConf.isConnectViaRedisProxy());
 
         if (oldConf.getSingleServerConfig() != null) {
             setSingleServerConfig(new SingleServerConfig(oldConf.getSingleServerConfig()));


### PR DESCRIPTION
 Fixed an issue where Redisson could not distinguish whether cross-slot execution of Lua scripts was allowed when connecting to a Redis cluster using a proxy service.  Added a new boolean field 'connectViaRedisProxy' to the Config class to allow connection to Redis via a proxy. Updated relevant methods to handle the new configuration option.  Closed issues: https://github.com/redisson/redisson/issues/6867