### PR TITLE
Fix invalid GET arity in cluster detection Lua script

### DIFF
--- a/redisson/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
@@ -218,10 +218,10 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
         CompletableFuture<RedisConnection> c = masterSlaveEntry.connectionReadOp(RedisCommands.EVAL_VOID, false);
         RedisConnection cc = c.join();
         try {
-            String script = "redis.call('get', KEYS[1], ARGV[1]) " +
-                            "redis.call('get', KEYS[2], ARGV[2])";
+            String script = "redis.call('get', KEYS[1]) " +
+                            "redis.call('get', KEYS[2])";
 
-            cc.sync(RedisCommands.EVAL_VOID, script, 2, "test1", "test2", "value1", "value2");
+            cc.sync(RedisCommands.EVAL_VOID, script, 2, "test1", "test2");
         } catch (Exception e) {
             if (e.getMessage().startsWith("CROSSSLOT")) {
                 log.info("Cluster setup detected");


### PR DESCRIPTION
Fixes a regression in single-node cluster detection introduced by `874588fa3` (`#7017`).

MasterSlaveConnectionManager.detectCluster() switched from `MGET` to `EVAL`, but the Lua script started calling:

```
redis.call('get', KEYS[1], ARGV[1])
redis.call('get', KEYS[2], ARGV[2])
```

GET only accepts one argument, so Redis rejects the script before cluster detection can work.

issue : #7033 