### PR TITLE
feat(RDeque): support DequeAddFirstListener

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonDeque.java
+++ b/redisson/src/main/java/org/redisson/RedissonDeque.java
@@ -27,10 +27,8 @@ import org.redisson.client.protocol.RedisCommand;
 import org.redisson.client.protocol.RedisCommands;
 import org.redisson.client.protocol.decoder.ListFirstObjectDecoder;
 import org.redisson.command.CommandAsyncExecutor;
-import org.redisson.misc.CompletableFutureWrapper;
 
 import java.util.*;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Distributed and concurrent implementation of {@link java.util.Queue}

--- a/redisson/src/main/java/org/redisson/RedissonDeque.java
+++ b/redisson/src/main/java/org/redisson/RedissonDeque.java
@@ -27,8 +27,10 @@ import org.redisson.client.protocol.RedisCommand;
 import org.redisson.client.protocol.RedisCommands;
 import org.redisson.client.protocol.decoder.ListFirstObjectDecoder;
 import org.redisson.command.CommandAsyncExecutor;
+import org.redisson.misc.CompletableFutureWrapper;
 
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Distributed and concurrent implementation of {@link java.util.Queue}
@@ -76,10 +78,7 @@ public class RedissonDeque<V> extends RedissonQueue<V> implements RDeque<V> {
 
     @Override
     public RFuture<Void> removeListenerAsync(int listenerId) {
-        RFuture<Void> f1 = removeListenerAsync(listenerId, "__keyevent@*:lpush");
-        RFuture<Void> f2 = super.removeListenerAsync(listenerId);
-        return new org.redisson.misc.CompletableFutureWrapper<>(
-                java.util.concurrent.CompletableFuture.allOf(f1.toCompletableFuture(), f2.toCompletableFuture()));
+        return removeListenerAsync(super.removeListenerAsync(listenerId), listenerId, "__keyevent@*:lpush");
     }
 
     @Override

--- a/redisson/src/main/java/org/redisson/RedissonDeque.java
+++ b/redisson/src/main/java/org/redisson/RedissonDeque.java
@@ -17,7 +17,9 @@ package org.redisson;
 
 import org.redisson.api.RDeque;
 import org.redisson.api.RFuture;
+import org.redisson.api.ObjectListener;
 import org.redisson.api.RedissonClient;
+import org.redisson.api.listener.DequeAddFirstListener;
 import org.redisson.api.queue.DequeMoveArgs;
 import org.redisson.api.queue.DequeMoveParams;
 import org.redisson.client.codec.Codec;
@@ -46,6 +48,38 @@ public class RedissonDeque<V> extends RedissonQueue<V> implements RDeque<V> {
 
     public RedissonDeque(Codec codec, CommandAsyncExecutor commandExecutor, String name, RedissonClient redisson) {
         super(codec, commandExecutor, name, redisson);
+    }
+
+    @Override
+    public int addListener(ObjectListener listener) {
+        if (listener instanceof DequeAddFirstListener) {
+            return addListener("__keyevent@*:lpush", (DequeAddFirstListener) listener, DequeAddFirstListener::onAddFirst);
+        }
+
+        return super.addListener(listener);
+    }
+
+    @Override
+    public RFuture<Integer> addListenerAsync(ObjectListener listener) {
+        if (listener instanceof DequeAddFirstListener) {
+            return addListenerAsync("__keyevent@*:lpush", (DequeAddFirstListener) listener, DequeAddFirstListener::onAddFirst);
+        }
+
+        return super.addListenerAsync(listener);
+    }
+
+    @Override
+    public void removeListener(int listenerId) {
+        removeListener(listenerId, "__keyevent@*:lpush");
+        super.removeListener(listenerId);
+    }
+
+    @Override
+    public RFuture<Void> removeListenerAsync(int listenerId) {
+        RFuture<Void> f1 = removeListenerAsync(listenerId, "__keyevent@*:lpush");
+        RFuture<Void> f2 = super.removeListenerAsync(listenerId);
+        return new org.redisson.misc.CompletableFutureWrapper<>(
+                java.util.concurrent.CompletableFuture.allOf(f1.toCompletableFuture(), f2.toCompletableFuture()));
     }
 
     @Override

--- a/redisson/src/main/java/org/redisson/api/RDeque.java
+++ b/redisson/src/main/java/org/redisson/api/RDeque.java
@@ -102,10 +102,13 @@ public interface RDeque<V> extends Deque<V>, RQueue<V>, RDequeAsync<V> {
      * Adds object event listener
      *
      * @see org.redisson.api.listener.TrackingListener
-     * @see org.redisson.api.ExpiredObjectListener
-     * @see org.redisson.api.DeletedObjectListener
      * @see org.redisson.api.listener.ListAddListener
      * @see org.redisson.api.listener.ListRemoveListener
+     * @see org.redisson.api.listener.ListTrimListener
+     * @see org.redisson.api.listener.ListSetListener
+     * @see org.redisson.api.listener.ListInsertListener
+     * @see org.redisson.api.ExpiredObjectListener
+     * @see org.redisson.api.DeletedObjectListener
      * @see org.redisson.api.listener.DequeAddFirstListener
      *
      * @param listener - object event listener

--- a/redisson/src/main/java/org/redisson/api/RDeque.java
+++ b/redisson/src/main/java/org/redisson/api/RDeque.java
@@ -98,4 +98,19 @@ public interface RDeque<V> extends Deque<V>, RQueue<V>, RDequeAsync<V> {
      */
     V move(DequeMoveArgs args);
 
+    /**
+     * Adds object event listener
+     *
+     * @see org.redisson.api.listener.TrackingListener
+     * @see org.redisson.api.ExpiredObjectListener
+     * @see org.redisson.api.DeletedObjectListener
+     * @see org.redisson.api.listener.ListAddListener
+     * @see org.redisson.api.listener.ListRemoveListener
+     * @see org.redisson.api.listener.DequeAddFirstListener
+     *
+     * @param listener - object event listener
+     * @return listener id
+     */
+    int addListener(ObjectListener listener);
+
 }

--- a/redisson/src/main/java/org/redisson/api/RDequeAsync.java
+++ b/redisson/src/main/java/org/redisson/api/RDequeAsync.java
@@ -221,13 +221,13 @@ public interface RDequeAsync<V> extends RQueueAsync<V> {
      * Adds object event listener
      *
      * @see org.redisson.api.listener.TrackingListener
-     * @see org.redisson.api.ExpiredObjectListener
-     * @see org.redisson.api.DeletedObjectListener
      * @see org.redisson.api.listener.ListAddListener
-     * @see org.redisson.api.listener.ListInsertListener
-     * @see org.redisson.api.listener.ListSetListener
      * @see org.redisson.api.listener.ListRemoveListener
      * @see org.redisson.api.listener.ListTrimListener
+     * @see org.redisson.api.listener.ListSetListener
+     * @see org.redisson.api.listener.ListInsertListener
+     * @see org.redisson.api.ExpiredObjectListener
+     * @see org.redisson.api.DeletedObjectListener
      * @see org.redisson.api.listener.DequeAddFirstListener
      *
      * @param listener - object event listener

--- a/redisson/src/main/java/org/redisson/api/RDequeAsync.java
+++ b/redisson/src/main/java/org/redisson/api/RDequeAsync.java
@@ -217,4 +217,22 @@ public interface RDequeAsync<V> extends RQueueAsync<V> {
      */
     RFuture<V> moveAsync(DequeMoveArgs args);
 
+    /**
+     * Adds object event listener
+     *
+     * @see org.redisson.api.listener.TrackingListener
+     * @see org.redisson.api.ExpiredObjectListener
+     * @see org.redisson.api.DeletedObjectListener
+     * @see org.redisson.api.listener.ListAddListener
+     * @see org.redisson.api.listener.ListInsertListener
+     * @see org.redisson.api.listener.ListSetListener
+     * @see org.redisson.api.listener.ListRemoveListener
+     * @see org.redisson.api.listener.ListTrimListener
+     * @see org.redisson.api.listener.DequeAddFirstListener
+     *
+     * @param listener - object event listener
+     * @return listener id
+     */
+    RFuture<Integer> addListenerAsync(ObjectListener listener);
+
 }

--- a/redisson/src/main/java/org/redisson/api/RQueue.java
+++ b/redisson/src/main/java/org/redisson/api/RQueue.java
@@ -55,10 +55,13 @@ public interface RQueue<V> extends Queue<V>, RExpirable, RQueueAsync<V> {
      * Adds object event listener
      *
      * @see org.redisson.api.listener.TrackingListener
-     * @see org.redisson.api.ExpiredObjectListener
-     * @see org.redisson.api.DeletedObjectListener
      * @see org.redisson.api.listener.ListAddListener
      * @see org.redisson.api.listener.ListRemoveListener
+     * @see org.redisson.api.listener.ListTrimListener
+     * @see org.redisson.api.listener.ListSetListener
+     * @see org.redisson.api.listener.ListInsertListener
+     * @see org.redisson.api.ExpiredObjectListener
+     * @see org.redisson.api.DeletedObjectListener
      *
      * @param listener - object event listener
      * @return listener id

--- a/redisson/src/main/java/org/redisson/api/RQueueAsync.java
+++ b/redisson/src/main/java/org/redisson/api/RQueueAsync.java
@@ -79,13 +79,13 @@ public interface RQueueAsync<V> extends RCollectionAsync<V> {
      * Adds object event listener
      *
      * @see org.redisson.api.listener.TrackingListener
-     * @see org.redisson.api.ExpiredObjectListener
-     * @see org.redisson.api.DeletedObjectListener
      * @see org.redisson.api.listener.ListAddListener
-     * @see org.redisson.api.listener.ListInsertListener
-     * @see org.redisson.api.listener.ListSetListener
      * @see org.redisson.api.listener.ListRemoveListener
      * @see org.redisson.api.listener.ListTrimListener
+     * @see org.redisson.api.listener.ListSetListener
+     * @see org.redisson.api.listener.ListInsertListener
+     * @see org.redisson.api.ExpiredObjectListener
+     * @see org.redisson.api.DeletedObjectListener
      *
      * @param listener - object event listener
      * @return listener id

--- a/redisson/src/main/java/org/redisson/api/listener/DequeAddFirstListener.java
+++ b/redisson/src/main/java/org/redisson/api/listener/DequeAddFirstListener.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2013-2026 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.api.listener;
+
+import org.redisson.api.ObjectListener;
+
+/**
+ * Redisson Object Event listener for <b>lpush</b> event published by Redis.
+ * <p>
+ * Redis notify-keyspace-events setting should contain El letters
+ *
+ * @author nhancdt
+ */
+@FunctionalInterface
+public interface DequeAddFirstListener extends ObjectListener {
+
+    /**
+     * Invoked when elements added to deque head
+     *
+     * @param name object name
+     */
+    void onAddFirst(String name);
+
+}
+

--- a/redisson/src/main/java/org/redisson/api/listener/DequeAddFirstListener.java
+++ b/redisson/src/main/java/org/redisson/api/listener/DequeAddFirstListener.java
@@ -18,7 +18,7 @@ package org.redisson.api.listener;
 import org.redisson.api.ObjectListener;
 
 /**
- * Redisson Object Event listener for <b>lpush</b> event published by Redis.
+ * Redisson Object Event listener for <b>lpush</b> event published by Valkey or Redis.
  * <p>
  * Redis notify-keyspace-events setting should contain El letters
  *

--- a/redisson/src/test/java/org/redisson/RedissonDequeTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonDequeTest.java
@@ -1,14 +1,20 @@
 package org.redisson;
 
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.redisson.api.RDeque;
+import org.redisson.api.listener.DequeAddFirstListener;
+import org.redisson.api.listener.ListAddListener;
 import org.redisson.api.queue.DequeMoveArgs;
 
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Deque;
+import java.time.Duration;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -24,6 +30,57 @@ public class RedissonDequeTest extends RedisDockerTest {
         deque1.addFirstIfExists(4, 5);
 
         assertThat(deque1).containsExactly(5, 4, 1, 2, 3);
+    }
+
+
+    @Test
+    public void testAddListCompatibleListener() {
+        testWithParams(redisson -> {
+            Queue<Integer> nfs = new ConcurrentLinkedQueue<>();
+            RDeque<Integer> deque = redisson.getDeque("testAddListCompatibleListener");
+            deque.add(1);
+
+            int id = deque.addListener((ListAddListener) name -> nfs.add(1));
+
+            deque.addLast(2);
+
+            Awaitility.waitAtMost(Duration.ofSeconds(1))
+                    .untilAsserted(() -> assertThat(nfs).contains(1));
+
+            nfs.clear();
+            deque.removeListener(id);
+            deque.addLast(3);
+
+            Awaitility.await()
+                    .during(Duration.ofMillis(500))
+                    .atMost(Duration.ofSeconds(1))
+                    .until(nfs::isEmpty);
+        }, NOTIFY_KEYSPACE_EVENTS, "El");
+    }
+
+    @Test
+    public void testAddFirstListener() {
+        testWithParams(redisson -> {
+            Queue<Integer> nfs = new ConcurrentLinkedQueue<>();
+            RDeque<Integer> deque = redisson.getDeque("testAddFirstListener");
+            deque.add(1);
+
+            int id = deque.addListener((DequeAddFirstListener) name -> nfs.add(1));
+
+            deque.addFirst(2);
+
+            Awaitility.waitAtMost(Duration.ofSeconds(1))
+                    .untilAsserted(() -> assertThat(nfs).contains(1));
+
+            nfs.clear();
+            deque.removeListener(id);
+            deque.addFirst(3);
+
+            Awaitility.await()
+                    .during(Duration.ofMillis(500))
+                    .atMost(Duration.ofSeconds(1))
+                    .until(nfs::isEmpty);
+        }, NOTIFY_KEYSPACE_EVENTS, "El");
     }
 
     @Test


### PR DESCRIPTION
Fix #7082

# Changes
- Added `addListener` and `addListenerAsync` overridden method to `RDeque` with `@see org.redisson.api.listener.DequeAddFirstListener`
- Overrode `addListener`, `addListenerAsync`, `removeListener` and `removeListenerAsync` implementations. Call super() versions if none Deque-like listener matches.
 