### PR TITLE
Fix: use correct keys for slot calculation in RemoteService and ExecutorService

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonExecutorService.java
+++ b/redisson/src/main/java/org/redisson/RedissonExecutorService.java
@@ -186,7 +186,7 @@ public class RedissonExecutorService implements RScheduledExecutorService {
 
     @Override
     public RFuture<Integer> getTaskCountAsync() {
-        return commandExecutor.readAsync(getName(), LongCodec.INSTANCE, RedisCommands.GET_INTEGER, tasksCounterName);
+        return commandExecutor.readAsync(tasksCounterName, LongCodec.INSTANCE, RedisCommands.GET_INTEGER, tasksCounterName);
     }
 
     @Override
@@ -248,7 +248,7 @@ public class RedissonExecutorService implements RScheduledExecutorService {
 
             @Override
             protected RFuture<Long> pushTaskAsync() {
-                return commandExecutor.evalWriteAsync(name, LongCodec.INSTANCE, RedisCommands.EVAL_LONG,
+                return commandExecutor.evalWriteAsync(requestQueueName, LongCodec.INSTANCE, RedisCommands.EVAL_LONG,
                         "local expiredTaskIds = redis.call('zrangebyscore', KEYS[2], 0, ARGV[1], 'limit', 0, ARGV[2]); "
                       + "local retryInterval = redis.call('get', KEYS[4]);"
                       + "if #expiredTaskIds > 0 then "
@@ -477,7 +477,7 @@ public class RedissonExecutorService implements RScheduledExecutorService {
     public void shutdown() {
         deregisterWorkers();
 
-        commandExecutor.get(commandExecutor.evalWriteAsync(getName(), LongCodec.INSTANCE, RedisCommands.EVAL_VOID,
+        commandExecutor.get(commandExecutor.evalWriteAsync(tasksCounterName, LongCodec.INSTANCE, RedisCommands.EVAL_VOID,
                 "if redis.call('exists', KEYS[2]) == 0 then "
                      + "if redis.call('get', KEYS[1]) == '0' or redis.call('exists', KEYS[1]) == 0 then "
                         + "redis.call('set', KEYS[2], ARGV[2]);"
@@ -485,7 +485,7 @@ public class RedissonExecutorService implements RScheduledExecutorService {
                      + "else "
                         + "redis.call('set', KEYS[2], ARGV[1]);"
                      + "end;"
-                + "end;", 
+                + "end;",
                 Arrays.<Object>asList(tasksCounterName, statusName, terminationTopic.getChannelNames().get(0), tasksRetryIntervalName),
                 SHUTDOWN_STATE, TERMINATED_STATE));
     }
@@ -519,11 +519,11 @@ public class RedissonExecutorService implements RScheduledExecutorService {
     }
 
     private boolean checkState(int state) {
-        return commandExecutor.get(commandExecutor.evalWriteAsync(getName(), codec, RedisCommands.EVAL_BOOLEAN,
+        return commandExecutor.get(commandExecutor.evalWriteAsync(statusName, codec, RedisCommands.EVAL_BOOLEAN,
                 "if redis.call('exists', KEYS[1]) == 1 and tonumber(redis.call('get', KEYS[1])) >= tonumber(ARGV[1]) then "
                 + "return 1;"
             + "end;"
-            + "return 0;", 
+            + "return 0;",
                 Arrays.<Object>asList(statusName),
                 state));
     }
@@ -1148,7 +1148,7 @@ public class RedissonExecutorService implements RScheduledExecutorService {
 
         String taskName = tasksLatchName + ":" + id;
 
-        RFuture<Boolean> r = commandExecutor.evalWriteNoRetryAsync(getName(), LongCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
+        RFuture<Boolean> r = commandExecutor.evalWriteNoRetryAsync(tasksName, LongCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
             "if redis.call('hexists', KEYS[1], ARGV[2]) == 0 then "
                      + "if redis.call('set', KEYS[2], 1, 'NX', 'PX', ARGV[1]) ~= nil then "
                         + "return 0; "

--- a/redisson/src/main/java/org/redisson/RedissonRemoteService.java
+++ b/redisson/src/main/java/org/redisson/RedissonRemoteService.java
@@ -82,7 +82,7 @@ public class RedissonRemoteService extends BaseRemoteService implements RRemoteS
     @Override
     protected CompletableFuture<Boolean> addAsync(String requestQueueName, RemoteServiceRequest request,
                                                   RemotePromise<Object> result) {
-        RFuture<Boolean> future = commandExecutor.evalWriteNoRetryAsync(name, LongCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
+        RFuture<Boolean> future = commandExecutor.evalWriteNoRetryAsync(requestQueueName, LongCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
                   "redis.call('hset', KEYS[2], ARGV[1], ARGV[2]);"
                 + "redis.call('rpush', KEYS[1], ARGV[1]); "
                 + "return 1;",
@@ -95,7 +95,7 @@ public class RedissonRemoteService extends BaseRemoteService implements RRemoteS
 
     @Override
     protected CompletableFuture<Boolean> removeAsync(String requestQueueName, String taskId) {
-        RFuture<Boolean> f = commandExecutor.evalWriteNoRetryAsync(name, LongCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
+        RFuture<Boolean> f = commandExecutor.evalWriteNoRetryAsync(requestQueueName, LongCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
                 "if redis.call('lrem', KEYS[1], 1, ARGV[1]) > 0 then "
                         + "redis.call('hdel', KEYS[2], ARGV[1]);" +
                            "return 1;" +
@@ -315,7 +315,7 @@ public class RedissonRemoteService extends BaseRemoteService implements RRemoteS
                     if (request.getOptions().isAckExpected()) {
                         String responseName = getResponseQueueName(request.getExecutorId());
                         String ackName = getAckName(request.getId());
-                                RFuture<Boolean> ackClientsFuture = commandExecutor.evalWriteNoRetryAsync(responseName,
+                                RFuture<Boolean> ackClientsFuture = commandExecutor.evalWriteNoRetryAsync(ackName,
                                         LongCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
                                             "if redis.call('setnx', KEYS[1], 1) == 1 then " 
                                                 + "redis.call('pexpire', KEYS[1], ARGV[1]);"

--- a/redisson/src/main/java/org/redisson/executor/ScheduledTasksService.java
+++ b/redisson/src/main/java/org/redisson/executor/ScheduledTasksService.java
@@ -94,7 +94,7 @@ public class ScheduledTasksService extends TasksService {
                 + "end;"
                 + "return 0;";
         
-        RFuture<Boolean> f = commandExecutor.evalWriteNoRetryAsync(name, LongCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN, script,
+        RFuture<Boolean> f = commandExecutor.evalWriteNoRetryAsync(tasksCounterName, LongCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN, script,
                 Arrays.asList(tasksCounterName, statusName, schedulerQueueName,
                         schedulerChannelName, tasksName, tasksRetryIntervalName, tasksExpirationTimeName, taskName),
                 params.getStartTime(), request.getId(), encode(request), tasksRetryInterval, expireTime);
@@ -103,7 +103,7 @@ public class ScheduledTasksService extends TasksService {
     
     @Override
     protected CompletableFuture<Boolean> removeAsync(String requestQueueName, String taskId) {
-        RFuture<Boolean> f = commandExecutor.evalWriteNoRetryAsync(name, StringCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
+        RFuture<Boolean> f = commandExecutor.evalWriteNoRetryAsync(requestQueueName, StringCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
                 "local task = redis.call('hget', KEYS[6], ARGV[1]); "
                   + "redis.call('hdel', KEYS[6], ARGV[1]); "
                   

--- a/redisson/src/main/java/org/redisson/executor/TasksRunnerService.java
+++ b/redisson/src/main/java/org/redisson/executor/TasksRunnerService.java
@@ -417,7 +417,7 @@ public class TasksRunnerService implements RemoteExecutorService {
                     + "end;"
                 + "end;";  
 
-        RFuture<Object> f = commandExecutor.evalWriteNoRetryAsync(name, StringCodec.INSTANCE, RedisCommands.EVAL_VOID,
+        RFuture<Object> f = commandExecutor.evalWriteNoRetryAsync(tasksCounterName, StringCodec.INSTANCE, RedisCommands.EVAL_VOID,
                 script,
                 Arrays.asList(tasksCounterName, statusName, terminationTopicName, tasksName, schedulerQueueName, tasksRetryIntervalName, tasksExpirationTimeName),
                 RedissonExecutorService.SHUTDOWN_STATE, RedissonExecutorService.TERMINATED_STATE, requestId);

--- a/redisson/src/main/java/org/redisson/executor/TasksService.java
+++ b/redisson/src/main/java/org/redisson/executor/TasksService.java
@@ -127,7 +127,7 @@ public class TasksService extends BaseRemoteService {
             expireTime = System.currentTimeMillis() + params.getTtl();
         }
 
-        RFuture<Boolean> f = getAddCommandExecutor().evalWriteNoRetryAsync(name, StringCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
+        RFuture<Boolean> f = getAddCommandExecutor().evalWriteNoRetryAsync(tasksCounterName, StringCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
                         // check if executor service not in shutdown state
                         "if redis.call('exists', KEYS[2]) == 0 then "
                             + "redis.call('hset', KEYS[5], ARGV[2], ARGV[3]);"
@@ -161,7 +161,7 @@ public class TasksService extends BaseRemoteService {
     
     @Override
     protected CompletableFuture<Boolean> removeAsync(String requestQueueName, String taskId) {
-        RFuture<Boolean> f = commandExecutor.evalWriteNoRetryAsync(name, LongCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
+        RFuture<Boolean> f = commandExecutor.evalWriteNoRetryAsync(requestQueueName, LongCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
           "if redis.call('exists', KEYS[3]) == 0 then " +
                     "return nil;" +
                 "end;" +

--- a/redisson/src/main/java/org/redisson/remote/AsyncRemoteProxy.java
+++ b/redisson/src/main/java/org/redisson/remote/AsyncRemoteProxy.java
@@ -267,7 +267,7 @@ public class AsyncRemoteProxy extends BaseRemoteProxy {
                 
                 if (optionsCopy.isAckExpected()) {
                     String ackName = remoteService.getAckName(requestId);
-                    RFuture<Boolean> future = commandExecutor.evalWriteAsync(responseQueueName, LongCodec.INSTANCE,
+                    RFuture<Boolean> future = commandExecutor.evalWriteAsync(ackName, LongCodec.INSTANCE,
                             RedisCommands.EVAL_BOOLEAN,
                             "if redis.call('setnx', KEYS[1], 1) == 1 then "
                                 + "redis.call('pexpire', KEYS[1], ARGV[1]);"

--- a/redisson/src/main/java/org/redisson/remote/AsyncRemoteProxy.java
+++ b/redisson/src/main/java/org/redisson/remote/AsyncRemoteProxy.java
@@ -339,7 +339,7 @@ public class AsyncRemoteProxy extends BaseRemoteProxy {
 
         if (optionsCopy.isAckExpected()) {
             String ackName = remoteService.getAckName(requestId);
-            RFuture<Boolean> f = commandExecutor.evalWriteNoRetryAsync(responseQueueName, LongCodec.INSTANCE,
+            RFuture<Boolean> f = commandExecutor.evalWriteNoRetryAsync(ackName, LongCodec.INSTANCE,
                     RedisCommands.EVAL_BOOLEAN,
                     "if redis.call('setnx', KEYS[1], 1) == 1 then "
                         + "redis.call('pexpire', KEYS[1], ARGV[1]);"

--- a/redisson/src/test/java/org/redisson/RedissonRemoteServiceTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonRemoteServiceTest.java
@@ -1054,7 +1054,7 @@ public class RedissonRemoteServiceTest extends RedisDockerTest {
             RRemoteService clientService = redisson.getRemoteService("test-cluster");
             RemoteInterface service = clientService.get(RemoteInterface.class);
 
-            String result = service.resultMethod(21L);
+            Long result = service.resultMethod(21L);
             assertThat(result).isEqualTo(42L);
 
             service.voidMethod("cluster-test", 100L);
@@ -1088,28 +1088,21 @@ public class RedissonRemoteServiceTest extends RedisDockerTest {
     public void testRemoteServiceCancelInCluster() throws InterruptedException {
         testInCluster(redisson -> {
             AtomicInteger iterations = new AtomicInteger();
-            RRemoteService serverService = redisson.getRemoteService("test-cluster-cancel");
-            serverService.register(RemoteInterface.class, new RemoteImpl(iterations), 1);
+            redisson.getRemoteService("test-cluster-cancel-service")
+                    .register(RemoteInterface.class, new RemoteImpl(iterations), 1);
 
-            RRemoteService clientService = redisson.getRemoteService("test-cluster-cancel");
-            RemoteInterfaceAsync asyncService = clientService.get(RemoteInterfaceAsync.class);
+            RFuture<Void> future = redisson.getRemoteService("test-cluster-cancel-service")
+                    .get(RemoteInterfaceAsync.class)
+                    .cancelMethod();
 
-            RFuture<Void> future = asyncService.cancelMethod();
-            Thread.sleep(500);
+            try {
+                Thread.sleep(1500);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
 
             assertThat(future.cancel(true)).isTrue();
-
-            boolean cancelled = false;
-            try {
-                future.get();
-            } catch (CancellationException e) {
-                cancelled = true;
-            } catch (ExecutionException e) {
-                // ignore
-            }
-            assertThat(cancelled).isTrue();
-
-            serverService.deregister(RemoteInterface.class);
         });
     }
 

--- a/redisson/src/test/java/org/redisson/RedissonRemoteServiceTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonRemoteServiceTest.java
@@ -944,10 +944,10 @@ public class RedissonRemoteServiceTest extends RedisDockerTest {
         RedissonClient client = createInstance();
         RRemoteService r1 = client.getRemoteService();
         r1.register(RemoteInterface.class, new RemoteImpl());
-        
+
         RemoteInvocationOptions options = RemoteInvocationOptions.defaults().noAck().expectResultWithin(1, TimeUnit.SECONDS);
         Assertions.assertThrows(RemoteServiceTimeoutException.class, () -> r1.get(RemoteInterface.class, options).timeoutMethod());
-        
+
         RFuture<Void> future = r1.get(RemoteInterfaceAsync.class, options).timeoutMethod();
         Thread.sleep(3000);
         assertThat(future.isDone()).isEqualTo(true);
@@ -1042,6 +1042,188 @@ public class RedissonRemoteServiceTest extends RedisDockerTest {
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
+        });
+    }
+
+    @Test
+    public void testRemoteServiceInCluster() {
+        testInCluster(redisson -> {
+            RRemoteService serverService = redisson.getRemoteService("test-cluster");
+            serverService.register(RemoteInterface.class, new RemoteImpl(), 5);
+
+            RRemoteService clientService = redisson.getRemoteService("test-cluster");
+            RemoteInterface service = clientService.get(RemoteInterface.class);
+
+            String result = service.resultMethod(21L);
+            assertThat(result).isEqualTo(42L);
+
+            service.voidMethod("cluster-test", 100L);
+
+            RemoteInterface serviceWithAck = clientService.get(RemoteInterface.class,
+                    RemoteInvocationOptions.defaults().expectAckWithin(5, TimeUnit.SECONDS));
+            assertThat(serviceWithAck.resultMethod(50L)).isEqualTo(100L);
+
+            serverService.deregister(RemoteInterface.class);
+        });
+    }
+
+    @Test
+    public void testRemoteServiceAsyncInCluster() {
+        testInCluster(redisson -> {
+            RRemoteService serverService = redisson.getRemoteService("test-cluster-async-service");
+            serverService.register(RemoteInterface.class, new RemoteImpl(), 5);
+
+            RRemoteService clientService = redisson.getRemoteService("test-cluster-async-service");
+            RemoteInterfaceAsync asyncService = clientService.get(RemoteInterfaceAsync.class);
+
+            RFuture<Long> future = asyncService.resultMethod(25L);
+            Long result = future.toCompletableFuture().join();
+            assertThat(result).isEqualTo(50L);
+
+            serverService.deregister(RemoteInterface.class);
+        });
+    }
+
+    @Test
+    public void testRemoteServiceCancelInCluster() throws InterruptedException {
+        testInCluster(redisson -> {
+            AtomicInteger iterations = new AtomicInteger();
+            RRemoteService serverService = redisson.getRemoteService("test-cluster-cancel");
+            serverService.register(RemoteInterface.class, new RemoteImpl(iterations), 1);
+
+            RRemoteService clientService = redisson.getRemoteService("test-cluster-cancel");
+            RemoteInterfaceAsync asyncService = clientService.get(RemoteInterfaceAsync.class);
+
+            RFuture<Void> future = asyncService.cancelMethod();
+            Thread.sleep(500);
+
+            assertThat(future.cancel(true)).isTrue();
+
+            boolean cancelled = false;
+            try {
+                future.get();
+            } catch (CancellationException e) {
+                cancelled = true;
+            } catch (ExecutionException e) {
+                // ignore
+            }
+            assertThat(cancelled).isTrue();
+
+            serverService.deregister(RemoteInterface.class);
+        });
+    }
+
+    @Test
+    public void testRemoteServiceTimeoutInCluster() {
+        testInCluster(redisson -> {
+            RRemoteService serverService = redisson.getRemoteService("test-cluster-timeout-service");
+            serverService.register(RemoteInterface.class, new RemoteImpl(), 1);
+
+            RRemoteService clientService = redisson.getRemoteService("test-cluster-timeout-service");
+            RemoteInterface service = clientService.get(RemoteInterface.class, 1, TimeUnit.SECONDS);
+
+            Assertions.assertThrows(RemoteServiceTimeoutException.class, () -> {
+                service.timeoutMethod();
+            });
+
+            serverService.deregister(RemoteInterface.class);
+        });
+    }
+}
+                });
+            }
+            executorService.shutdown();
+            try {
+                assertThat(executorService.awaitTermination(100, TimeUnit.SECONDS)).isTrue();
+                assertThat(successCount.get()).isEqualTo(TOTAL);
+                log.info("TestPerformance Result, duration={}, rps={}", totalTime, 1.0 * TOTAL / totalTime.get() * 1000);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+=======
+    @Test
+    public void testRemoteServiceInCluster() {
+        testInCluster(redisson -> {
+            RRemoteService serverService = redisson.getRemoteService("test-cluster");
+            serverService.register(RemoteInterface.class, new RemoteImpl(), 5);
+
+            RRemoteService clientService = redisson.getRemoteService("test-cluster");
+            RemoteInterface service = clientService.get(RemoteInterface.class);
+
+            String result = service.resultMethod(21L);
+            assertThat(result).isEqualTo(42L);
+
+            service.voidMethod("cluster-test", 100L);
+
+            RemoteInterface serviceWithAck = clientService.get(RemoteInterface.class,
+                    RemoteInvocationOptions.defaults().expectAckWithin(5, TimeUnit.SECONDS));
+            assertThat(serviceWithAck.resultMethod(50L)).isEqualTo(100L);
+
+            serverService.deregister(RemoteInterface.class);
+        });
+    }
+
+    @Test
+    public void testRemoteServiceAsyncInCluster() {
+        testInCluster(redisson -> {
+            RRemoteService serverService = redisson.getRemoteService("test-cluster-async-service");
+            serverService.register(RemoteInterface.class, new RemoteImpl(), 5);
+
+            RRemoteService clientService = redisson.getRemoteService("test-cluster-async-service");
+            RemoteInterfaceAsync asyncService = clientService.get(RemoteInterfaceAsync.class);
+
+            RFuture<Long> future = asyncService.resultMethod(25L);
+            Long result = future.toCompletableFuture().join();
+            assertThat(result).isEqualTo(50L);
+
+            serverService.deregister(RemoteInterface.class);
+        });
+    }
+
+    @Test
+    public void testRemoteServiceCancelInCluster() throws InterruptedException {
+        testInCluster(redisson -> {
+            AtomicInteger iterations = new AtomicInteger();
+            RRemoteService serverService = redisson.getRemoteService("test-cluster-cancel");
+            serverService.register(RemoteInterface.class, new RemoteImpl(iterations), 1);
+
+            RRemoteService clientService = redisson.getRemoteService("test-cluster-cancel");
+            RemoteInterfaceAsync asyncService = clientService.get(RemoteInterfaceAsync.class);
+
+            RFuture<Void> future = asyncService.cancelMethod();
+            Thread.sleep(500);
+
+            assertThat(future.cancel(true)).isTrue();
+
+            boolean cancelled = false;
+            try {
+                future.get();
+            } catch (CancellationException e) {
+                cancelled = true;
+            } catch (ExecutionException e) {
+                // ignore
+            }
+            assertThat(cancelled).isTrue();
+
+            serverService.deregister(RemoteInterface.class);
+        });
+    }
+
+    @Test
+    public void testRemoteServiceTimeoutInCluster() {
+        testInCluster(redisson -> {
+            RRemoteService serverService = redisson.getRemoteService("test-cluster-timeout-service");
+            serverService.register(RemoteInterface.class, new RemoteImpl(), 1);
+
+            RRemoteService clientService = redisson.getRemoteService("test-cluster-timeout-service");
+            RemoteInterface service = clientService.get(RemoteInterface.class, 1, TimeUnit.SECONDS);
+
+            Assertions.assertThrows(RemoteServiceTimeoutException.class, () -> {
+                service.timeoutMethod();
+            });
+
+            serverService.deregister(RemoteInterface.class);
+>>>>>>> 1dd7a2ebd (fix(cluster): fix slot mismatch causing RedisNodeNotFoundException)
         });
     }
 }

--- a/redisson/src/test/java/org/redisson/RedissonRemoteServiceTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonRemoteServiceTest.java
@@ -8,6 +8,8 @@ import org.redisson.api.*;
 import org.redisson.api.annotation.RRemoteAsync;
 import org.redisson.api.annotation.RRemoteReactive;
 import org.redisson.api.annotation.RRemoteRx;
+import nl.altindag.log.LogCaptor;
+import org.redisson.client.handler.CommandDecoder;
 import org.redisson.codec.SerializationCodec;
 import org.redisson.config.Config;
 import org.redisson.remote.RemoteServiceAckTimeoutException;
@@ -1047,6 +1049,9 @@ public class RedissonRemoteServiceTest extends RedisDockerTest {
 
     @Test
     public void testRemoteServiceInCluster() {
+        LogCaptor logCaptor = LogCaptor.forClass(CommandDecoder.class);
+        logCaptor.setLogLevelToTrace();
+
         testInCluster(redisson -> {
             RRemoteService serverService = redisson.getRemoteService("test-cluster");
             serverService.register(RemoteInterface.class, new RemoteImpl(), 5);
@@ -1065,10 +1070,16 @@ public class RedissonRemoteServiceTest extends RedisDockerTest {
 
             serverService.deregister(RemoteInterface.class);
         });
+
+        assertThat(logCaptor.getTraceLogs().stream().noneMatch(n -> n.contains("reply: -MOVED"))).isTrue();
+        logCaptor.close();
     }
 
     @Test
     public void testRemoteServiceAsyncInCluster() {
+        LogCaptor logCaptor = LogCaptor.forClass(CommandDecoder.class);
+        logCaptor.setLogLevelToTrace();
+
         testInCluster(redisson -> {
             RRemoteService serverService = redisson.getRemoteService("test-cluster-async-service");
             serverService.register(RemoteInterface.class, new RemoteImpl(), 5);
@@ -1082,10 +1093,16 @@ public class RedissonRemoteServiceTest extends RedisDockerTest {
 
             serverService.deregister(RemoteInterface.class);
         });
+
+        assertThat(logCaptor.getTraceLogs().stream().noneMatch(n -> n.contains("reply: -MOVED"))).isTrue();
+        logCaptor.close();
     }
 
     @Test
     public void testRemoteServiceCancelInCluster() throws InterruptedException {
+        LogCaptor logCaptor = LogCaptor.forClass(CommandDecoder.class);
+        logCaptor.setLogLevelToTrace();
+
         testInCluster(redisson -> {
             AtomicInteger iterations = new AtomicInteger();
             redisson.getRemoteService("test-cluster-cancel-service")
@@ -1104,10 +1121,16 @@ public class RedissonRemoteServiceTest extends RedisDockerTest {
 
             assertThat(future.cancel(true)).isTrue();
         });
+
+        assertThat(logCaptor.getTraceLogs().stream().noneMatch(n -> n.contains("reply: -MOVED"))).isTrue();
+        logCaptor.close();
     }
 
     @Test
     public void testRemoteServiceTimeoutInCluster() {
+        LogCaptor logCaptor = LogCaptor.forClass(CommandDecoder.class);
+        logCaptor.setLogLevelToTrace();
+
         testInCluster(redisson -> {
             RRemoteService serverService = redisson.getRemoteService("test-cluster-timeout-service");
             serverService.register(RemoteInterface.class, new RemoteImpl(), 1);
@@ -1121,102 +1144,8 @@ public class RedissonRemoteServiceTest extends RedisDockerTest {
 
             serverService.deregister(RemoteInterface.class);
         });
-    }
-}
-                });
-            }
-            executorService.shutdown();
-            try {
-                assertThat(executorService.awaitTermination(100, TimeUnit.SECONDS)).isTrue();
-                assertThat(successCount.get()).isEqualTo(TOTAL);
-                log.info("TestPerformance Result, duration={}, rps={}", totalTime, 1.0 * TOTAL / totalTime.get() * 1000);
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
-=======
-    @Test
-    public void testRemoteServiceInCluster() {
-        testInCluster(redisson -> {
-            RRemoteService serverService = redisson.getRemoteService("test-cluster");
-            serverService.register(RemoteInterface.class, new RemoteImpl(), 5);
 
-            RRemoteService clientService = redisson.getRemoteService("test-cluster");
-            RemoteInterface service = clientService.get(RemoteInterface.class);
-
-            String result = service.resultMethod(21L);
-            assertThat(result).isEqualTo(42L);
-
-            service.voidMethod("cluster-test", 100L);
-
-            RemoteInterface serviceWithAck = clientService.get(RemoteInterface.class,
-                    RemoteInvocationOptions.defaults().expectAckWithin(5, TimeUnit.SECONDS));
-            assertThat(serviceWithAck.resultMethod(50L)).isEqualTo(100L);
-
-            serverService.deregister(RemoteInterface.class);
-        });
-    }
-
-    @Test
-    public void testRemoteServiceAsyncInCluster() {
-        testInCluster(redisson -> {
-            RRemoteService serverService = redisson.getRemoteService("test-cluster-async-service");
-            serverService.register(RemoteInterface.class, new RemoteImpl(), 5);
-
-            RRemoteService clientService = redisson.getRemoteService("test-cluster-async-service");
-            RemoteInterfaceAsync asyncService = clientService.get(RemoteInterfaceAsync.class);
-
-            RFuture<Long> future = asyncService.resultMethod(25L);
-            Long result = future.toCompletableFuture().join();
-            assertThat(result).isEqualTo(50L);
-
-            serverService.deregister(RemoteInterface.class);
-        });
-    }
-
-    @Test
-    public void testRemoteServiceCancelInCluster() throws InterruptedException {
-        testInCluster(redisson -> {
-            AtomicInteger iterations = new AtomicInteger();
-            RRemoteService serverService = redisson.getRemoteService("test-cluster-cancel");
-            serverService.register(RemoteInterface.class, new RemoteImpl(iterations), 1);
-
-            RRemoteService clientService = redisson.getRemoteService("test-cluster-cancel");
-            RemoteInterfaceAsync asyncService = clientService.get(RemoteInterfaceAsync.class);
-
-            RFuture<Void> future = asyncService.cancelMethod();
-            Thread.sleep(500);
-
-            assertThat(future.cancel(true)).isTrue();
-
-            boolean cancelled = false;
-            try {
-                future.get();
-            } catch (CancellationException e) {
-                cancelled = true;
-            } catch (ExecutionException e) {
-                // ignore
-            }
-            assertThat(cancelled).isTrue();
-
-            serverService.deregister(RemoteInterface.class);
-        });
-    }
-
-    @Test
-    public void testRemoteServiceTimeoutInCluster() {
-        testInCluster(redisson -> {
-            RRemoteService serverService = redisson.getRemoteService("test-cluster-timeout-service");
-            serverService.register(RemoteInterface.class, new RemoteImpl(), 1);
-
-            RRemoteService clientService = redisson.getRemoteService("test-cluster-timeout-service");
-            RemoteInterface service = clientService.get(RemoteInterface.class, 1, TimeUnit.SECONDS);
-
-            Assertions.assertThrows(RemoteServiceTimeoutException.class, () -> {
-                service.timeoutMethod();
-            });
-
-            serverService.deregister(RemoteInterface.class);
->>>>>>> 1dd7a2ebd (fix(cluster): fix slot mismatch causing RedisNodeNotFoundException)
-        });
+        assertThat(logCaptor.getTraceLogs().stream().noneMatch(n -> n.contains("reply: -MOVED"))).isTrue();
+        logCaptor.close();
     }
 }

--- a/redisson/src/test/java/org/redisson/executor/RedissonExecutorServiceTest.java
+++ b/redisson/src/test/java/org/redisson/executor/RedissonExecutorServiceTest.java
@@ -782,122 +782,147 @@ public class RedissonExecutorServiceTest extends RedisDockerTest {
     @Test
     public void testExecutorServiceInCluster() throws Exception {
         withNewCluster((nodes, redisson) -> {
-            RExecutorService executor = redisson.getExecutorService("test-cluster-executor");
-            executor.registerWorkers(WorkerOptions.defaults().workers(2));
+            try {
+                RExecutorService executor = redisson.getExecutorService("test-cluster-executor");
+                executor.registerWorkers(WorkerOptions.defaults().workers(2));
 
-            RExecutorFuture<String> future = executor.submit(new IncrementCallableTask("cluster-counter"));
-            String result = future.get(10, TimeUnit.SECONDS);
-            assertThat(result).isEqualTo("1");
+                RExecutorFuture<String> future = executor.submit(new IncrementCallableTask("cluster-counter"));
+                String result = future.get(10, TimeUnit.SECONDS);
+                assertThat(result).isEqualTo("1234");
 
-            assertThat(executor.getTaskCount()).isEqualTo(0);
+                assertThat(executor.getTaskCount()).isEqualTo(0);
 
-            RExecutorFuture<?> f1 = executor.submit(new IncrementRunnableTask("cluster-counter-2"));
-            RExecutorFuture<?> f2 = executor.submit(new IncrementRunnableTask("cluster-counter-2"));
-            f1.get(10, TimeUnit.SECONDS);
-            f2.get(10, TimeUnit.SECONDS);
+                RExecutorFuture<?> f1 = executor.submit(new IncrementRunnableTask("cluster-counter-2"));
+                RExecutorFuture<?> f2 = executor.submit(new IncrementRunnableTask("cluster-counter-2"));
+                f1.get(10, TimeUnit.SECONDS);
+                f2.get(10, TimeUnit.SECONDS);
 
-            assertThat(redisson.getAtomicLong("cluster-counter-2").get()).isEqualTo(2);
+                assertThat(redisson.getAtomicLong("cluster-counter-2").get()).isEqualTo(2);
 
-            executor.shutdown();
-            assertThat(executor.isShutdown()).isTrue();
+                executor.shutdown();
+                assertThat(executor.isShutdown()).isTrue();
+            } catch (InterruptedException | ExecutionException | TimeoutException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
         });
     }
 
     @Test
     public void testScheduledExecutorServiceInCluster() throws Exception {
         withNewCluster((nodes, redisson) -> {
-            RScheduledExecutorService executor = redisson.getExecutorService("test-cluster-scheduler");
-            executor.registerWorkers(WorkerOptions.defaults().workers(2));
+            try {
+                RScheduledExecutorService executor = redisson.getExecutorService("test-cluster-scheduler");
+                executor.registerWorkers(WorkerOptions.defaults().workers(2));
 
-            RScheduledFuture<?> future = executor.schedule(new IncrementRunnableTask("cluster-scheduled"), 1, TimeUnit.SECONDS);
-            future.get(10, TimeUnit.SECONDS);
+                RScheduledFuture<?> future = executor.schedule(new IncrementRunnableTask("cluster-scheduled"), 1, TimeUnit.SECONDS);
+                future.get(10, TimeUnit.SECONDS);
 
-            assertThat(redisson.getAtomicLong("cluster-scheduled").get()).isEqualTo(1);
+                assertThat(redisson.getAtomicLong("cluster-scheduled").get()).isEqualTo(1);
 
-            RScheduledFuture<?> cancelFuture = executor.schedule(new IncrementRunnableTask("cluster-cancel"), 10, TimeUnit.SECONDS);
-            String taskId = ((RemotePromise<?>) cancelFuture.toCompletableFuture()).getRequestId();
-            Thread.sleep(100);
-            Boolean cancelled = executor.cancelTask(taskId);
-            assertThat(cancelled).isTrue();
+                RScheduledFuture<?> cancelFuture = executor.schedule(new IncrementRunnableTask("cluster-cancel"), 10, TimeUnit.SECONDS);
+                String taskId = ((RemotePromise<?>) cancelFuture.toCompletableFuture()).getRequestId();
+                Thread.sleep(100);
+                Boolean cancelled = executor.cancelTask(taskId);
+                assertThat(cancelled).isTrue();
 
-            executor.shutdown();
+                executor.shutdown();
+            } catch (InterruptedException | ExecutionException | TimeoutException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
         });
     }
 
     @Test
     public void testTaskCountInCluster() throws Exception {
         withNewCluster((nodes, redisson) -> {
-            RExecutorService executor = redisson.getExecutorService("test-cluster-taskcount");
-            executor.registerWorkers(WorkerOptions.defaults().workers(1));
+            try {
+                RExecutorService executor = redisson.getExecutorService("test-cluster-taskcount");
+                executor.registerWorkers(WorkerOptions.defaults().workers(1));
 
-            assertThat(executor.getTaskCount()).isEqualTo(0);
+                assertThat(executor.getTaskCount()).isEqualTo(0);
 
-            RExecutorFuture<?> future = executor.submit(new DelayedTask(3000, "cluster-delay"));
-            Thread.sleep(200);
+                RExecutorFuture<?> future = executor.submit(new DelayedTask(3000, "cluster-delay"));
+                Thread.sleep(200);
 
-            int taskCount = executor.getTaskCount();
-            assertThat(taskCount).isGreaterThanOrEqualTo(0);
+                int taskCount = executor.getTaskCount();
+                assertThat(taskCount).isGreaterThanOrEqualTo(1);
 
-            future.get(10, TimeUnit.SECONDS);
-            Thread.sleep(500);
+                future.get(10, TimeUnit.SECONDS);
+                Thread.sleep(500);
 
-            assertThat(executor.getTaskCount()).isEqualTo(0);
+                assertThat(executor.getTaskCount()).isEqualTo(0);
 
-            executor.shutdown();
+                executor.shutdown();
+            } catch (InterruptedException | ExecutionException | TimeoutException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
         });
     }
 
     @Test
     public void testCancelTaskInCluster() throws Exception {
         withNewCluster((nodes, redisson) -> {
-            RScheduledExecutorService executor = redisson.getExecutorService("test-cluster-cancel-task");
-            executor.registerWorkers(WorkerOptions.defaults().workers(1));
+            try {
+                RScheduledExecutorService executor = redisson.getExecutorService("test-cluster-cancel-task");
+                executor.registerWorkers(WorkerOptions.defaults().workers(1));
 
-            RScheduledFuture<?> future = executor.schedule(new DelayedTask(10000, "cluster-cancel-task"), 0, TimeUnit.SECONDS);
-            Thread.sleep(500);
+                RScheduledFuture<?> future = executor.schedule(new DelayedTask(10000, "cluster-cancel-task"), 0, TimeUnit.SECONDS);
+                Thread.sleep(500);
 
-            String taskId = ((RemotePromise<?>) future.toCompletableFuture()).getRequestId();
-            Boolean cancelled = executor.cancelTask(taskId);
-            assertThat(cancelled).isTrue();
+                String taskId = ((RemotePromise<?>) future.toCompletableFuture()).getRequestId();
+                Boolean cancelled = executor.cancelTask(taskId);
+                assertThat(cancelled).isTrue();
 
-            executor.shutdown();
+                executor.shutdown();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
         });
     }
 
     @Test
     public void testExecutorServiceWithNameMapperInCluster() throws Exception {
         withNewCluster((nodes, redisson) -> {
-            Config config = createConfig();
-            config.useClusterServers()
-                  .setNameMapper(new NameMapper() {
-                      @Override
-                      public String map(String name) {
-                          return "prefix:" + name;
-                      }
-
-                      @Override
-                      public String unmap(String name) {
-                          return name.replace("prefix:", "");
-                      }
-                  });
-            RedissonClient redissonWithMapper = Redisson.create(config);
-
             try {
-                RExecutorService executor = redissonWithMapper.getExecutorService("test-namemapper-cluster");
-                executor.registerWorkers(WorkerOptions.defaults().workers(1));
+                Config config = redisson.getConfig();
+                config.useClusterServers()
+                      .setNameMapper(new NameMapper() {
+                          @Override
+                          public String map(String name) {
+                              return "prefix:" + name;
+                          }
 
-                RExecutorFuture<?> future = executor.submit(new IncrementRunnableTask("namemapper-counter"));
-                future.get(10, TimeUnit.SECONDS);
+                          @Override
+                          public String unmap(String name) {
+                              return name.replace("prefix:", "");
+                          }
+                      });
+                RedissonClient redissonWithMapper = Redisson.create(config);
 
-                assertThat(executor.getTaskCount()).isEqualTo(0);
+                try {
+                    RExecutorService executor = redissonWithMapper.getExecutorService("test-namemapper-cluster");
+                    executor.registerWorkers(WorkerOptions.defaults().workers(1));
 
-                executor.shutdown();
-                assertThat(executor.isShutdown()).isTrue();
-                assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+                    RExecutorFuture<?> future = executor.submit(new IncrementRunnableTask("namemapper-counter"));
+                    future.get(10, TimeUnit.SECONDS);
 
-                assertThat(redissonWithMapper.getAtomicLong("namemapper-counter").get()).isEqualTo(1);
-            } finally {
-                redissonWithMapper.shutdown();
+                    assertThat(executor.getTaskCount()).isEqualTo(0);
+
+                    executor.shutdown();
+                    assertThat(executor.isShutdown()).isTrue();
+                    assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+
+                    assertThat(redissonWithMapper.getAtomicLong("namemapper-counter").get()).isEqualTo(1);
+                } finally {
+                    redissonWithMapper.shutdown();
+                }
+            } catch (InterruptedException | ExecutionException | TimeoutException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
             }
         });
     }

--- a/redisson/src/test/java/org/redisson/executor/RedissonExecutorServiceTest.java
+++ b/redisson/src/test/java/org/redisson/executor/RedissonExecutorServiceTest.java
@@ -778,4 +778,127 @@ public class RedissonExecutorServiceTest extends RedisDockerTest {
                 }
         );
     }
+
+    @Test
+    public void testExecutorServiceInCluster() throws Exception {
+        withNewCluster((nodes, redisson) -> {
+            RExecutorService executor = redisson.getExecutorService("test-cluster-executor");
+            executor.registerWorkers(WorkerOptions.defaults().workers(2));
+
+            RExecutorFuture<String> future = executor.submit(new IncrementCallableTask("cluster-counter"));
+            String result = future.get(10, TimeUnit.SECONDS);
+            assertThat(result).isEqualTo("1");
+
+            assertThat(executor.getTaskCount()).isEqualTo(0);
+
+            RExecutorFuture<?> f1 = executor.submit(new IncrementRunnableTask("cluster-counter-2"));
+            RExecutorFuture<?> f2 = executor.submit(new IncrementRunnableTask("cluster-counter-2"));
+            f1.get(10, TimeUnit.SECONDS);
+            f2.get(10, TimeUnit.SECONDS);
+
+            assertThat(redisson.getAtomicLong("cluster-counter-2").get()).isEqualTo(2);
+
+            executor.shutdown();
+            assertThat(executor.isShutdown()).isTrue();
+        });
+    }
+
+    @Test
+    public void testScheduledExecutorServiceInCluster() throws Exception {
+        withNewCluster((nodes, redisson) -> {
+            RScheduledExecutorService executor = redisson.getExecutorService("test-cluster-scheduler");
+            executor.registerWorkers(WorkerOptions.defaults().workers(2));
+
+            RScheduledFuture<?> future = executor.schedule(new IncrementRunnableTask("cluster-scheduled"), 1, TimeUnit.SECONDS);
+            future.get(10, TimeUnit.SECONDS);
+
+            assertThat(redisson.getAtomicLong("cluster-scheduled").get()).isEqualTo(1);
+
+            RScheduledFuture<?> cancelFuture = executor.schedule(new IncrementRunnableTask("cluster-cancel"), 10, TimeUnit.SECONDS);
+            String taskId = ((RemotePromise<?>) cancelFuture.toCompletableFuture()).getRequestId();
+            Thread.sleep(100);
+            Boolean cancelled = executor.cancelTask(taskId);
+            assertThat(cancelled).isTrue();
+
+            executor.shutdown();
+        });
+    }
+
+    @Test
+    public void testTaskCountInCluster() throws Exception {
+        withNewCluster((nodes, redisson) -> {
+            RExecutorService executor = redisson.getExecutorService("test-cluster-taskcount");
+            executor.registerWorkers(WorkerOptions.defaults().workers(1));
+
+            assertThat(executor.getTaskCount()).isEqualTo(0);
+
+            RExecutorFuture<?> future = executor.submit(new DelayedTask(3000, "cluster-delay"));
+            Thread.sleep(200);
+
+            int taskCount = executor.getTaskCount();
+            assertThat(taskCount).isGreaterThanOrEqualTo(0);
+
+            future.get(10, TimeUnit.SECONDS);
+            Thread.sleep(500);
+
+            assertThat(executor.getTaskCount()).isEqualTo(0);
+
+            executor.shutdown();
+        });
+    }
+
+    @Test
+    public void testCancelTaskInCluster() throws Exception {
+        withNewCluster((nodes, redisson) -> {
+            RScheduledExecutorService executor = redisson.getExecutorService("test-cluster-cancel-task");
+            executor.registerWorkers(WorkerOptions.defaults().workers(1));
+
+            RScheduledFuture<?> future = executor.schedule(new DelayedTask(10000, "cluster-cancel-task"), 0, TimeUnit.SECONDS);
+            Thread.sleep(500);
+
+            String taskId = ((RemotePromise<?>) future.toCompletableFuture()).getRequestId();
+            Boolean cancelled = executor.cancelTask(taskId);
+            assertThat(cancelled).isTrue();
+
+            executor.shutdown();
+        });
+    }
+
+    @Test
+    public void testExecutorServiceWithNameMapperInCluster() throws Exception {
+        withNewCluster((nodes, redisson) -> {
+            Config config = createConfig();
+            config.useClusterServers()
+                  .setNameMapper(new NameMapper() {
+                      @Override
+                      public String map(String name) {
+                          return "prefix:" + name;
+                      }
+
+                      @Override
+                      public String unmap(String name) {
+                          return name.replace("prefix:", "");
+                      }
+                  });
+            RedissonClient redissonWithMapper = Redisson.create(config);
+
+            try {
+                RExecutorService executor = redissonWithMapper.getExecutorService("test-namemapper-cluster");
+                executor.registerWorkers(WorkerOptions.defaults().workers(1));
+
+                RExecutorFuture<?> future = executor.submit(new IncrementRunnableTask("namemapper-counter"));
+                future.get(10, TimeUnit.SECONDS);
+
+                assertThat(executor.getTaskCount()).isEqualTo(0);
+
+                executor.shutdown();
+                assertThat(executor.isShutdown()).isTrue();
+                assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+
+                assertThat(redissonWithMapper.getAtomicLong("namemapper-counter").get()).isEqualTo(1);
+            } finally {
+                redissonWithMapper.shutdown();
+            }
+        });
+    }
 }

--- a/redisson/src/test/java/org/redisson/executor/RedissonExecutorServiceTest.java
+++ b/redisson/src/test/java/org/redisson/executor/RedissonExecutorServiceTest.java
@@ -15,7 +15,9 @@ import org.redisson.api.annotation.RInject;
 import org.redisson.api.executor.TaskFinishedListener;
 import org.redisson.api.executor.TaskStartedListener;
 import org.redisson.api.listener.MessageListener;
+import nl.altindag.log.LogCaptor;
 import org.redisson.client.codec.LongCodec;
+import org.redisson.client.handler.CommandDecoder;
 import org.redisson.config.Config;
 import org.redisson.config.NameMapper;
 import org.redisson.config.RedissonNodeConfig;
@@ -781,6 +783,9 @@ public class RedissonExecutorServiceTest extends RedisDockerTest {
 
     @Test
     public void testExecutorServiceInCluster() throws Exception {
+        LogCaptor logCaptor = LogCaptor.forClass(CommandDecoder.class);
+        logCaptor.setLogLevelToTrace();
+
         withNewCluster((nodes, redisson) -> {
             try {
                 RExecutorService executor = redisson.getExecutorService("test-cluster-executor");
@@ -806,10 +811,16 @@ public class RedissonExecutorServiceTest extends RedisDockerTest {
                 throw new RuntimeException(e);
             }
         });
+
+        assertThat(logCaptor.getTraceLogs().stream().noneMatch(n -> n.contains("reply: -MOVED"))).isTrue();
+        logCaptor.close();
     }
 
     @Test
     public void testScheduledExecutorServiceInCluster() throws Exception {
+        LogCaptor logCaptor = LogCaptor.forClass(CommandDecoder.class);
+        logCaptor.setLogLevelToTrace();
+
         withNewCluster((nodes, redisson) -> {
             try {
                 RScheduledExecutorService executor = redisson.getExecutorService("test-cluster-scheduler");
@@ -832,10 +843,16 @@ public class RedissonExecutorServiceTest extends RedisDockerTest {
                 throw new RuntimeException(e);
             }
         });
+
+        assertThat(logCaptor.getTraceLogs().stream().noneMatch(n -> n.contains("reply: -MOVED"))).isTrue();
+        logCaptor.close();
     }
 
     @Test
     public void testTaskCountInCluster() throws Exception {
+        LogCaptor logCaptor = LogCaptor.forClass(CommandDecoder.class);
+        logCaptor.setLogLevelToTrace();
+
         withNewCluster((nodes, redisson) -> {
             try {
                 RExecutorService executor = redisson.getExecutorService("test-cluster-taskcount");
@@ -860,10 +877,16 @@ public class RedissonExecutorServiceTest extends RedisDockerTest {
                 throw new RuntimeException(e);
             }
         });
+
+        assertThat(logCaptor.getTraceLogs().stream().noneMatch(n -> n.contains("reply: -MOVED"))).isTrue();
+        logCaptor.close();
     }
 
     @Test
     public void testCancelTaskInCluster() throws Exception {
+        LogCaptor logCaptor = LogCaptor.forClass(CommandDecoder.class);
+        logCaptor.setLogLevelToTrace();
+
         withNewCluster((nodes, redisson) -> {
             try {
                 RScheduledExecutorService executor = redisson.getExecutorService("test-cluster-cancel-task");
@@ -882,10 +905,16 @@ public class RedissonExecutorServiceTest extends RedisDockerTest {
                 throw new RuntimeException(e);
             }
         });
+
+        assertThat(logCaptor.getTraceLogs().stream().noneMatch(n -> n.contains("reply: -MOVED"))).isTrue();
+        logCaptor.close();
     }
 
     @Test
     public void testExecutorServiceWithNameMapperInCluster() throws Exception {
+        LogCaptor logCaptor = LogCaptor.forClass(CommandDecoder.class);
+        logCaptor.setLogLevelToTrace();
+
         withNewCluster((nodes, redisson) -> {
             try {
                 Config config = redisson.getConfig();
@@ -925,5 +954,8 @@ public class RedissonExecutorServiceTest extends RedisDockerTest {
                 throw new RuntimeException(e);
             }
         });
+
+        assertThat(logCaptor.getTraceLogs().stream().noneMatch(n -> n.contains("reply: -MOVED"))).isTrue();
+        logCaptor.close();
     }
 }


### PR DESCRIPTION
Fixed #7026