### PR TITLE
Fix findIds() crash caused by shared Convertor state leaking across iterators

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonLiveObjectService.java
+++ b/redisson/src/main/java/org/redisson/RedissonLiveObjectService.java
@@ -32,13 +32,7 @@ import org.redisson.api.*;
 import org.redisson.api.annotation.*;
 import org.redisson.api.condition.Condition;
 import org.redisson.client.codec.StringCodec;
-import org.redisson.client.protocol.RedisCommand;
 import org.redisson.client.protocol.RedisCommands;
-import org.redisson.client.protocol.convertor.Convertor;
-import org.redisson.client.protocol.decoder.ListMultiDecoder2;
-import org.redisson.client.protocol.decoder.ListScanResult;
-import org.redisson.client.protocol.decoder.ListScanResultReplayDecoder;
-import org.redisson.client.protocol.decoder.ObjectListReplayDecoder;
 import org.redisson.command.CommandAsyncExecutor;
 import org.redisson.command.CommandBatchService;
 import org.redisson.liveobject.LiveObjectSearch;
@@ -759,21 +753,11 @@ public class RedissonLiveObjectService implements RLiveObjectService {
         NamingScheme namingScheme = commandExecutor.getObjectBuilder().getNamingScheme(entityClass);
         String pattern = namingScheme.getNamePattern(entityClass);
         RedissonKeys keys = new RedissonKeys(commandExecutor);
-
-        RedisCommand<ListScanResult<String>> command = new RedisCommand<>("SCAN",
-                new ListMultiDecoder2(new ListScanResultReplayDecoder(), new ObjectListReplayDecoder<Object>()), new Convertor<Object>() {
-            int index;
-            @Override
-            public Object convert(Object obj) {
-                index++;
-                if (index == 1) {
-                    return obj;
-                }
-                return namingScheme.resolveId(obj.toString());
-            }
-        });
-
-        return keys.getKeysByPattern(command, pattern, 0, count, null);
+        List<K> result = new ArrayList<>();
+        for (String name : keys.getKeysByPattern(pattern, count)) {
+            result.add((K) namingScheme.resolveId(name));
+        }
+        return result;
     }
 
     @Override

--- a/redisson/src/test/java/org/redisson/RedissonLiveObjectServiceTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonLiveObjectServiceTest.java
@@ -1540,6 +1540,24 @@ public class RedissonLiveObjectServiceTest extends RedisDockerTest {
     }
 
     @Test
+    public void testFindIdsPagination() {
+        RLiveObjectService s = redisson.getLiveObjectService();
+        int count = 25;
+        List<TestIndexed1> entities = new ArrayList<>();
+        List<String> expectedIds = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            TestIndexed1 t = new TestIndexed1();
+            t.setId("pg-" + i);
+            entities.add(t);
+            expectedIds.add("pg-" + i);
+        }
+        s.persist(entities.toArray(new TestIndexed1[0]));
+
+        Iterable<String> ids = s.findIds(TestIndexed1.class);
+        assertThat(ids).containsExactlyInAnyOrderElementsOf(expectedIds);
+    }
+
+    @Test
     public void testMergeList2() {
         RLiveObjectService s = redisson.getLiveObjectService();
         TestIndexed1 t1 = new TestIndexed1();


### PR DESCRIPTION
Fixed #7102 