### PR TITLE
Fix ClassCastException in RedissonSession.load() due to unsafe numeric casts

### DIFF
--- a/redisson-micronaut/redisson-micronaut-20/src/main/java/org/redisson/micronaut/session/RedissonSession.java
+++ b/redisson-micronaut/redisson-micronaut-20/src/main/java/org/redisson/micronaut/session/RedissonSession.java
@@ -261,17 +261,17 @@ public class RedissonSession extends InMemorySession implements Session {
     }
 
     public void load(Map<CharSequence, Object> attrs) {
-        Long creationTime = (Long) attrs.remove(CREATION_TIME_ATTR);
+        Number creationTime = (Number) attrs.remove(CREATION_TIME_ATTR);
         if (creationTime != null) {
-            this.creationTime = Instant.ofEpochMilli(creationTime);
+            this.creationTime = Instant.ofEpochMilli(creationTime.longValue());
         }
-        Long lastAccessedTime = (Long) attrs.remove(LAST_ACCESSED_TIME_ATTR);
+        Number lastAccessedTime = (Number) attrs.remove(LAST_ACCESSED_TIME_ATTR);
         if (lastAccessedTime != null) {
-            super.setLastAccessedTime(Instant.ofEpochMilli(lastAccessedTime));
+            super.setLastAccessedTime(Instant.ofEpochMilli(lastAccessedTime.longValue()));
         }
-        Long maxInactiveInterval = (Long) attrs.remove(MAX_INACTIVE_INTERVAL_ATTR);
+        Number maxInactiveInterval = (Number) attrs.remove(MAX_INACTIVE_INTERVAL_ATTR);
         if (maxInactiveInterval != null) {
-            super.setMaxInactiveInterval(Duration.ofMillis(maxInactiveInterval));
+            super.setMaxInactiveInterval(Duration.ofMillis(maxInactiveInterval.longValue()));
         }
         setNew(false);
 

--- a/redisson-micronaut/redisson-micronaut-30/src/main/java/org/redisson/micronaut/session/RedissonSession.java
+++ b/redisson-micronaut/redisson-micronaut-30/src/main/java/org/redisson/micronaut/session/RedissonSession.java
@@ -261,17 +261,17 @@ public class RedissonSession extends InMemorySession implements Session {
     }
 
     public void load(Map<CharSequence, Object> attrs) {
-        Long creationTime = (Long) attrs.remove(CREATION_TIME_ATTR);
+        Number creationTime = (Number) attrs.remove(CREATION_TIME_ATTR);
         if (creationTime != null) {
-            this.creationTime = Instant.ofEpochMilli(creationTime);
+            this.creationTime = Instant.ofEpochMilli(creationTime.longValue());
         }
-        Long lastAccessedTime = (Long) attrs.remove(LAST_ACCESSED_TIME_ATTR);
+        Number lastAccessedTime = (Number) attrs.remove(LAST_ACCESSED_TIME_ATTR);
         if (lastAccessedTime != null) {
-            super.setLastAccessedTime(Instant.ofEpochMilli(lastAccessedTime));
+            super.setLastAccessedTime(Instant.ofEpochMilli(lastAccessedTime.longValue()));
         }
-        Long maxInactiveInterval = (Long) attrs.remove(MAX_INACTIVE_INTERVAL_ATTR);
+        Number maxInactiveInterval = (Number) attrs.remove(MAX_INACTIVE_INTERVAL_ATTR);
         if (maxInactiveInterval != null) {
-            super.setMaxInactiveInterval(Duration.ofMillis(maxInactiveInterval));
+            super.setMaxInactiveInterval(Duration.ofMillis(maxInactiveInterval.longValue()));
         }
         setNew(false);
 

--- a/redisson-micronaut/redisson-micronaut-40/src/main/java/org/redisson/micronaut/session/RedissonSession.java
+++ b/redisson-micronaut/redisson-micronaut-40/src/main/java/org/redisson/micronaut/session/RedissonSession.java
@@ -261,17 +261,17 @@ public class RedissonSession extends InMemorySession implements Session {
     }
 
     public void load(Map<CharSequence, Object> attrs) {
-        Long creationTime = (Long) attrs.remove(CREATION_TIME_ATTR);
+        Number creationTime = (Number) attrs.remove(CREATION_TIME_ATTR);
         if (creationTime != null) {
-            this.creationTime = Instant.ofEpochMilli(creationTime);
+            this.creationTime = Instant.ofEpochMilli(creationTime.longValue());
         }
-        Long lastAccessedTime = (Long) attrs.remove(LAST_ACCESSED_TIME_ATTR);
+        Number lastAccessedTime = (Number) attrs.remove(LAST_ACCESSED_TIME_ATTR);
         if (lastAccessedTime != null) {
-            super.setLastAccessedTime(Instant.ofEpochMilli(lastAccessedTime));
+            super.setLastAccessedTime(Instant.ofEpochMilli(lastAccessedTime.longValue()));
         }
-        Long maxInactiveInterval = (Long) attrs.remove(MAX_INACTIVE_INTERVAL_ATTR);
+        Number maxInactiveInterval = (Number) attrs.remove(MAX_INACTIVE_INTERVAL_ATTR);
         if (maxInactiveInterval != null) {
-            super.setMaxInactiveInterval(Duration.ofMillis(maxInactiveInterval));
+            super.setMaxInactiveInterval(Duration.ofMillis(maxInactiveInterval.longValue()));
         }
         setNew(false);
 

--- a/redisson-tomcat/redisson-tomcat-10/src/main/java/org/redisson/tomcat/RedissonSession.java
+++ b/redisson-tomcat/redisson-tomcat-10/src/main/java/org/redisson/tomcat/RedissonSession.java
@@ -493,21 +493,21 @@ public class RedissonSession extends StandardSession {
     }
     
     public void load(Map<String, Object> attrs) {
-        Long creationTime = (Long) attrs.remove(CREATION_TIME_ATTR);
+        Number creationTime = (Number) attrs.remove(CREATION_TIME_ATTR);
         if (creationTime != null) {
-            this.creationTime = creationTime;
+            this.creationTime = creationTime.longValue();
         }
-        Long lastAccessedTime = (Long) attrs.remove(LAST_ACCESSED_TIME_ATTR);
+        Number lastAccessedTime = (Number) attrs.remove(LAST_ACCESSED_TIME_ATTR);
         if (lastAccessedTime != null) {
-            this.lastAccessedTime = lastAccessedTime;
+            this.lastAccessedTime = lastAccessedTime.longValue();
         }
         Integer maxInactiveInterval = (Integer) attrs.remove(MAX_INACTIVE_INTERVAL_ATTR);
         if (maxInactiveInterval != null) {
             this.maxInactiveInterval = maxInactiveInterval;
         }
-        Long thisAccessedTime = (Long) attrs.remove(THIS_ACCESSED_TIME_ATTR);
+        Number thisAccessedTime = (Number) attrs.remove(THIS_ACCESSED_TIME_ATTR);
         if (thisAccessedTime != null) {
-            this.thisAccessedTime = thisAccessedTime;
+            this.thisAccessedTime = thisAccessedTime.longValue();
         }
         Boolean isValid = (Boolean) attrs.remove(IS_VALID_ATTR);
         if (isValid != null) {

--- a/redisson-tomcat/redisson-tomcat-11/src/main/java/org/redisson/tomcat/RedissonSession.java
+++ b/redisson-tomcat/redisson-tomcat-11/src/main/java/org/redisson/tomcat/RedissonSession.java
@@ -493,21 +493,21 @@ public class RedissonSession extends StandardSession {
     }
     
     public void load(Map<String, Object> attrs) {
-        Long creationTime = (Long) attrs.remove(CREATION_TIME_ATTR);
+        Number creationTime = (Number) attrs.remove(CREATION_TIME_ATTR);
         if (creationTime != null) {
-            this.creationTime = creationTime;
+            this.creationTime = creationTime.longValue();
         }
-        Long lastAccessedTime = (Long) attrs.remove(LAST_ACCESSED_TIME_ATTR);
+        Number lastAccessedTime = (Number) attrs.remove(LAST_ACCESSED_TIME_ATTR);
         if (lastAccessedTime != null) {
-            this.lastAccessedTime = lastAccessedTime;
+            this.lastAccessedTime = lastAccessedTime.longValue();
         }
         Integer maxInactiveInterval = (Integer) attrs.remove(MAX_INACTIVE_INTERVAL_ATTR);
         if (maxInactiveInterval != null) {
             this.maxInactiveInterval = maxInactiveInterval;
         }
-        Long thisAccessedTime = (Long) attrs.remove(THIS_ACCESSED_TIME_ATTR);
+        Number thisAccessedTime = (Number) attrs.remove(THIS_ACCESSED_TIME_ATTR);
         if (thisAccessedTime != null) {
-            this.thisAccessedTime = thisAccessedTime;
+            this.thisAccessedTime = thisAccessedTime.longValue();
         }
         Boolean isValid = (Boolean) attrs.remove(IS_VALID_ATTR);
         if (isValid != null) {

--- a/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSession.java
+++ b/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSession.java
@@ -511,21 +511,21 @@ public class RedissonSession extends StandardSession {
     }
     
     public void load(Map<String, Object> attrs) {
-        Long creationTime = (Long) attrs.remove(CREATION_TIME_ATTR);
+        Number creationTime = (Number) attrs.remove(CREATION_TIME_ATTR);
         if (creationTime != null) {
-            this.creationTime = creationTime;
+            this.creationTime = creationTime.longValue();
         }
-        Long lastAccessedTime = (Long) attrs.remove(LAST_ACCESSED_TIME_ATTR);
+        Number lastAccessedTime = (Number) attrs.remove(LAST_ACCESSED_TIME_ATTR);
         if (lastAccessedTime != null) {
-            this.lastAccessedTime = lastAccessedTime;
+            this.lastAccessedTime = lastAccessedTime.longValue();
         }
         Integer maxInactiveInterval = (Integer) attrs.remove(MAX_INACTIVE_INTERVAL_ATTR);
         if (maxInactiveInterval != null) {
             this.maxInactiveInterval = maxInactiveInterval;
         }
-        Long thisAccessedTime = (Long) attrs.remove(THIS_ACCESSED_TIME_ATTR);
+        Number thisAccessedTime = (Number) attrs.remove(THIS_ACCESSED_TIME_ATTR);
         if (thisAccessedTime != null) {
-            this.thisAccessedTime = thisAccessedTime;
+            this.thisAccessedTime = thisAccessedTime.longValue();
         }
         Boolean isValid = (Boolean) attrs.remove(IS_VALID_ATTR);
         if (isValid != null) {

--- a/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSession.java
+++ b/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSession.java
@@ -488,21 +488,21 @@ public class RedissonSession extends StandardSession {
     }
     
     public void load(Map<String, Object> attrs) {
-        Long creationTime = (Long) attrs.remove(CREATION_TIME_ATTR);
+        Number creationTime = (Number) attrs.remove(CREATION_TIME_ATTR);
         if (creationTime != null) {
-            this.creationTime = creationTime;
+            this.creationTime = creationTime.longValue();
         }
-        Long lastAccessedTime = (Long) attrs.remove(LAST_ACCESSED_TIME_ATTR);
+        Number lastAccessedTime = (Number) attrs.remove(LAST_ACCESSED_TIME_ATTR);
         if (lastAccessedTime != null) {
-            this.lastAccessedTime = lastAccessedTime;
+            this.lastAccessedTime = lastAccessedTime.longValue();
         }
         Integer maxInactiveInterval = (Integer) attrs.remove(MAX_INACTIVE_INTERVAL_ATTR);
         if (maxInactiveInterval != null) {
             this.maxInactiveInterval = maxInactiveInterval;
         }
-        Long thisAccessedTime = (Long) attrs.remove(THIS_ACCESSED_TIME_ATTR);
+        Number thisAccessedTime = (Number) attrs.remove(THIS_ACCESSED_TIME_ATTR);
         if (thisAccessedTime != null) {
-            this.thisAccessedTime = thisAccessedTime;
+            this.thisAccessedTime = thisAccessedTime.longValue();
         }
         Boolean isValid = (Boolean) attrs.remove(IS_VALID_ATTR);
         if (isValid != null) {

--- a/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/RedissonSession.java
+++ b/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/RedissonSession.java
@@ -488,21 +488,21 @@ public class RedissonSession extends StandardSession {
     }
     
     public void load(Map<String, Object> attrs) {
-        Long creationTime = (Long) attrs.remove(CREATION_TIME_ATTR);
+        Number creationTime = (Number) attrs.remove(CREATION_TIME_ATTR);
         if (creationTime != null) {
-            this.creationTime = creationTime;
+            this.creationTime = creationTime.longValue();
         }
-        Long lastAccessedTime = (Long) attrs.remove(LAST_ACCESSED_TIME_ATTR);
+        Number lastAccessedTime = (Number) attrs.remove(LAST_ACCESSED_TIME_ATTR);
         if (lastAccessedTime != null) {
-            this.lastAccessedTime = lastAccessedTime;
+            this.lastAccessedTime = lastAccessedTime.longValue();
         }
         Integer maxInactiveInterval = (Integer) attrs.remove(MAX_INACTIVE_INTERVAL_ATTR);
         if (maxInactiveInterval != null) {
             this.maxInactiveInterval = maxInactiveInterval;
         }
-        Long thisAccessedTime = (Long) attrs.remove(THIS_ACCESSED_TIME_ATTR);
+        Number thisAccessedTime = (Number) attrs.remove(THIS_ACCESSED_TIME_ATTR);
         if (thisAccessedTime != null) {
-            this.thisAccessedTime = thisAccessedTime;
+            this.thisAccessedTime = thisAccessedTime.longValue();
         }
         Boolean isValid = (Boolean) attrs.remove(IS_VALID_ATTR);
         if (isValid != null) {


### PR DESCRIPTION
## Fix ClassCastException in RedissonSession.load() due to unsafe numeric casts

Fixes #7005
Related: #4254 (same root cause, reported in 2022 but never applied to source code)

Credit to @bogdanOwner for reporting this issue, and to @Drofff for proposing the `(Number)` cast approach in #4254.

### Root Cause

`RedissonSession.load()` performs hard casts like `(Long) attrs.remove(CREATION_TIME_ATTR)`, which assumes the codec always returns `Long` for numeric values. However, this assumption does not hold for all codec configurations.

`JsonJacksonCodec` is aware of this risk — `initTypeInclusion()` (line 164-196) sets up a `TypeResolverBuilder` with special handling for `Long.class`:

```java
// JsonJacksonCodec.java line 179
// to fix problem with wrong long to int conversion
```

This embeds type metadata during serialization, so Jackson can reconstruct the correct type on deserialization. However, `TypedJsonJacksonCodec` explicitly overrides this protection:

```java
// TypedJsonJacksonCodec.java line 163-165
@Override
protected void initTypeInclusion(ObjectMapper mapObjectMapper) {
    // intentionally empty — disables type inclusion
}
```

Without type metadata, Jackson falls back to its default deserialization behavior for loosely typed targets (`Object`, `Number`, untyped `Map`): small integral values that fit in 32-bit are bound as `Integer`. This is because [`USE_LONG_FOR_INTS`](https://fasterxml.github.io/jackson-databind/javadoc/2.9/com/fasterxml/jackson/databind/DeserializationFeature.html) is disabled by default:

> `USE_LONG_FOR_INTS` — Feature that determines how "small" JSON integral (non-floating-point) numbers -- ones that fit in 32-bit signed integer (`int`) -- are bound when target type is loosely typed as `Object` or `Number` (or within untyped `Map` or `Collection` context).

While `MsgPackJacksonCodec`, `CborJacksonCodec`, and `SmileJacksonCodec` inherit the type inclusion from `JsonJacksonCodec`, the protection still breaks when data was written by a different codec, a different version, or an external system that lacks type metadata.

As a result, `(Long)` casts in `load()` throw `ClassCastException` when the codec returns an `Integer`.

### Fix

Replaced unsafe `(Long)` casts with `(Number)` casts followed by `.longValue()` calls, as originally suggested by @Drofff in #4254.

This is safe because `Number` is the common superclass of both `Long` and `Integer`. Calling `.longValue()` on either type returns the correct value without loss, so the fix is resilient regardless of which numeric type the codec returns.

`(Integer)` casts in the Tomcat modules (e.g., `maxInactiveInterval`) were intentionally left unchanged, as these fields are semantically int-ranged values and the existing cast is appropriate.

### Affected Modules

I found the same `(Long)` hard cast pattern in `RedissonSession.load()` across all Tomcat and Micronaut modules:

| Module | Unsafe casts fixed |
|---|---|
| redisson-tomcat-7 | 3x (Long) |
| redisson-tomcat-8 | 3x (Long) |
| redisson-tomcat-9 | 3x (Long) |
| redisson-tomcat-10 | 3x (Long) |
| redisson-tomcat-11 | 3x (Long) |
| redisson-micronaut-20 | 3x (Long) |
| redisson-micronaut-30 | 3x (Long) |
| redisson-micronaut-40 | 3x (Long) |

All existing tests pass after the change (`mvn clean install`).

Happy to add targeted test cases if needed!