### PR TITLE
Fixed - RedisURI.toString() leaks password in plaintext in exception messages and logs. #7031

### DIFF
--- a/redisson/src/main/java/org/redisson/misc/RedisURI.java
+++ b/redisson/src/main/java/org/redisson/misc/RedisURI.java
@@ -187,9 +187,9 @@ public final class RedisURI {
     @Override
     public String toString() {
         if (username != null && password != null) {
-            return getScheme() + "://" + username + ":" + password + "@" + trimIpv6Brackets(host) + ":" + port;
+            return getScheme() + "://***:***@" + trimIpv6Brackets(host) + ":" + port;
         } else if (password != null) {
-            return getScheme() + "://" + password + "@" + trimIpv6Brackets(host) + ":" + port;
+            return getScheme() + "://***@" + trimIpv6Brackets(host) + ":" + port;
         }
         return getScheme() + "://" + trimIpv6Brackets(host) + ":" + port;
     }

--- a/redisson/src/test/java/org/redisson/misc/RedisURITest.java
+++ b/redisson/src/test/java/org/redisson/misc/RedisURITest.java
@@ -50,4 +50,25 @@ public class RedisURITest {
         assertThat(uri1.getPassword()).isEqualTo("my-token");
     }
 
+    @Test
+    public void testPasswordMasking() {
+        RedisURI uri = new RedisURI("redis://secretPassword@localhost:6379");
+        assertThat(uri.toString()).doesNotContain("secretPassword");
+        assertThat(uri.toString()).contains("***");
+    }
+
+    @Test
+    public void testUsernamePasswordMasking() {
+        RedisURI uri = new RedisURI("redis://user:secretPassword@localhost:6379");
+        assertThat(uri.toString()).doesNotContain("user");
+        assertThat(uri.toString()).doesNotContain("secretPassword");
+        assertThat(uri.toString()).contains("***");
+    }
+
+    @Test
+    public void testNoCredentialsMasking() {
+        RedisURI uri = new RedisURI("redis://localhost:6379");
+        assertThat(uri.toString()).isEqualTo("redis://localhost:6379");
+    }
+
 }


### PR DESCRIPTION
Fixed #7031

### Problem
`RedisURI.toString()` was exposing credentials in plaintext in exception messages and log output.

**Before**
RedisConnectionException: Unable to connect to: redis://secretPassword@prod.example.com:6379

**After**
RedisConnectionException: Unable to connect to: redis://***@prod.example.com:6379

### Changes
- `RedisURI.toString()`: mask `username` and `password` with `***`
- `RedisURITest`: added unit tests for masking behavior