### PR TITLE
Fix Un-Refreshed Slave Nodes In Replicated Mode

### DIFF
--- a/redisson/src/main/java/org/redisson/config/ReplicatedServersConfig.java
+++ b/redisson/src/main/java/org/redisson/config/ReplicatedServersConfig.java
@@ -28,6 +28,8 @@ import java.util.List;
  */
 public class ReplicatedServersConfig extends BaseMasterSlaveServersConfig<ReplicatedServersConfig> {
 
+    private NatMapper natMapper = NatMapper.direct();
+
     /**
      * Replication group node urls list
      */
@@ -116,6 +118,25 @@ public class ReplicatedServersConfig extends BaseMasterSlaveServersConfig<Replic
      */
     public ReplicatedServersConfig setMonitorIPChanges(boolean monitorIPChanges) {
         this.monitorIPChanges = monitorIPChanges;
+        return this;
+    }
+
+    public NatMapper getNatMapper() {
+        return natMapper;
+    }
+
+    /**
+     * Defines NAT mapper which maps Redis URI object.
+     * Applied to all Redis connections.
+     *
+     * @see HostNatMapper
+     * @see HostPortNatMapper
+     *
+     * @param natMapper nat mapper object
+     * @return config
+     */
+    public ReplicatedServersConfig setNatMapper(NatMapper natMapper) {
+        this.natMapper = natMapper;
         return this;
     }
 

--- a/redisson/src/main/java/org/redisson/connection/ReplicatedConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/ReplicatedConnectionManager.java
@@ -158,9 +158,9 @@ public class ReplicatedConnectionManager extends MasterSlaveConnectionManager {
                         log.error("No master available among the configured addresses, "
                                 + "please check your configuration.");
                     }
-
-                    checkFailedSlaves(slaveIPs);
                 }
+
+                checkFailedSlaves(slaveIPs);
 
                 scheduleMasterChangeCheck(cfg);
             });

--- a/redisson/src/main/java/org/redisson/connection/ReplicatedConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/ReplicatedConnectionManager.java
@@ -69,6 +69,7 @@ public class ReplicatedConnectionManager extends MasterSlaveConnectionManager {
 
     ReplicatedConnectionManager(ReplicatedServersConfig cfg, Config configCopy) {
         super(cfg, configCopy);
+        this.serviceManager.setNatMapper(cfg.getNatMapper());
     }
 
     @Override

--- a/redisson/src/test/java/org/redisson/RedisDockerTest.java
+++ b/redisson/src/test/java/org/redisson/RedisDockerTest.java
@@ -438,6 +438,78 @@ public class RedisDockerTest {
         }
     }
 
