### PR TITLE
Fix: Add missing @Deprecated annotation to RedissonClient.getDelayedQueue()

### DIFF
--- a/redisson/src/main/java/org/redisson/api/RedissonClient.java
+++ b/redisson/src/main/java/org/redisson/api/RedissonClient.java
@@ -1367,6 +1367,7 @@ public interface RedissonClient {
      * @param destinationQueue destination queue
      * @return Delayed queue object
      */
+    @Deprecated
     <V> RDelayedQueue<V> getDelayedQueue(RQueue<V> destinationQueue);
 
     /**


### PR DESCRIPTION
`RDelayedQueue` was deprecated in #6552, but the `@Deprecated` annotation was missing from the `RedissonClient` interface method `getDelayedQueue()`.

The implementation (`RedissonDelayedQueue`) and test class (`RedissonDelayedQueueTest`) were already marked as `@Deprecated`, but the interface was overlooked.

ref #6371