### PR TITLE
Add GCRA Rate Limiting

### DIFF
--- a/redisson/src/main/java/org/redisson/Redisson.java
+++ b/redisson/src/main/java/org/redisson/Redisson.java
@@ -224,6 +224,17 @@ public final class Redisson implements RedissonClient {
     }
 
     @Override
+    public RGcra getGcra(String name) {
+        return new RedissonGcra(commandExecutor, name);
+    }
+
+    @Override
+    public RGcra getGcra(CommonOptions options) {
+        CommonParams params = (CommonParams) options;
+        return new RedissonGcra(commandExecutor.copy(params), params.getName());
+    }
+
+    @Override
     public <V> RBucket<V> getBucket(String name, Codec codec) {
         return new RedissonBucket<>(codec, commandExecutor, name);
     }

--- a/redisson/src/main/java/org/redisson/RedissonGcra.java
+++ b/redisson/src/main/java/org/redisson/RedissonGcra.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2013-2026 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson;
+
+import org.redisson.api.GcraResult;
+import org.redisson.api.RFuture;
+import org.redisson.api.RGcra;
+import org.redisson.client.codec.StringCodec;
+import org.redisson.client.protocol.RedisCommands;
+import org.redisson.command.CommandAsyncExecutor;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ *
+ * @author Su Ko
+ *
+ */
+public final class RedissonGcra extends RedissonExpirable implements RGcra {
+
+    public RedissonGcra(CommandAsyncExecutor commandExecutor, String name) {
+        super(commandExecutor, name);
+    }
+
+    @Override
+    public GcraResult tryAcquire(long maxBurst, long tokensPerPeriod, Duration period) {
+        return get(tryAcquireAsync(maxBurst, tokensPerPeriod, period));
+    }
+
+    @Override
+    public RFuture<GcraResult> tryAcquireAsync(long maxBurst, long tokensPerPeriod, Duration period) {
+        return tryAcquireAsync(maxBurst, tokensPerPeriod, period, 1);
+    }
+
+    @Override
+    public GcraResult tryAcquire(long maxBurst, long tokensPerPeriod, Duration period, long tokens) {
+        return get(tryAcquireAsync(maxBurst, tokensPerPeriod, period, tokens));
+    }
+
+    @Override
+    public RFuture<GcraResult> tryAcquireAsync(long maxBurst, long tokensPerPeriod, Duration period, long tokens) {
+        validate(maxBurst, tokensPerPeriod, period, tokens);
+
+        List<Object> params = new ArrayList<>(6);
+        params.add(name);
+        params.add(maxBurst);
+        params.add(tokensPerPeriod);
+        params.add(toSeconds(period));
+        if (tokens != 1) {
+            params.add("TOKENS");
+            params.add(tokens);
+        }
+
+        return commandExecutor.writeAsync(getRawName(), StringCodec.INSTANCE, RedisCommands.GCRA, params.toArray());
+    }
+
+    static void validate(long maxBurst, long tokensPerPeriod, Duration period, long tokens) {
+        if (maxBurst < 0) {
+            throw new IllegalArgumentException("maxBurst can't be negative");
+        }
+        if (tokensPerPeriod <= 0) {
+            throw new IllegalArgumentException("tokensPerPeriod must be positive");
+        }
+        if (period == null || period.isZero() || period.isNegative()) {
+            throw new IllegalArgumentException("period must be positive");
+        }
+        if (tokens <= 0) {
+            throw new IllegalArgumentException("tokens must be positive");
+        }
+    }
+
+    static String toSeconds(Duration period) {
+        return BigDecimal.valueOf(period.getSeconds())
+                .add(BigDecimal.valueOf(period.getNano(), 9))
+                .stripTrailingZeros()
+                .toPlainString();
+    }
+}

--- a/redisson/src/main/java/org/redisson/RedissonReactive.java
+++ b/redisson/src/main/java/org/redisson/RedissonReactive.java
@@ -145,6 +145,18 @@ public final class RedissonReactive implements RedissonReactiveClient {
     }
 
     @Override