+    record ReplicatedData(Startable container, RedissonClient redisson, List<ContainerState> nodes) {}
+
+    private static ReplicatedData createReplicated() {
+        DockerComposeContainer environment =
+                new DockerComposeContainer(new File("src/test/resources/docker-compose-redis-replicated.yml"))
+                        .withOptions("--compatibility")
+                        .withExposedService("redis-master", 6379)
+                        .withExposedService("redis-replica", 6379);
+
+        environment.start();
+
+        try {
+            Thread.sleep(10000);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        List<ContainerState> nodes = new ArrayList<>();
+        Optional<ContainerState> master = environment.getContainerByServiceName("redis-master");
+        Optional<ContainerState> replica = environment.getContainerByServiceName("redis-replica");
+        nodes.add(master.get());
+        nodes.add(replica.get());
+
+        Ports.Binding[] masterPort = master.get().getContainerInfo().getNetworkSettings()
+                .getPorts().getBindings().get(new ExposedPort(master.get().getExposedPorts().get(0)));
+        Ports.Binding[] replicaPort = replica.get().getContainerInfo().getNetworkSettings()
+                .getPorts().getBindings().get(new ExposedPort(replica.get().getExposedPorts().get(0)));
+
+        Config config = new Config();
+        config.setProtocol(protocol);
+        config.useReplicatedServers()
+                .setNatMapper(new NatMapper() {
+                    @Override
+                    public RedisURI map(RedisURI uri) {
+                        for (ContainerState state : nodes) {
+                            if (state.getContainerInfo() == null) {
+                                continue;
+                            }
+
+                            InspectContainerResponse node = state.getContainerInfo();
+                            Ports.Binding[] mappedPort = node.getNetworkSettings()
+                                    .getPorts().getBindings().get(new ExposedPort(uri.getPort()));
+
+                            Map<String, ContainerNetwork> ss = node.getNetworkSettings().getNetworks();
+                            ContainerNetwork s = ss.values().iterator().next();
+
+                            if (mappedPort != null
+                                    && s.getIpAddress().equals(uri.getHost())) {
+                                return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.valueOf(mappedPort[0].getHostPortSpec()));
+                            }
+                        }
+                        return uri;
+                    }
+                })
+                .addNodeAddress("redis://127.0.0.1:" + masterPort[0].getHostPortSpec())
+                .addNodeAddress("redis://127.0.0.1:" + replicaPort[0].getHostPortSpec());
+
+        RedissonClient redisson = Redisson.create(config);
+        return new ReplicatedData(environment, redisson, nodes);
+    }
+
+    protected void withNewReplicated(BiConsumer<List<ContainerState>, RedissonClient> callback) {
+        ReplicatedData data = createReplicated();
+
+        try {
+            callback.accept(data.nodes, data.redisson);
+        } finally {
+            data.redisson.shutdown();
+            data.container.stop();
+        }
+    }
+
     protected String execute(ContainerState node, String... commands) {
         try {
             Container.ExecResult r = node.execInContainer(commands);

--- a/redisson/src/test/java/org/redisson/RedissonFailoverTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonFailoverTest.java
@@ -1,6 +1,7 @@
 package org.redisson;
 
 import org.junit.jupiter.api.Test;
+import org.redisson.api.NodeType;
 import org.redisson.api.RFuture;
 import org.redisson.api.RedissonClient;
 import org.redisson.api.redisnode.RedisClusterMaster;
@@ -8,6 +9,8 @@ import org.redisson.api.redisnode.RedisNodes;
 import org.redisson.config.Config;
 import org.redisson.config.ReadMode;
 import org.redisson.config.SubscriptionMode;
+import org.redisson.connection.ClientConnectionsEntry;
+import org.redisson.connection.balancer.RoundRobinLoadBalancer;
 import org.testcontainers.containers.ContainerState;
 import org.testcontainers.containers.GenericContainer;
 
@@ -16,6 +19,7 @@ import java.util.*;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -305,6 +309,48 @@ public class RedissonFailoverTest extends RedisDockerTest {
             }
 
             redisson.shutdown();
+        });
+    }
+
+    @Test
+    public void testReplicatedFailoverToMaster() {
+        withNewReplicated((nodes, redisson) -> {
+            List<ContainerState> slaves = getSlaveNodes(nodes);
+            AtomicReference<ClientConnectionsEntry> lastUsedConn = new AtomicReference<>();
+
+            Config config = redisson.getConfig();
+            config.useReplicatedServers()
+                    .setReadMode(ReadMode.SLAVE)
+                    .setLoadBalancer(new RoundRobinLoadBalancer() {
+                        @Override
+                        public ClientConnectionsEntry getEntry(List<ClientConnectionsEntry> clientsCopy) {
+                            ClientConnectionsEntry entry = super.getEntry(clientsCopy);
+                            lastUsedConn.set(entry);
+                            return entry;
+                        }
+                    });
+            RedissonClient observeClient = Redisson.create(config);
+
+            observeClient.getBucket("testFallbackInCluster").get();
+            assertThat(lastUsedConn.get()).isNotNull();
+            assertThat(lastUsedConn.get().getNodeType()).isEqualTo(NodeType.SLAVE);
+
+            for (ContainerState slave : slaves) {
+                stop(slave);
+            }
+
+            // wait for refreshing failed slaves
+            try {
+                Thread.sleep(5000);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+
+            observeClient.getBucket("testFallbackInCluster").get();
+            assertThat(lastUsedConn.get()).isNotNull();
+            assertThat(lastUsedConn.get().getNodeType()).isEqualTo(NodeType.MASTER);
+
+            observeClient.shutdown();
         });
     }
 

--- a/redisson/src/test/resources/docker-compose-redis-replicated.yml
+++ b/redisson/src/test/resources/docker-compose-redis-replicated.yml
@@ -1,0 +1,30 @@
+services:
+  redis-master:
+    image: redis:latest
+    command: redis-server --port 6379 --protected-mode no --bind 0.0.0.0
+    ports:
+      - "6379"
+    volumes:
+      - redis-replicated-master:/data
+    networks:
+      - redisreplicated
+
+  redis-replica:
+    image: redis:latest
+    command: redis-server --port 6379 --protected-mode no --bind 0.0.0.0 --replicaof redis-master 6379
+    depends_on:
+      - redis-master
+    ports:
+      - "6379"
+    volumes:
+      - redis-replicated-replica:/data
+    networks:
+      - redisreplicated
+
+volumes:
+  redis-replicated-master:
+  redis-replicated-replica:
+
+networks:
+  redisreplicated:
+    driver: bridge


### PR DESCRIPTION
Fixed #6882 with related tests
## Changes
- Add NAT mapper support for `useReplicatedServers`
- Add `withNewReplicated` for `RedisDockerTest`
- Move `checkFailedSlaves` out of exception check block

## Before Fix
The `testReplicatedFailoverToMaster` test case fails with an exception
```
org.redisson.client.RedisException: Unexpected exception while processing command

	at org.redisson.command.RedisExecutor.convertException(RedisExecutor.java:858)
	at org.redisson.command.RedisExecutor.lambda$execute$4(RedisExecutor.java:192)
	at org.redisson.connection.pool.ConnectionPool.lambda$acquireConnection$2(ConnectionPool.java:132)
	at org.redisson.connection.ConnectionsHolder.lambda$createConnection$5(ConnectionsHolder.java:201)
	at org.redisson.client.RedisClient$2$2.run(RedisClient.java:325)
	at io.netty.util.concurrent.AbstractEventExecutor.runTask$$$capture(AbstractEventExecutor.java:148)
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java)
	at --- Async.Stack.Trace --- (captured by IntelliJ IDEA debugger)
	at io.netty.util.concurrent.SingleThreadEventExecutor.addTask(SingleThreadEventExecutor.java)
	at io.netty.util.concurrent.SingleThreadEventExecutor.execute(SingleThreadEventExecutor.java:1027)
	at io.netty.util.concurrent.SingleThreadEventExecutor.execute0(SingleThreadEventExecutor.java:993)
	at io.netty.util.concurrent.SingleThreadEventExecutor.execute(SingleThreadEventExecutor.java:983)
	at io.netty.util.concurrent.AbstractEventExecutorGroup.execute(AbstractEventExecutorGroup.java:115)
	at org.redisson.client.RedisClient$2.operationComplete(RedisClient.java:323)
	at org.redisson.client.RedisClient$2.operationComplete(RedisClient.java:290)
	at io.netty.util.concurrent.DefaultPromise.notifyListener0(DefaultPromise.java:604)
	at io.netty.util.concurrent.DefaultPromise.notifyListeners0(DefaultPromise.java:597)
	at io.netty.util.concurrent.DefaultPromise.notifyListenersNow(DefaultPromise.java:573)
	at io.netty.util.concurrent.DefaultPromise.notifyListeners(DefaultPromise.java:506)
	at io.netty.util.concurrent.DefaultPromise.setValue0(DefaultPromise.java:650)
	at io.netty.util.concurrent.DefaultPromise.setFailure0(DefaultPromise.java:643)
	at io.netty.util.concurrent.DefaultPromise.tryFailure(DefaultPromise.java:132)
	at io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe.fulfillConnectPromise(AbstractNioChannel.java:371)
	at io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe.finishConnect(AbstractNioChannel.java:387)
	at io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe.handle(AbstractNioChannel.java:432)
	at io.netty.channel.nio.NioIoHandler$DefaultNioRegistration.handle(NioIoHandler.java:388)
	at io.netty.channel.nio.NioIoHandler.processSelectedKey(NioIoHandler.java:596)
	at io.netty.channel.nio.NioIoHandler.processSelectedKeysOptimized(NioIoHandler.java:571)
	at io.netty.channel.nio.NioIoHandler.processSelectedKeys(NioIoHandler.java:512)
	at io.netty.channel.nio.NioIoHandler.run(NioIoHandler.java:484)
	at io.netty.channel.SingleThreadIoEventLoop.runIo(SingleThreadIoEventLoop.java:225)
	at io.netty.channel.SingleThreadIoEventLoop.run(SingleThreadIoEventLoop.java:196)
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:1195)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:1583)
	Suppressed: java.util.concurrent.CompletionException: io.netty.channel.AbstractChannel$AnnotatedConnectException: Connection refused: 127.0.0.1/127.0.0.1:57829
		at java.base/java.util.concurrent.CompletableFuture.encodeRelay(CompletableFuture.java:368)
		at java.base/java.util.concurrent.CompletableFuture.completeRelay(CompletableFuture.java:377)
		at java.base/java.util.concurrent.CompletableFuture$UniRelay.tryFire(CompletableFuture.java:1097)
		at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510)
		at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2194)
		... 32 more
	Caused by: io.netty.channel.AbstractChannel$AnnotatedConnectException: Connection refused: 127.0.0.1/127.0.0.1:57829
	Caused by: java.net.ConnectException: Connection refused
		at java.base/sun.nio.ch.Net.pollConnect(Native Method)
		at io.netty.channel.socket.nio.NioSocketChannel.doFinishConnect(NioSocketChannel.java:330)
		at io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe.finishConnect(AbstractNioChannel.java:384)
		at io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe.handle(AbstractNioChannel.java:432)
		at io.netty.channel.nio.NioIoHandler$DefaultNioRegistration.handle(NioIoHandler.java:388)
		at io.netty.channel.nio.NioIoHandler.processSelectedKey(NioIoHandler.java:596)
		at io.netty.channel.nio.NioIoHandler.processSelectedKeysOptimized(NioIoHandler.java:571)
		at io.netty.channel.nio.NioIoHandler.processSelectedKeys(NioIoHandler.java:512)
		at io.netty.channel.nio.NioIoHandler.run(NioIoHandler.java:484)
		at io.netty.channel.SingleThreadIoEventLoop.runIo(SingleThreadIoEventLoop.java:225)
		at io.netty.channel.SingleThreadIoEventLoop.run(SingleThreadIoEventLoop.java:196)
		at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:1195)
		at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
		at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
		at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: [CIRCULAR REFERENCE: io.netty.channel.AbstractChannel$AnnotatedConnectException: Connection refused: 127.0.0.1/127.0.0.1:57829]

```

## After Fix
The `testReplicatedFailoverToMaster` passes