### PR TITLE
Add opt-out for master fallback on slave LOADING errors

### DIFF
--- a/redisson/src/main/java/org/redisson/command/RedisExecutor.java
+++ b/redisson/src/main/java/org/redisson/command/RedisExecutor.java
@@ -594,7 +594,7 @@ public class RedisExecutor<V, R> {
                     ClientConnectionsEntry ce = entry.getEntry(connection.getRedisClient());
                     if (ce != null
                             && ce.getNodeType() == NodeType.SLAVE
-                            && entry.getConfig().isSlaveLoadingFallbackToMaster()) {
+                            && entry.getConfig().isFallbackLoadingToMaster()) {
                         onException();
                         source = new NodeSource(entry.getClient());
                         execute();

--- a/redisson/src/main/java/org/redisson/command/RedisExecutor.java
+++ b/redisson/src/main/java/org/redisson/command/RedisExecutor.java
@@ -592,7 +592,9 @@ public class RedisExecutor<V, R> {
                 RedisConnection connection = connectionFuture.getNow(null);
                 if (connection != null) {
                     ClientConnectionsEntry ce = entry.getEntry(connection.getRedisClient());
-                    if (ce != null && ce.getNodeType() == NodeType.SLAVE) {
+                    if (ce != null
+                            && ce.getNodeType() == NodeType.SLAVE
+                            && entry.getConfig().isSlaveLoadingFallbackToMaster()) {
                         onException();
                         source = new NodeSource(entry.getClient());
                         execute();

--- a/redisson/src/main/java/org/redisson/config/BaseMasterSlaveServersConfig.java
+++ b/redisson/src/main/java/org/redisson/config/BaseMasterSlaveServersConfig.java
@@ -60,7 +60,7 @@ public class BaseMasterSlaveServersConfig<T extends BaseMasterSlaveServersConfig
 
     private ReadMode readMode = ReadMode.SLAVE;
 
-    private boolean slaveLoadingFallbackToMaster = true;
+    private boolean fallbackLoadingToMaster = true;
     
     private SubscriptionMode subscriptionMode = SubscriptionMode.MASTER;
     
@@ -91,7 +91,7 @@ public class BaseMasterSlaveServersConfig<T extends BaseMasterSlaveServersConfig
         setSlaveConnectionMinimumIdleSize(config.getSlaveConnectionMinimumIdleSize());
         setSubscriptionConnectionMinimumIdleSize(config.getSubscriptionConnectionMinimumIdleSize());
         setReadMode(config.getReadMode());
-        setSlaveLoadingFallbackToMaster(config.isSlaveLoadingFallbackToMaster());
+        setFallbackLoadingToMaster(config.isFallbackLoadingToMaster());
         setSubscriptionMode(config.getSubscriptionMode());
         setDnsMonitoringInterval(config.getDnsMonitoringInterval());
         setFailedSlaveReconnectionInterval(config.getFailedSlaveReconnectionInterval());
@@ -291,15 +291,16 @@ public class BaseMasterSlaveServersConfig<T extends BaseMasterSlaveServersConfig
      * <p>
      * Default is <code>true</code>
      *
-     * @param slaveLoadingFallbackToMaster <code>true</code> to retry on master
+     * @param fallbackLoadingToMaster <code>true</code> to retry on master
      * @return config
      */
-    public T setSlaveLoadingFallbackToMaster(boolean slaveLoadingFallbackToMaster) {
-        this.slaveLoadingFallbackToMaster = slaveLoadingFallbackToMaster;
+    public T setFallbackLoadingToMaster(boolean fallbackLoadingToMaster) {
+        this.fallbackLoadingToMaster = fallbackLoadingToMaster;
         return (T) this;
     }
-    public boolean isSlaveLoadingFallbackToMaster() {
-        return slaveLoadingFallbackToMaster;
+
+    public boolean isFallbackLoadingToMaster() {
+        return fallbackLoadingToMaster;
     }
     
     public boolean isSlaveNotUsed() {

--- a/redisson/src/main/java/org/redisson/config/BaseMasterSlaveServersConfig.java
+++ b/redisson/src/main/java/org/redisson/config/BaseMasterSlaveServersConfig.java
@@ -59,6 +59,8 @@ public class BaseMasterSlaveServersConfig<T extends BaseMasterSlaveServersConfig
     private int masterConnectionPoolSize = 64;
 
     private ReadMode readMode = ReadMode.SLAVE;
+
+    private boolean slaveLoadingFallbackToMaster = true;
     
     private SubscriptionMode subscriptionMode = SubscriptionMode.MASTER;
     
@@ -89,6 +91,7 @@ public class BaseMasterSlaveServersConfig<T extends BaseMasterSlaveServersConfig
         setSlaveConnectionMinimumIdleSize(config.getSlaveConnectionMinimumIdleSize());
         setSubscriptionConnectionMinimumIdleSize(config.getSubscriptionConnectionMinimumIdleSize());
         setReadMode(config.getReadMode());
+        setSlaveLoadingFallbackToMaster(config.isSlaveLoadingFallbackToMaster());
         setSubscriptionMode(config.getSubscriptionMode());
         setDnsMonitoringInterval(config.getDnsMonitoringInterval());
         setFailedSlaveReconnectionInterval(config.getFailedSlaveReconnectionInterval());
@@ -280,6 +283,23 @@ public class BaseMasterSlaveServersConfig<T extends BaseMasterSlaveServersConfig
     }
     public ReadMode getReadMode() {
         return readMode;
+    }
+
+    /**
+     * Defines whether a read command should be redirected to the master node
+     * if a slave node returns a LOADING error.
+     * <p>
+     * Default is <code>true</code>
+     *
+     * @param slaveLoadingFallbackToMaster <code>true</code> to retry on master
+     * @return config
+     */
+    public T setSlaveLoadingFallbackToMaster(boolean slaveLoadingFallbackToMaster) {
+        this.slaveLoadingFallbackToMaster = slaveLoadingFallbackToMaster;
+        return (T) this;
+    }
+    public boolean isSlaveLoadingFallbackToMaster() {
+        return slaveLoadingFallbackToMaster;
     }
     
     public boolean isSlaveNotUsed() {

--- a/redisson/src/test/java/org/redisson/RedissonTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonTest.java
@@ -895,7 +895,7 @@ public class RedissonTest extends RedisDockerTest {
         Config c2 = new Config();
         c2.useClusterServers()
                 .addNodeAddress("redis://82.12.47.12:1028", "redis://82.12.47.14:1028")
-                .setSlaveLoadingFallbackToMaster(false);
+                .setFallbackLoadingToMaster(false);
         String t = c2.toYAML();
 
         Config c = Config.fromYAML(t);

--- a/redisson/src/test/java/org/redisson/RedissonTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonTest.java
@@ -891,6 +891,20 @@ public class RedissonTest extends RedisDockerTest {
     }
 
     @Test
+    public void testClusterConfigYAMLWithSlaveLoadingFallbackDisabled() throws IOException {
+        Config c2 = new Config();
+        c2.useClusterServers()
+                .addNodeAddress("redis://82.12.47.12:1028", "redis://82.12.47.14:1028")
+                .setSlaveLoadingFallbackToMaster(false);
+        String t = c2.toYAML();
+
+        Config c = Config.fromYAML(t);
+
+        assertThat(t).contains("slaveLoadingFallbackToMaster: false");
+        assertThat(c.toYAML()).isEqualTo(t);
+    }
+
+    @Test
     public void testReplicatedConfigYAML() throws IOException {
         Config c2 = new Config();
         c2.useReplicatedServers().addNodeAddress("redis://82.12.47.12:1028", "redis://82.12.47.14:1028");


### PR DESCRIPTION
Adds a new slaveLoadingFallbackToMaster config option to disable immediate master reroute when a slave returns LOADING during reads. Keeps the current default behavior

issue : #7034 