+    public RGcraReactive getGcra(String name) {
+        return ReactiveProxyBuilder.create(commandExecutor, new RedissonGcra(commandExecutor, name), RGcraReactive.class);
+    }
+
+    @Override
+    public RGcraReactive getGcra(CommonOptions options) {
+        CommonParams params = (CommonParams) options;
+        CommandReactiveExecutor ca = commandExecutor.copy(params);
+        return ReactiveProxyBuilder.create(commandExecutor, new RedissonGcra(ca, params.getName()), RGcraReactive.class);
+    }
+
+    @Override
     public RBinaryStreamReactive getBinaryStream(String name) {
         RedissonBinaryStream stream = new RedissonBinaryStream(commandExecutor, name);
         return ReactiveProxyBuilder.create(commandExecutor, stream,

--- a/redisson/src/main/java/org/redisson/RedissonRx.java
+++ b/redisson/src/main/java/org/redisson/RedissonRx.java
@@ -144,6 +144,18 @@ public final class RedissonRx implements RedissonRxClient {
     }
 
     @Override
+    public RGcraRx getGcra(String name) {
+        return RxProxyBuilder.create(commandExecutor, new RedissonGcra(commandExecutor, name), RGcraRx.class);
+    }
+
+    @Override
+    public RGcraRx getGcra(CommonOptions options) {
+        CommonParams params = (CommonParams) options;
+        return RxProxyBuilder.create(commandExecutor,
+                new RedissonGcra(commandExecutor.copy(params), params.getName()), RGcraRx.class);
+    }
+
+    @Override
     public RBinaryStreamRx getBinaryStream(String name) {
         RedissonBinaryStream stream = new RedissonBinaryStream(commandExecutor, name);
         return RxProxyBuilder.create(commandExecutor, stream,

--- a/redisson/src/main/java/org/redisson/api/GcraResult.java
+++ b/redisson/src/main/java/org/redisson/api/GcraResult.java
@@ -40,22 +40,47 @@ public final class GcraResult {
         this.fullBurstAfterSeconds = fullBurstAfterSeconds;
     }
 
+    /**
+     * Returns {@code true} if the requested tokens can't be acquired.
+     *
+     * @return {@code true} if rate limit has been exceeded
+     */
     public boolean isLimited() {
         return limited;
     }
 
+    /**
+     * Returns maximum token amount available for burst.
+     *
+     * @return maximum token amount
+     */
     public long getMaxTokens() {
         return maxTokens;
     }
 
+    /**
+     * Returns token amount currently available.
+     *
+     * @return available token amount
+     */
     public long getAvailableTokens() {
         return availableTokens;
     }
 
+    /**
+     * Returns number of seconds to wait before the requested tokens can be acquired.
+     *
+     * @return retry interval in seconds
+     */
     public long getRetryAfterSeconds() {
         return retryAfterSeconds;
     }
 
+    /**
+     * Returns number of seconds to wait before the full burst capacity is restored.
+     *
+     * @return full burst restore interval in seconds
+     */
     public long getFullBurstAfterSeconds() {
         return fullBurstAfterSeconds;
     }

--- a/redisson/src/main/java/org/redisson/api/GcraResult.java
+++ b/redisson/src/main/java/org/redisson/api/GcraResult.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2013-2026 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.api;
+
+import java.util.Objects;
+
+/**
+ * Result returned by Redis {@code GCRA} command.
+ *
+ * @author Su Ko
+ *
+ */
+public final class GcraResult {
+
+    private final boolean limited;
+    private final long maxTokens;
+    private final long availableTokens;
+    private final long retryAfterSeconds;
+    private final long fullBurstAfterSeconds;
+
+    public GcraResult(boolean limited, long maxTokens, long availableTokens,
+                      long retryAfterSeconds, long fullBurstAfterSeconds) {
+        this.limited = limited;
+        this.maxTokens = maxTokens;
+        this.availableTokens = availableTokens;
+        this.retryAfterSeconds = retryAfterSeconds;
+        this.fullBurstAfterSeconds = fullBurstAfterSeconds;
+    }
+
+    public boolean isLimited() {
+        return limited;
+    }
+
+    public long getMaxTokens() {
+        return maxTokens;
+    }
+
+    public long getAvailableTokens() {
+        return availableTokens;
+    }
+
+    public long getRetryAfterSeconds() {
+        return retryAfterSeconds;
+    }
+
+    public long getFullBurstAfterSeconds() {
+        return fullBurstAfterSeconds;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        GcraResult that = (GcraResult) o;
+        return limited == that.limited
+                && maxTokens == that.maxTokens
+                && availableTokens == that.availableTokens
+                && retryAfterSeconds == that.retryAfterSeconds
+                && fullBurstAfterSeconds == that.fullBurstAfterSeconds;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(limited, maxTokens, availableTokens, retryAfterSeconds, fullBurstAfterSeconds);
+    }
+
+    @Override
+    public String toString() {
+        return "GcraResult{"
+                + "limited=" + limited
+                + ", maxTokens=" + maxTokens
+                + ", availableTokens=" + availableTokens
+                + ", retryAfterSeconds=" + retryAfterSeconds
+                + ", fullBurstAfterSeconds=" + fullBurstAfterSeconds
+                + '}';
+    }
+}

--- a/redisson/src/main/java/org/redisson/api/RGcra.java
+++ b/redisson/src/main/java/org/redisson/api/RGcra.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2013-2026 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.api;
+
+import java.time.Duration;
+
+/**
+ * Redis based GCRA object.
+ * <p>
+ * Requires <b>Redis 8.8.0 or higher.</b>
+ *
+ * @author Su Ko
+ *
+ */
+public interface RGcra extends RGcraAsync, RExpirable {
+
+    /**
+     * Applies the GCRA algorithm with a single token request.
+     *
+     * @param maxBurst maximum burst size
+     * @param tokensPerPeriod token replenishment rate per period
+     * @param period replenishment period
+     * @return GCRA result
+     */
+    GcraResult tryAcquire(long maxBurst, long tokensPerPeriod, Duration period);
+
+    /**
+     * Applies the GCRA algorithm with a custom token request size.
+     *
+     * @param maxBurst maximum burst size
+     * @param tokensPerPeriod token replenishment rate per period
+     * @param period replenishment period
+     * @param tokens requested token amount
+     * @return GCRA result
+     */
+    GcraResult tryAcquire(long maxBurst, long tokensPerPeriod, Duration period, long tokens);
+
+}

--- a/redisson/src/main/java/org/redisson/api/RGcraAsync.java
+++ b/redisson/src/main/java/org/redisson/api/RGcraAsync.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2013-2026 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.api;
+
+import java.time.Duration;
+
+/**
+ * Async interface for Redis based GCRA object.
+ * <p>
+ * Requires <b>Redis 8.8.0 or higher.</b>
+ *
+ * @author Su Ko
+ *
+ */
+public interface RGcraAsync extends RExpirableAsync {
+
+    /**
+     * Applies the GCRA algorithm with a single token request.
+     *
+     * @param maxBurst maximum burst size
+     * @param tokensPerPeriod token replenishment rate per period
+     * @param period replenishment period
+     * @return GCRA result
+     */
+    RFuture<GcraResult> tryAcquireAsync(long maxBurst, long tokensPerPeriod, Duration period);
+
+    /**
+     * Applies the GCRA algorithm with a custom token request size.
+     *
+     * @param maxBurst maximum burst size
+     * @param tokensPerPeriod token replenishment rate per period
+     * @param period replenishment period
+     * @param tokens requested token amount
+     * @return GCRA result
+     */
+    RFuture<GcraResult> tryAcquireAsync(long maxBurst, long tokensPerPeriod, Duration period, long tokens);
+
+}

--- a/redisson/src/main/java/org/redisson/api/RGcraReactive.java
+++ b/redisson/src/main/java/org/redisson/api/RGcraReactive.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2013-2026 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.api;
+
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+
+/**
+ * Reactive interface for Redis based GCRA object.
+ * <p>
+ * Requires <b>Redis 8.8.0 or higher.</b>
+ *
+ * @author Su Ko
+ *
+ */
+public interface RGcraReactive extends RExpirableReactive {
+
+    /**
+     * Applies the GCRA algorithm with a single token request.
+     *
+     * @param maxBurst maximum burst size
+     * @param tokensPerPeriod token replenishment rate per period
+     * @param period replenishment period
+     * @return GCRA result
+     */
+    Mono<GcraResult> tryAcquire(long maxBurst, long tokensPerPeriod, Duration period);
+
+    /**
+     * Applies the GCRA algorithm with a custom token request size.
+     *
+     * @param maxBurst maximum burst size
+     * @param tokensPerPeriod token replenishment rate per period
+     * @param period replenishment period
+     * @param tokens requested token amount
+     * @return GCRA result
+     */
+    Mono<GcraResult> tryAcquire(long maxBurst, long tokensPerPeriod, Duration period, long tokens);
+
+}

--- a/redisson/src/main/java/org/redisson/api/RGcraRx.java
+++ b/redisson/src/main/java/org/redisson/api/RGcraRx.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2013-2026 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.api;
+
+import io.reactivex.rxjava3.core.Single;
+
+import java.time.Duration;
+
+/**
+ * Rx interface for Redis based GCRA object.
+ * <p>
+ * Requires <b>Redis 8.8.0 or higher.</b>
+ *
+ * @author Su Ko
+ *
+ */
+public interface RGcraRx extends RExpirableRx {
+
+    /**
+     * Applies the GCRA algorithm with a single token request.
+     *
+     * @param maxBurst maximum burst size
+     * @param tokensPerPeriod token replenishment rate per period
+     * @param period replenishment period
+     * @return GCRA result
+     */
+    Single<GcraResult> tryAcquire(long maxBurst, long tokensPerPeriod, Duration period);
+
+    /**
+     * Applies the GCRA algorithm with a custom token request size.
+     *
+     * @param maxBurst maximum burst size
+     * @param tokensPerPeriod token replenishment rate per period
+     * @param period replenishment period
+     * @param tokens requested token amount
+     * @return GCRA result
+     */
+    Single<GcraResult> tryAcquire(long maxBurst, long tokensPerPeriod, Duration period, long tokens);
+
+}

--- a/redisson/src/main/java/org/redisson/api/RType.java
+++ b/redisson/src/main/java/org/redisson/api/RType.java
@@ -28,6 +28,7 @@ public enum RType {
     SET("set"),
     ZSET("zset"),
     STREAM("stream"),
+    GCRA("gcra"),
     JSON("ReJSON-RL");
 
     private final String value;

--- a/redisson/src/main/java/org/redisson/api/RedissonClient.java
+++ b/redisson/src/main/java/org/redisson/api/RedissonClient.java
@@ -145,6 +145,22 @@ public interface RedissonClient {
      * @return RateLimiter object
      */
     RRateLimiter getRateLimiter(CommonOptions options);
+
+    /**
+     * Returns GCRA instance by <code>name</code>.
+     *
+     * @param name of GCRA object
+     * @return GCRA object
+     */
+    RGcra getGcra(String name);
+
+    /**
+     * Returns GCRA instance with specified <code>options</code>.
+     *
+     * @param options instance options
+     * @return GCRA object
+     */
+    RGcra getGcra(CommonOptions options);
     
     /**
      * Returns binary stream holder instance by <code>name</code>

--- a/redisson/src/main/java/org/redisson/api/RedissonClient.java
+++ b/redisson/src/main/java/org/redisson/api/RedissonClient.java
@@ -148,6 +148,8 @@ public interface RedissonClient {
 
     /**
      * Returns GCRA instance by <code>name</code>.
+     * <p>
+     * Requires Redis 8.8.0 or higher.
      *
      * @param name of GCRA object
      * @return GCRA object
@@ -156,6 +158,8 @@ public interface RedissonClient {
 
     /**
      * Returns GCRA instance with specified <code>options</code>.
+     * <p>
+     * Requires Redis 8.8.0 or higher.
      *
      * @param options instance options
      * @return GCRA object

--- a/redisson/src/main/java/org/redisson/api/RedissonReactiveClient.java
+++ b/redisson/src/main/java/org/redisson/api/RedissonReactiveClient.java
@@ -174,6 +174,8 @@ public interface RedissonReactiveClient {
 
     /**
      * Returns GCRA instance by <code>name</code>.
+     * <p>
+     * Requires Redis 8.8.0 or higher.
      *
      * @param name of GCRA object
      * @return GCRA object
@@ -182,6 +184,8 @@ public interface RedissonReactiveClient {
 
     /**
      * Returns GCRA instance with specified <code>options</code>.
+     * <p>
+     * Requires Redis 8.8.0 or higher.
      *
      * @param options instance options
      * @return GCRA object

--- a/redisson/src/main/java/org/redisson/api/RedissonReactiveClient.java
+++ b/redisson/src/main/java/org/redisson/api/RedissonReactiveClient.java
@@ -173,6 +173,22 @@ public interface RedissonReactiveClient {
     RRateLimiterReactive getRateLimiter(CommonOptions options);
 
     /**
+     * Returns GCRA instance by <code>name</code>.
+     *
+     * @param name of GCRA object
+     * @return GCRA object
+     */
+    RGcraReactive getGcra(String name);
+
+    /**
+     * Returns GCRA instance with specified <code>options</code>.
+     *
+     * @param options instance options
+     * @return GCRA object
+     */
+    RGcraReactive getGcra(CommonOptions options);
+
+    /**
      * Returns binary stream holder instance by <code>name</code>
      *
      * @param name of binary stream

--- a/redisson/src/main/java/org/redisson/api/RedissonRxClient.java
+++ b/redisson/src/main/java/org/redisson/api/RedissonRxClient.java
@@ -174,6 +174,8 @@ public interface RedissonRxClient {
 
     /**
      * Returns GCRA instance by <code>name</code>.
+     * <p>
+     * Requires Redis 8.8.0 or higher.
      *
      * @param name of GCRA object
      * @return GCRA object
@@ -182,6 +184,8 @@ public interface RedissonRxClient {
 
     /**
      * Returns GCRA instance with specified <code>options</code>.
+     * <p>
+     * Requires Redis 8.8.0 or higher.
      *
      * @param options instance options
      * @return GCRA object

--- a/redisson/src/main/java/org/redisson/api/RedissonRxClient.java
+++ b/redisson/src/main/java/org/redisson/api/RedissonRxClient.java
@@ -173,6 +173,22 @@ public interface RedissonRxClient {
     RRateLimiterRx getRateLimiter(CommonOptions options);
 
     /**
+     * Returns GCRA instance by <code>name</code>.
+     *
+     * @param name of GCRA object
+     * @return GCRA object
+     */
+    RGcraRx getGcra(String name);
+
+    /**
+     * Returns GCRA instance with specified <code>options</code>.
+     *
+     * @param options instance options
+     * @return GCRA object
+     */
+    RGcraRx getGcra(CommonOptions options);
+
+    /**
      * Returns binary stream holder instance by <code>name</code>
      *
      * @param name of binary stream

--- a/redisson/src/main/java/org/redisson/client/protocol/RedisCommands.java
+++ b/redisson/src/main/java/org/redisson/client/protocol/RedisCommands.java
@@ -121,6 +121,7 @@ public interface RedisCommands {
     RedisCommand<Object> GEORADIUS_STORE = new RedisCommand<Object>("GEORADIUS", new Long2MultiDecoder());
     RedisCommand<Object> GEORADIUSBYMEMBER_STORE = new RedisCommand<Object>("GEORADIUSBYMEMBER", new Long2MultiDecoder());
     RedisCommand<Object> GEOSEARCHSTORE_STORE = new RedisCommand<Object>("GEOSEARCHSTORE", new Long2MultiDecoder());
+    RedisCommand<GcraResult> GCRA = new RedisCommand<>("GCRA", new GcraResultDecoder());
 
     RedisStrictCommand<Integer> KEYSLOT = new RedisStrictCommand<Integer>("CLUSTER", "KEYSLOT", new IntegerReplayConvertor());
     RedisStrictCommand<RType> TYPE = new RedisStrictCommand<RType>("TYPE", new TypeConvertor());
@@ -949,7 +950,8 @@ public interface RedisCommands {
             Arrays.asList(RPOPLPUSH.getName(), LPOP.getName(), RPOP.getName(), LPUSH.getName(), RPUSH.getName(),
                     LPUSHX.getName(), RPUSHX.getName(), GEOADD.getName(), XADD.getName(), APPEND.getName(),
                     DECR.getName(), "DECRBY", INCR.getName(), INCRBY.getName(), ZINCRBY.getName(),
-                    "HINCRBYFLOAT", "HINCRBY", "INCRBYFLOAT", SETNX.getName(), MSETNX.getName(), HSETNX.getName()));
+                    "HINCRBYFLOAT", "HINCRBY", "INCRBYFLOAT", SETNX.getName(), MSETNX.getName(), HSETNX.getName(),
+                    GCRA.getName()));
 
     RedisStrictCommand<Long> JSON_STRLEN = new RedisStrictCommand<>("JSON.STRLEN");
     RedisCommand<List<Long>> JSON_STRLEN_LIST = new RedisCommand("JSON.STRLEN", new ObjectListReplayDecoder<Long>(), new LongReplayConvertor());

--- a/redisson/src/main/java/org/redisson/client/protocol/convertor/TypeConvertor.java
+++ b/redisson/src/main/java/org/redisson/client/protocol/convertor/TypeConvertor.java
@@ -45,6 +45,9 @@ public class TypeConvertor implements Convertor<RType> {
         if ("stream".equals(val)) {
             return RType.STREAM;
         }
+        if ("gcra".equals(val)) {
+            return RType.GCRA;
+        }
         if ("ReJSON-RL".equals(val)) {
             return RType.JSON;
         }

--- a/redisson/src/main/java/org/redisson/client/protocol/decoder/GcraResultDecoder.java
+++ b/redisson/src/main/java/org/redisson/client/protocol/decoder/GcraResultDecoder.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2013-2026 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.client.protocol.decoder;
+
+import org.redisson.api.GcraResult;
+import org.redisson.client.handler.State;
+
+import java.util.List;
+
+/**
+ *
+ * @author Su Ko
+ *
+ */
+public class GcraResultDecoder implements MultiDecoder<GcraResult> {
+
+    @Override
+    public GcraResult decode(List<Object> parts, State state) {
+        if (parts == null || parts.size() != 5) {
+            throw new IllegalStateException("Unexpected GCRA response: " + parts);
+        }
+
+        return new GcraResult(toLong(parts.get(0)) == 1,
+                toLong(parts.get(1)),
+                toLong(parts.get(2)),
+                toLong(parts.get(3)),
+                toLong(parts.get(4)));
+    }
+
+    private long toLong(Object value) {
+        if (value instanceof Number) {
+            return ((Number) value).longValue();
+        }
+        return Long.parseLong(value.toString());
+    }
+
+}

--- a/redisson/src/test/java/org/redisson/RedissonGcraTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonGcraTest.java
@@ -1,0 +1,70 @@
+package org.redisson;
+
+import org.junit.jupiter.api.Test;
+import org.redisson.api.GcraResult;
+import org.redisson.api.RGcra;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ *
+ * @author Su Ko
+ *
+ */
+public class RedissonGcraTest extends RedisDockerTest {
+
+    @Test
+    public void testTryAcquire() {
+        RGcra gcra = redisson.getGcra("test");
+
+        GcraResult first = gcra.tryAcquire(2, 4, Duration.ofSeconds(1));
+        GcraResult second = gcra.tryAcquire(2, 4, Duration.ofSeconds(1));
+        GcraResult third = gcra.tryAcquire(2, 4, Duration.ofSeconds(1));
+        GcraResult fourth = gcra.tryAcquire(2, 4, Duration.ofSeconds(1));
+
+        assertThat(first.isLimited()).isFalse();
+        assertThat(second.isLimited()).isFalse();
+        assertThat(third.isLimited()).isFalse();
+        assertThat(fourth.isLimited()).isTrue();
+
+        assertThat(first.getMaxTokens()).isEqualTo(3);
+        assertThat(second.getMaxTokens()).isEqualTo(3);
+        assertThat(third.getMaxTokens()).isEqualTo(3);
+        assertThat(fourth.getMaxTokens()).isEqualTo(3);
+
+        assertThat(first.getRetryAfterSeconds()).isEqualTo(-1);
+        assertThat(fourth.getRetryAfterSeconds()).isGreaterThanOrEqualTo(0);
+    }
+
+    @Test
+    public void testTryAcquireWithTokens() {
+        RGcra gcra = redisson.getGcra("test");
+
+        GcraResult result = gcra.tryAcquire(2, 4, Duration.ofMillis(250), 2);
+
+        assertThat(result.isLimited()).isFalse();
+        assertThat(result.getMaxTokens()).isEqualTo(3);
+        assertThat(result.getRetryAfterSeconds()).isEqualTo(-1);
+    }
+
+    @Test
+    public void testValidation() {
+        RGcra gcra = redisson.getGcra("test");
+
+        assertThatThrownBy(() -> gcra.tryAcquire(-1, 1, Duration.ofSeconds(1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("maxBurst");
+        assertThatThrownBy(() -> gcra.tryAcquire(1, 0, Duration.ofSeconds(1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("tokensPerPeriod");
+        assertThatThrownBy(() -> gcra.tryAcquire(1, 1, Duration.ZERO))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("period");
+        assertThatThrownBy(() -> gcra.tryAcquire(1, 1, Duration.ofSeconds(1), 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("tokens");
+    }
+}


### PR DESCRIPTION
 Adds support for Redis 8.8 GCRA rate limiter via the new `RGcra` 

~~This PR remains a draft for now
I will run the integration tests against the official Redis 8.8 release image and mark it ready afterward.~~

Passed test with 8.8-m03 image

issue : #7058 