### PR TITLE
refactor: remove unnecessary boxing of primitives

### DIFF
--- a/redisson-hibernate/redisson-hibernate-4/src/main/java/org/redisson/hibernate/RedissonRegionFactory.java
+++ b/redisson-hibernate/redisson-hibernate-4/src/main/java/org/redisson/hibernate/RedissonRegionFactory.java
@@ -82,7 +82,7 @@ public class RedissonRegionFactory implements RegionFactory {
         this.settings = settings;
 
         String fallbackValue = (String) properties.getOrDefault(FALLBACK, "false");
-        fallback = Boolean.valueOf(fallbackValue);
+        fallback = Boolean.parseBoolean(fallbackValue);
     }
 
     protected RedissonClient createRedissonClient(Properties properties) {

--- a/redisson-hibernate/redisson-hibernate-4/src/main/java/org/redisson/hibernate/region/BaseRegion.java
+++ b/redisson-hibernate/redisson-hibernate-4/src/main/java/org/redisson/hibernate/region/BaseRegion.java
@@ -61,20 +61,20 @@ public class BaseRegion implements TransactionalDataRegion, GeneralDataRegion {
         
         String maxEntries = getProperty(properties, mapCache.getName(), defaultKey, RedissonRegionFactory.MAX_ENTRIES_SUFFIX);
         if (maxEntries != null) {
-            size = Integer.valueOf(maxEntries);
+            size = Integer.parseInt(maxEntries);
             mapCache.setMaxSize(size);
         }
         String timeToLive = getProperty(properties, mapCache.getName(), defaultKey, RedissonRegionFactory.TTL_SUFFIX);
         if (timeToLive != null) {
-            ttl = Integer.valueOf(timeToLive);
+            ttl = Integer.parseInt(timeToLive);
         }
         String maxIdleTime = getProperty(properties, mapCache.getName(), defaultKey, RedissonRegionFactory.MAX_IDLE_SUFFIX);
         if (maxIdleTime != null) {
-            maxIdle = Integer.valueOf(maxIdleTime);
+            maxIdle = Integer.parseInt(maxIdleTime);
         }
 
         String fallbackValue = (String) properties.getOrDefault(RedissonRegionFactory.FALLBACK, "false");
-        fallback = Boolean.valueOf(fallbackValue);
+        fallback = Boolean.parseBoolean(fallbackValue);
     }
 
     private String getProperty(Properties properties, String name, String defaultKey, String suffix) {

--- a/redisson-hibernate/redisson-hibernate-5/src/main/java/org/redisson/hibernate/RedissonRegionFactory.java
+++ b/redisson-hibernate/redisson-hibernate-5/src/main/java/org/redisson/hibernate/RedissonRegionFactory.java
@@ -89,7 +89,7 @@ import java.util.concurrent.atomic.AtomicLong;
                                 properties.get(Environment.CACHE_KEYS_FACTORY), new RedissonCacheKeysFactory(redisson.getConfig().getCodec()));
 
         String fallbackValue = (String) properties.getOrDefault(FALLBACK, "false");
-        fallback = Boolean.valueOf(fallbackValue);
+        fallback = Boolean.parseBoolean(fallbackValue);
     }
     
     protected RedissonClient createRedissonClient(Properties properties) {

--- a/redisson-hibernate/redisson-hibernate-5/src/main/java/org/redisson/hibernate/region/BaseRegion.java
+++ b/redisson-hibernate/redisson-hibernate-5/src/main/java/org/redisson/hibernate/region/BaseRegion.java
@@ -62,20 +62,20 @@ public class BaseRegion implements TransactionalDataRegion, GeneralDataRegion {
         
         String maxEntries = getProperty(properties, mapCache.getName(), defaultKey, RedissonRegionFactory.MAX_ENTRIES_SUFFIX);
         if (maxEntries != null) {
-            size = Integer.valueOf(maxEntries);
+            size = Integer.parseInt(maxEntries);
             mapCache.setMaxSize(size);
         }
         String timeToLive = getProperty(properties, mapCache.getName(), defaultKey, RedissonRegionFactory.TTL_SUFFIX);
         if (timeToLive != null) {
-            ttl = Integer.valueOf(timeToLive);
+            ttl = Integer.parseInt(timeToLive);
         }
         String maxIdleTime = getProperty(properties, mapCache.getName(), defaultKey, RedissonRegionFactory.MAX_IDLE_SUFFIX);
         if (maxIdleTime != null) {
-            maxIdle = Integer.valueOf(maxIdleTime);
+            maxIdle = Integer.parseInt(maxIdleTime);
         }
 
         String fallbackValue = (String) properties.getOrDefault(RedissonRegionFactory.FALLBACK, "false");
-        fallback = Boolean.valueOf(fallbackValue);
+        fallback = Boolean.parseBoolean(fallbackValue);
     }
 
     private String getProperty(Properties properties, String name, String defaultKey, String suffix) {

--- a/redisson-hibernate/redisson-hibernate-52/src/main/java/org/redisson/hibernate/RedissonRegionFactory.java
+++ b/redisson-hibernate/redisson-hibernate-52/src/main/java/org/redisson/hibernate/RedissonRegionFactory.java
@@ -90,7 +90,7 @@ public class RedissonRegionFactory implements RegionFactory {
                                 properties.get(Environment.CACHE_KEYS_FACTORY), new RedissonCacheKeysFactory(redisson.getConfig().getCodec()));
 
         String fallbackValue = (String) properties.getOrDefault(FALLBACK, "false");
-        fallback = Boolean.valueOf(fallbackValue);
+        fallback = Boolean.parseBoolean(fallbackValue);
     }
 
     protected RedissonClient createRedissonClient(Properties properties) {

--- a/redisson-hibernate/redisson-hibernate-52/src/main/java/org/redisson/hibernate/region/BaseRegion.java
+++ b/redisson-hibernate/redisson-hibernate-52/src/main/java/org/redisson/hibernate/region/BaseRegion.java
@@ -62,20 +62,20 @@ public class BaseRegion implements TransactionalDataRegion, GeneralDataRegion {
         
         String maxEntries = getProperty(properties, mapCache.getName(), defaultKey, RedissonRegionFactory.MAX_ENTRIES_SUFFIX);
         if (maxEntries != null) {
-            size = Integer.valueOf(maxEntries);
+            size = Integer.parseInt(maxEntries);
             mapCache.setMaxSize(size);
         }
         String timeToLive = getProperty(properties, mapCache.getName(), defaultKey, RedissonRegionFactory.TTL_SUFFIX);
         if (timeToLive != null) {
-            ttl = Integer.valueOf(timeToLive);
+            ttl = Integer.parseInt(timeToLive);
         }
         String maxIdleTime = getProperty(properties, mapCache.getName(), defaultKey, RedissonRegionFactory.MAX_IDLE_SUFFIX);
         if (maxIdleTime != null) {
-            maxIdle = Integer.valueOf(maxIdleTime);
+            maxIdle = Integer.parseInt(maxIdleTime);
         }
 
         String fallbackValue = (String) properties.getOrDefault(RedissonRegionFactory.FALLBACK, "false");
-        fallback = Boolean.valueOf(fallbackValue);
+        fallback = Boolean.parseBoolean(fallbackValue);
     }
 
     private String getProperty(Properties properties, String name, String defaultKey, String suffix) {

--- a/redisson-hibernate/redisson-hibernate-53/src/main/java/org/redisson/hibernate/RedissonRegionFactory.java
+++ b/redisson-hibernate/redisson-hibernate-53/src/main/java/org/redisson/hibernate/RedissonRegionFactory.java
@@ -86,7 +86,7 @@ public class RedissonRegionFactory extends RegionFactoryTemplate {
         this.redisson = createRedissonClient(properties);
 
         String fallbackValue = (String) properties.getOrDefault(FALLBACK, "false");
-        fallback = Boolean.valueOf(fallbackValue);
+        fallback = Boolean.parseBoolean(fallbackValue);
 
         StrategySelector selector = settings.getServiceRegistry().getService(StrategySelector.class);
         cacheKeysFactory = selector.resolveDefaultableStrategy(CacheKeysFactory.class, 

--- a/redisson-hibernate/redisson-hibernate-53/src/main/java/org/redisson/hibernate/RedissonStorage.java
+++ b/redisson-hibernate/redisson-hibernate-53/src/main/java/org/redisson/hibernate/RedissonStorage.java
@@ -54,20 +54,20 @@ public class RedissonStorage implements DomainDataStorageAccess {
         
         String maxEntries = getProperty(properties, mapCache.getName(), regionName, defaultKey, RedissonRegionFactory.MAX_ENTRIES_SUFFIX);
         if (maxEntries != null) {
-            size = Integer.valueOf(maxEntries);
+            size = Integer.parseInt(maxEntries);
             mapCache.setMaxSize(size);
         }
         String timeToLive = getProperty(properties, mapCache.getName(), regionName, defaultKey, RedissonRegionFactory.TTL_SUFFIX);
         if (timeToLive != null) {
-            ttl = Integer.valueOf(timeToLive);
+            ttl = Integer.parseInt(timeToLive);
         }
         String maxIdleTime = getProperty(properties, mapCache.getName(), regionName, defaultKey, RedissonRegionFactory.MAX_IDLE_SUFFIX);
         if (maxIdleTime != null) {
-            maxIdle = Integer.valueOf(maxIdleTime);
+            maxIdle = Integer.parseInt(maxIdleTime);
         }
 
         String fallbackValue = (String) properties.getOrDefault(RedissonRegionFactory.FALLBACK, "false");
-        fallback = Boolean.valueOf(fallbackValue);
+        fallback = Boolean.parseBoolean(fallbackValue);
     }
 
     private String getProperty(Map<String, Object> properties, String name, String regionName, String defaultKey, String suffix) {

--- a/redisson-hibernate/redisson-hibernate-6/src/main/java/org/redisson/hibernate/RedissonRegionFactory.java
+++ b/redisson-hibernate/redisson-hibernate-6/src/main/java/org/redisson/hibernate/RedissonRegionFactory.java
@@ -88,7 +88,7 @@ public class RedissonRegionFactory extends RegionFactoryTemplate {
         this.redisson = createRedissonClient(settings.getServiceRegistry(), properties);
 
         String fallbackValue = (String) properties.getOrDefault(FALLBACK, "false");
-        fallback = Boolean.valueOf(fallbackValue);
+        fallback = Boolean.parseBoolean(fallbackValue);
 
         StrategySelector selector = settings.getServiceRegistry().getService(StrategySelector.class);
         cacheKeysFactory = selector.resolveDefaultableStrategy(CacheKeysFactory.class, 

--- a/redisson-hibernate/redisson-hibernate-6/src/main/java/org/redisson/hibernate/RedissonStorage.java
+++ b/redisson-hibernate/redisson-hibernate-6/src/main/java/org/redisson/hibernate/RedissonStorage.java
@@ -53,20 +53,20 @@ public class RedissonStorage implements DomainDataStorageAccess {
         
         String maxEntries = getProperty(properties, mapCache.getName(), regionName, defaultKey, RedissonRegionFactory.MAX_ENTRIES_SUFFIX);
         if (maxEntries != null) {
-            size = Integer.valueOf(maxEntries);
+            size = Integer.parseInt(maxEntries);
             mapCache.setMaxSize(size);
         }
         String timeToLive = getProperty(properties, mapCache.getName(), regionName, defaultKey, RedissonRegionFactory.TTL_SUFFIX);
         if (timeToLive != null) {
-            ttl = Integer.valueOf(timeToLive);
+            ttl = Integer.parseInt(timeToLive);
         }
         String maxIdleTime = getProperty(properties, mapCache.getName(), regionName, defaultKey, RedissonRegionFactory.MAX_IDLE_SUFFIX);
         if (maxIdleTime != null) {
-            maxIdle = Integer.valueOf(maxIdleTime);
+            maxIdle = Integer.parseInt(maxIdleTime);
         }
 
         String fallbackValue = (String) properties.getOrDefault(RedissonRegionFactory.FALLBACK, "false");
-        fallback = Boolean.valueOf(fallbackValue);
+        fallback = Boolean.parseBoolean(fallbackValue);
     }
 
     private String getProperty(Map<String, Object> properties, String name, String regionName, String defaultKey, String suffix) {

--- a/redisson-hibernate/redisson-hibernate-7/src/main/java/org/redisson/hibernate/RedissonRegionFactory.java
+++ b/redisson-hibernate/redisson-hibernate-7/src/main/java/org/redisson/hibernate/RedissonRegionFactory.java
@@ -87,7 +87,7 @@ public class RedissonRegionFactory extends RegionFactoryTemplate {
         this.redisson = createRedissonClient(settings.getServiceRegistry(), properties);
 
         String fallbackValue = (String) properties.getOrDefault(FALLBACK, "false");
-        fallback = Boolean.valueOf(fallbackValue);
+        fallback = Boolean.parseBoolean(fallbackValue);
 
         StrategySelector selector = settings.getServiceRegistry().getService(StrategySelector.class);
         cacheKeysFactory = selector.resolveDefaultableStrategy(CacheKeysFactory.class, 

--- a/redisson-hibernate/redisson-hibernate-7/src/main/java/org/redisson/hibernate/RedissonStorage.java
+++ b/redisson-hibernate/redisson-hibernate-7/src/main/java/org/redisson/hibernate/RedissonStorage.java
@@ -53,20 +53,20 @@ public class RedissonStorage implements DomainDataStorageAccess {
         
         String maxEntries = getProperty(properties, mapCache.getName(), regionName, defaultKey, RedissonRegionFactory.MAX_ENTRIES_SUFFIX);
         if (maxEntries != null) {
-            size = Integer.valueOf(maxEntries);
+            size = Integer.parseInt(maxEntries);
             mapCache.setMaxSize(size);
         }
         String timeToLive = getProperty(properties, mapCache.getName(), regionName, defaultKey, RedissonRegionFactory.TTL_SUFFIX);
         if (timeToLive != null) {
-            ttl = Integer.valueOf(timeToLive);
+            ttl = Integer.parseInt(timeToLive);
         }
         String maxIdleTime = getProperty(properties, mapCache.getName(), regionName, defaultKey, RedissonRegionFactory.MAX_IDLE_SUFFIX);
         if (maxIdleTime != null) {
-            maxIdle = Integer.valueOf(maxIdleTime);
+            maxIdle = Integer.parseInt(maxIdleTime);
         }
 
         String fallbackValue = (String) properties.getOrDefault(RedissonRegionFactory.FALLBACK, "false");
-        fallback = Boolean.valueOf(fallbackValue);
+        fallback = Boolean.parseBoolean(fallbackValue);
     }
 
     private String getProperty(Map<String, Object> properties, String name, String regionName, String defaultKey, String suffix) {

--- a/redisson-hibernate/redisson-hibernate-72/src/main/java/org/redisson/hibernate/RedissonRegionFactory.java
+++ b/redisson-hibernate/redisson-hibernate-72/src/main/java/org/redisson/hibernate/RedissonRegionFactory.java
@@ -87,7 +87,7 @@ public class RedissonRegionFactory extends RegionFactoryTemplate {
         this.redisson = createRedissonClient(settings.getServiceRegistry(), properties);
 
         String fallbackValue = (String) properties.getOrDefault(FALLBACK, "false");
-        fallback = Boolean.valueOf(fallbackValue);
+        fallback = Boolean.parseBoolean(fallbackValue);
 
         StrategySelector selector = settings.getServiceRegistry().getService(StrategySelector.class);
         cacheKeysFactory = selector.resolveDefaultableStrategy(CacheKeysFactory.class, 

--- a/redisson-hibernate/redisson-hibernate-72/src/main/java/org/redisson/hibernate/RedissonStorage.java
+++ b/redisson-hibernate/redisson-hibernate-72/src/main/java/org/redisson/hibernate/RedissonStorage.java
@@ -53,20 +53,20 @@ public class RedissonStorage implements DomainDataStorageAccess {
         
         String maxEntries = getProperty(properties, mapCache.getName(), regionName, defaultKey, RedissonRegionFactory.MAX_ENTRIES_SUFFIX);
         if (maxEntries != null) {
-            size = Integer.valueOf(maxEntries);
+            size = Integer.parseInt(maxEntries);
             mapCache.setMaxSize(size);
         }
         String timeToLive = getProperty(properties, mapCache.getName(), regionName, defaultKey, RedissonRegionFactory.TTL_SUFFIX);
         if (timeToLive != null) {
-            ttl = Integer.valueOf(timeToLive);
+            ttl = Integer.parseInt(timeToLive);
         }
         String maxIdleTime = getProperty(properties, mapCache.getName(), regionName, defaultKey, RedissonRegionFactory.MAX_IDLE_SUFFIX);
         if (maxIdleTime != null) {
-            maxIdle = Integer.valueOf(maxIdleTime);
+            maxIdle = Integer.parseInt(maxIdleTime);
         }
 
         String fallbackValue = (String) properties.getOrDefault(RedissonRegionFactory.FALLBACK, "false");
-        fallback = Boolean.valueOf(fallbackValue);
+        fallback = Boolean.parseBoolean(fallbackValue);
     }
 
     private String getProperty(Map<String, Object> properties, String name, String regionName, String defaultKey, String suffix) {

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-16/src/test/java/org/redisson/RedisDockerTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-16/src/test/java/org/redisson/RedisDockerTest.java
@@ -402,7 +402,7 @@ public class RedisDockerTest {
 
                         if (mappedPort != null
                                 && s.getIpAddress().equals(uri.getHost())) {
-                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.valueOf(mappedPort[0].getHostPortSpec()));
+                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.parseInt(mappedPort[0].getHostPortSpec()));
                         }
                     }
                     return uri;

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-17/src/main/java/org/redisson/spring/data/connection/RedisClusterNodeDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-17/src/main/java/org/redisson/spring/data/connection/RedisClusterNodeDecoder.java
@@ -95,7 +95,7 @@ public class RedisClusterNodeDecoder implements Decoder<List<RedisClusterNode>> 
                     if(parts.length == 1) {
                         slotsCollection.add(Integer.valueOf(parts[0]));
                     } else if(parts.length == 2) {
-                        for (int j = Integer.valueOf(parts[0]); j < Integer.valueOf(parts[1]) + 1; j++) {
+                        for (int j = Integer.parseInt(parts[0]); j < Integer.parseInt(parts[1]) + 1; j++) {
                             slotsCollection.add(j);
                         }
                     }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-17/src/test/java/org/redisson/RedisDockerTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-17/src/test/java/org/redisson/RedisDockerTest.java
@@ -413,7 +413,7 @@ public class RedisDockerTest {
 
                         if (mappedPort != null
                                 && s.getIpAddress().equals(uri.getHost())) {
-                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.valueOf(mappedPort[0].getHostPortSpec()));
+                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.parseInt(mappedPort[0].getHostPortSpec()));
                         }
                     }
                     return uri;

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-18/src/main/java/org/redisson/spring/data/connection/RedisClusterNodeDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-18/src/main/java/org/redisson/spring/data/connection/RedisClusterNodeDecoder.java
@@ -95,7 +95,7 @@ public class RedisClusterNodeDecoder implements Decoder<List<RedisClusterNode>> 
                     if(parts.length == 1) {
                         slotsCollection.add(Integer.valueOf(parts[0]));
                     } else if(parts.length == 2) {
-                        for (int j = Integer.valueOf(parts[0]); j < Integer.valueOf(parts[1]) + 1; j++) {
+                        for (int j = Integer.parseInt(parts[0]); j < Integer.parseInt(parts[1]) + 1; j++) {
                             slotsCollection.add(j);
                         }
                     }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-18/src/test/java/org/redisson/RedisDockerTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-18/src/test/java/org/redisson/RedisDockerTest.java
@@ -413,7 +413,7 @@ public class RedisDockerTest {
 
                         if (mappedPort != null
                                 && s.getIpAddress().equals(uri.getHost())) {
-                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.valueOf(mappedPort[0].getHostPortSpec()));
+                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.parseInt(mappedPort[0].getHostPortSpec()));
                         }
                     }
                     return uri;

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-20/src/main/java/org/redisson/spring/data/connection/RedisClusterNodeDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-20/src/main/java/org/redisson/spring/data/connection/RedisClusterNodeDecoder.java
@@ -95,7 +95,7 @@ public class RedisClusterNodeDecoder implements Decoder<List<RedisClusterNode>> 
                     if(parts.length == 1) {
                         slotsCollection.add(Integer.valueOf(parts[0]));
                     } else if(parts.length == 2) {
-                        for (int j = Integer.valueOf(parts[0]); j < Integer.valueOf(parts[1]) + 1; j++) {
+                        for (int j = Integer.parseInt(parts[0]); j < Integer.parseInt(parts[1]) + 1; j++) {
                             slotsCollection.add(j);
                         }
                     }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-20/src/test/java/org/redisson/RedisDockerTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-20/src/test/java/org/redisson/RedisDockerTest.java
@@ -413,7 +413,7 @@ public class RedisDockerTest {
 
                         if (mappedPort != null
                                 && s.getIpAddress().equals(uri.getHost())) {
-                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.valueOf(mappedPort[0].getHostPortSpec()));
+                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.parseInt(mappedPort[0].getHostPortSpec()));
                         }
                     }
                     return uri;

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-21/src/main/java/org/redisson/spring/data/connection/RedisClusterNodeDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-21/src/main/java/org/redisson/spring/data/connection/RedisClusterNodeDecoder.java
@@ -95,7 +95,7 @@ public class RedisClusterNodeDecoder implements Decoder<List<RedisClusterNode>> 
                     if(parts.length == 1) {
                         slotsCollection.add(Integer.valueOf(parts[0]));
                     } else if(parts.length == 2) {
-                        for (int j = Integer.valueOf(parts[0]); j < Integer.valueOf(parts[1]) + 1; j++) {
+                        for (int j = Integer.parseInt(parts[0]); j < Integer.parseInt(parts[1]) + 1; j++) {
                             slotsCollection.add(j);
                         }
                     }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-21/src/test/java/org/redisson/RedisDockerTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-21/src/test/java/org/redisson/RedisDockerTest.java
@@ -413,7 +413,7 @@ public class RedisDockerTest {
 
                         if (mappedPort != null
                                 && s.getIpAddress().equals(uri.getHost())) {
-                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.valueOf(mappedPort[0].getHostPortSpec()));
+                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.parseInt(mappedPort[0].getHostPortSpec()));
                         }
                     }
                     return uri;

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-22/src/main/java/org/redisson/spring/data/connection/RedisClusterNodeDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-22/src/main/java/org/redisson/spring/data/connection/RedisClusterNodeDecoder.java
@@ -95,7 +95,7 @@ public class RedisClusterNodeDecoder implements Decoder<List<RedisClusterNode>> 
                     if(parts.length == 1) {
                         slotsCollection.add(Integer.valueOf(parts[0]));
                     } else if(parts.length == 2) {
-                        for (int j = Integer.valueOf(parts[0]); j < Integer.valueOf(parts[1]) + 1; j++) {
+                        for (int j = Integer.parseInt(parts[0]); j < Integer.parseInt(parts[1]) + 1; j++) {
                             slotsCollection.add(j);
                         }
                     }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-22/src/test/java/org/redisson/RedisDockerTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-22/src/test/java/org/redisson/RedisDockerTest.java
@@ -413,7 +413,7 @@ public class RedisDockerTest {
 
                         if (mappedPort != null
                                 && s.getIpAddress().equals(uri.getHost())) {
-                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.valueOf(mappedPort[0].getHostPortSpec()));
+                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.parseInt(mappedPort[0].getHostPortSpec()));
                         }
                     }
                     return uri;

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-23/src/main/java/org/redisson/spring/data/connection/RedisClusterNodeDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-23/src/main/java/org/redisson/spring/data/connection/RedisClusterNodeDecoder.java
@@ -95,7 +95,7 @@ public class RedisClusterNodeDecoder implements Decoder<List<RedisClusterNode>> 
                     if(parts.length == 1) {
                         slotsCollection.add(Integer.valueOf(parts[0]));
                     } else if(parts.length == 2) {
-                        for (int j = Integer.valueOf(parts[0]); j < Integer.valueOf(parts[1]) + 1; j++) {
+                        for (int j = Integer.parseInt(parts[0]); j < Integer.parseInt(parts[1]) + 1; j++) {
                             slotsCollection.add(j);
                         }
                     }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-23/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-23/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
@@ -281,8 +281,8 @@ public class RedissonStreamCommands implements RedisStreamCommands {
         public PendingMessage decode(List<Object> parts, State state) {
             PendingMessage pm = new PendingMessage(RecordId.of(parts.get(0).toString()),
                     Consumer.from(groupName, parts.get(1).toString()),
-                    Duration.of(Long.valueOf(parts.get(2).toString()), ChronoUnit.MILLIS),
-                    Long.valueOf(parts.get(3).toString()));
+                    Duration.of(Long.parseLong(parts.get(2).toString()), ChronoUnit.MILLIS),
+                    Long.parseLong(parts.get(3).toString()));
             return pm;
         }
     }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-23/src/test/java/org/redisson/RedisDockerTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-23/src/test/java/org/redisson/RedisDockerTest.java
@@ -413,7 +413,7 @@ public class RedisDockerTest {
 
                         if (mappedPort != null
                                 && s.getIpAddress().equals(uri.getHost())) {
-                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.valueOf(mappedPort[0].getHostPortSpec()));
+                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.parseInt(mappedPort[0].getHostPortSpec()));
                         }
                     }
                     return uri;

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-24/src/main/java/org/redisson/spring/data/connection/RedisClusterNodeDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-24/src/main/java/org/redisson/spring/data/connection/RedisClusterNodeDecoder.java
@@ -95,7 +95,7 @@ public class RedisClusterNodeDecoder implements Decoder<List<RedisClusterNode>> 
                     if(parts.length == 1) {
                         slotsCollection.add(Integer.valueOf(parts[0]));
                     } else if(parts.length == 2) {
-                        for (int j = Integer.valueOf(parts[0]); j < Integer.valueOf(parts[1]) + 1; j++) {
+                        for (int j = Integer.parseInt(parts[0]); j < Integer.parseInt(parts[1]) + 1; j++) {
                             slotsCollection.add(j);
                         }
                     }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-24/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-24/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
@@ -281,8 +281,8 @@ public class RedissonStreamCommands implements RedisStreamCommands {
         public PendingMessage decode(List<Object> parts, State state) {
             PendingMessage pm = new PendingMessage(RecordId.of(parts.get(0).toString()),
                     Consumer.from(groupName, parts.get(1).toString()),
-                    Duration.of(Long.valueOf(parts.get(2).toString()), ChronoUnit.MILLIS),
-                    Long.valueOf(parts.get(3).toString()));
+                    Duration.of(Long.parseLong(parts.get(2).toString()), ChronoUnit.MILLIS),
+                    Long.parseLong(parts.get(3).toString()));
             return pm;
         }
     }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-24/src/test/java/org/redisson/RedisDockerTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-24/src/test/java/org/redisson/RedisDockerTest.java
@@ -413,7 +413,7 @@ public class RedisDockerTest {
 
                         if (mappedPort != null
                                 && s.getIpAddress().equals(uri.getHost())) {
-                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.valueOf(mappedPort[0].getHostPortSpec()));
+                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.parseInt(mappedPort[0].getHostPortSpec()));
                         }
                     }
                     return uri;

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-25/src/main/java/org/redisson/spring/data/connection/RedisClusterNodeDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-25/src/main/java/org/redisson/spring/data/connection/RedisClusterNodeDecoder.java
@@ -95,7 +95,7 @@ public class RedisClusterNodeDecoder implements Decoder<List<RedisClusterNode>> 
                     if(parts.length == 1) {
                         slotsCollection.add(Integer.valueOf(parts[0]));
                     } else if(parts.length == 2) {
-                        for (int j = Integer.valueOf(parts[0]); j < Integer.valueOf(parts[1]) + 1; j++) {
+                        for (int j = Integer.parseInt(parts[0]); j < Integer.parseInt(parts[1]) + 1; j++) {
                             slotsCollection.add(j);
                         }
                     }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-25/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-25/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
@@ -281,8 +281,8 @@ public class RedissonStreamCommands implements RedisStreamCommands {
         public PendingMessage decode(List<Object> parts, State state) {
             PendingMessage pm = new PendingMessage(RecordId.of(parts.get(0).toString()),
                     Consumer.from(groupName, parts.get(1).toString()),
-                    Duration.of(Long.valueOf(parts.get(2).toString()), ChronoUnit.MILLIS),
-                    Long.valueOf(parts.get(3).toString()));
+                    Duration.of(Long.parseLong(parts.get(2).toString()), ChronoUnit.MILLIS),
+                    Long.parseLong(parts.get(3).toString()));
             return pm;
         }
     }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-25/src/test/java/org/redisson/RedisDockerTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-25/src/test/java/org/redisson/RedisDockerTest.java
@@ -413,7 +413,7 @@ public class RedisDockerTest {
 
                         if (mappedPort != null
                                 && s.getIpAddress().equals(uri.getHost())) {
-                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.valueOf(mappedPort[0].getHostPortSpec()));
+                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.parseInt(mappedPort[0].getHostPortSpec()));
                         }
                     }
                     return uri;

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-26/src/main/java/org/redisson/spring/data/connection/RedisClusterNodeDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-26/src/main/java/org/redisson/spring/data/connection/RedisClusterNodeDecoder.java
@@ -95,7 +95,7 @@ public class RedisClusterNodeDecoder implements Decoder<List<RedisClusterNode>> 
                     if(parts.length == 1) {
                         slotsCollection.add(Integer.valueOf(parts[0]));
                     } else if(parts.length == 2) {
-                        for (int j = Integer.valueOf(parts[0]); j < Integer.valueOf(parts[1]) + 1; j++) {
+                        for (int j = Integer.parseInt(parts[0]); j < Integer.parseInt(parts[1]) + 1; j++) {
                             slotsCollection.add(j);
                         }
                     }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-26/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-26/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
@@ -281,8 +281,8 @@ public class RedissonStreamCommands implements RedisStreamCommands {
         public PendingMessage decode(List<Object> parts, State state) {
             PendingMessage pm = new PendingMessage(RecordId.of(parts.get(0).toString()),
                     Consumer.from(groupName, parts.get(1).toString()),
-                    Duration.of(Long.valueOf(parts.get(2).toString()), ChronoUnit.MILLIS),
-                    Long.valueOf(parts.get(3).toString()));
+                    Duration.of(Long.parseLong(parts.get(2).toString()), ChronoUnit.MILLIS),
+                    Long.parseLong(parts.get(3).toString()));
             return pm;
         }
     }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-26/src/test/java/org/redisson/RedisDockerTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-26/src/test/java/org/redisson/RedisDockerTest.java
@@ -413,7 +413,7 @@ public class RedisDockerTest {
 
                         if (mappedPort != null
                                 && s.getIpAddress().equals(uri.getHost())) {
-                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.valueOf(mappedPort[0].getHostPortSpec()));
+                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.parseInt(mappedPort[0].getHostPortSpec()));
                         }
                     }
                     return uri;

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-27/src/main/java/org/redisson/spring/data/connection/RedisClusterNodeDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-27/src/main/java/org/redisson/spring/data/connection/RedisClusterNodeDecoder.java
@@ -95,7 +95,7 @@ public class RedisClusterNodeDecoder implements Decoder<List<RedisClusterNode>> 
                     if(parts.length == 1) {
                         slotsCollection.add(Integer.valueOf(parts[0]));
                     } else if(parts.length == 2) {
-                        for (int j = Integer.valueOf(parts[0]); j < Integer.valueOf(parts[1]) + 1; j++) {
+                        for (int j = Integer.parseInt(parts[0]); j < Integer.parseInt(parts[1]) + 1; j++) {
                             slotsCollection.add(j);
                         }
                     }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-27/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-27/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
@@ -281,8 +281,8 @@ public class RedissonStreamCommands implements RedisStreamCommands {
         public PendingMessage decode(List<Object> parts, State state) {
             PendingMessage pm = new PendingMessage(RecordId.of(parts.get(0).toString()),
                     Consumer.from(groupName, parts.get(1).toString()),
-                    Duration.of(Long.valueOf(parts.get(2).toString()), ChronoUnit.MILLIS),
-                    Long.valueOf(parts.get(3).toString()));
+                    Duration.of(Long.parseLong(parts.get(2).toString()), ChronoUnit.MILLIS),
+                    Long.parseLong(parts.get(3).toString()));
             return pm;
         }
     }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-27/src/test/java/org/redisson/RedisDockerTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-27/src/test/java/org/redisson/RedisDockerTest.java
@@ -413,7 +413,7 @@ public class RedisDockerTest {
 
                         if (mappedPort != null
                                 && s.getIpAddress().equals(uri.getHost())) {
-                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.valueOf(mappedPort[0].getHostPortSpec()));
+                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.parseInt(mappedPort[0].getHostPortSpec()));
                         }
                     }
                     return uri;

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-30/src/main/java/org/redisson/spring/data/connection/RedisClusterNodeDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-30/src/main/java/org/redisson/spring/data/connection/RedisClusterNodeDecoder.java
@@ -96,7 +96,7 @@ public class RedisClusterNodeDecoder implements Decoder<List<RedisClusterNode>> 
                     if(parts.length == 1) {
                         slotsCollection.add(Integer.valueOf(parts[0]));
                     } else if(parts.length == 2) {
-                        for (int j = Integer.valueOf(parts[0]); j < Integer.valueOf(parts[1]) + 1; j++) {
+                        for (int j = Integer.parseInt(parts[0]); j < Integer.parseInt(parts[1]) + 1; j++) {
                             slotsCollection.add(j);
                         }
                     }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-30/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-30/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
@@ -281,8 +281,8 @@ public class RedissonStreamCommands implements RedisStreamCommands {
         public PendingMessage decode(List<Object> parts, State state) {
             PendingMessage pm = new PendingMessage(RecordId.of(parts.get(0).toString()),
                     Consumer.from(groupName, parts.get(1).toString()),
-                    Duration.of(Long.valueOf(parts.get(2).toString()), ChronoUnit.MILLIS),
-                    Long.valueOf(parts.get(3).toString()));
+                    Duration.of(Long.parseLong(parts.get(2).toString()), ChronoUnit.MILLIS),
+                    Long.parseLong(parts.get(3).toString()));
             return pm;
         }
     }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-30/src/test/java/org/redisson/RedisDockerTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-30/src/test/java/org/redisson/RedisDockerTest.java
@@ -413,7 +413,7 @@ public class RedisDockerTest {
 
                         if (mappedPort != null
                                 && s.getIpAddress().equals(uri.getHost())) {
-                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.valueOf(mappedPort[0].getHostPortSpec()));
+                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.parseInt(mappedPort[0].getHostPortSpec()));
                         }
                     }
                     return uri;

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-31/src/main/java/org/redisson/spring/data/connection/RedisClusterNodeDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-31/src/main/java/org/redisson/spring/data/connection/RedisClusterNodeDecoder.java
@@ -96,7 +96,7 @@ public class RedisClusterNodeDecoder implements Decoder<List<RedisClusterNode>> 
                     if(parts.length == 1) {
                         slotsCollection.add(Integer.valueOf(parts[0]));
                     } else if(parts.length == 2) {
-                        for (int j = Integer.valueOf(parts[0]); j < Integer.valueOf(parts[1]) + 1; j++) {
+                        for (int j = Integer.parseInt(parts[0]); j < Integer.parseInt(parts[1]) + 1; j++) {
                             slotsCollection.add(j);
                         }
                     }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-31/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-31/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
@@ -281,8 +281,8 @@ public class RedissonStreamCommands implements RedisStreamCommands {
         public PendingMessage decode(List<Object> parts, State state) {
             PendingMessage pm = new PendingMessage(RecordId.of(parts.get(0).toString()),
                     Consumer.from(groupName, parts.get(1).toString()),
-                    Duration.of(Long.valueOf(parts.get(2).toString()), ChronoUnit.MILLIS),
-                    Long.valueOf(parts.get(3).toString()));
+                    Duration.of(Long.parseLong(parts.get(2).toString()), ChronoUnit.MILLIS),
+                    Long.parseLong(parts.get(3).toString()));
             return pm;
         }
     }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-31/src/test/java/org/redisson/RedisDockerTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-31/src/test/java/org/redisson/RedisDockerTest.java
@@ -413,7 +413,7 @@ public class RedisDockerTest {
 
                         if (mappedPort != null
                                 && s.getIpAddress().equals(uri.getHost())) {
-                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.valueOf(mappedPort[0].getHostPortSpec()));
+                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.parseInt(mappedPort[0].getHostPortSpec()));
                         }
                     }
                     return uri;

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-32/src/main/java/org/redisson/spring/data/connection/RedisClusterNodeDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-32/src/main/java/org/redisson/spring/data/connection/RedisClusterNodeDecoder.java
@@ -96,7 +96,7 @@ public class RedisClusterNodeDecoder implements Decoder<List<RedisClusterNode>> 
                     if(parts.length == 1) {
                         slotsCollection.add(Integer.valueOf(parts[0]));
                     } else if(parts.length == 2) {
-                        for (int j = Integer.valueOf(parts[0]); j < Integer.valueOf(parts[1]) + 1; j++) {
+                        for (int j = Integer.parseInt(parts[0]); j < Integer.parseInt(parts[1]) + 1; j++) {
                             slotsCollection.add(j);
                         }
                     }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-32/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-32/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
@@ -281,8 +281,8 @@ public class RedissonStreamCommands implements RedisStreamCommands {
         public PendingMessage decode(List<Object> parts, State state) {
             PendingMessage pm = new PendingMessage(RecordId.of(parts.get(0).toString()),
                     Consumer.from(groupName, parts.get(1).toString()),
-                    Duration.of(Long.valueOf(parts.get(2).toString()), ChronoUnit.MILLIS),
-                    Long.valueOf(parts.get(3).toString()));
+                    Duration.of(Long.parseLong(parts.get(2).toString()), ChronoUnit.MILLIS),
+                    Long.parseLong(parts.get(3).toString()));
             return pm;
         }
     }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-32/src/test/java/org/redisson/RedisDockerTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-32/src/test/java/org/redisson/RedisDockerTest.java
@@ -413,7 +413,7 @@ public class RedisDockerTest {
 
                         if (mappedPort != null
                                 && s.getIpAddress().equals(uri.getHost())) {
-                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.valueOf(mappedPort[0].getHostPortSpec()));
+                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.parseInt(mappedPort[0].getHostPortSpec()));
                         }
                     }
                     return uri;

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-33/src/main/java/org/redisson/spring/data/connection/RedisClusterNodeDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-33/src/main/java/org/redisson/spring/data/connection/RedisClusterNodeDecoder.java
@@ -96,7 +96,7 @@ public class RedisClusterNodeDecoder implements Decoder<List<RedisClusterNode>> 
                     if(parts.length == 1) {
                         slotsCollection.add(Integer.valueOf(parts[0]));
                     } else if(parts.length == 2) {
-                        for (int j = Integer.valueOf(parts[0]); j < Integer.valueOf(parts[1]) + 1; j++) {
+                        for (int j = Integer.parseInt(parts[0]); j < Integer.parseInt(parts[1]) + 1; j++) {
                             slotsCollection.add(j);
                         }
                     }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-33/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-33/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
@@ -281,8 +281,8 @@ public class RedissonStreamCommands implements RedisStreamCommands {
         public PendingMessage decode(List<Object> parts, State state) {
             PendingMessage pm = new PendingMessage(RecordId.of(parts.get(0).toString()),
                     Consumer.from(groupName, parts.get(1).toString()),
-                    Duration.of(Long.valueOf(parts.get(2).toString()), ChronoUnit.MILLIS),
-                    Long.valueOf(parts.get(3).toString()));
+                    Duration.of(Long.parseLong(parts.get(2).toString()), ChronoUnit.MILLIS),
+                    Long.parseLong(parts.get(3).toString()));
             return pm;
         }
     }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-33/src/test/java/org/redisson/RedisDockerTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-33/src/test/java/org/redisson/RedisDockerTest.java
@@ -413,7 +413,7 @@ public class RedisDockerTest {
 
                         if (mappedPort != null
                                 && s.getIpAddress().equals(uri.getHost())) {
-                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.valueOf(mappedPort[0].getHostPortSpec()));
+                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.parseInt(mappedPort[0].getHostPortSpec()));
                         }
                     }
                     return uri;

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-34/src/main/java/org/redisson/spring/data/connection/RedisClusterNodeDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-34/src/main/java/org/redisson/spring/data/connection/RedisClusterNodeDecoder.java
@@ -96,7 +96,7 @@ public class RedisClusterNodeDecoder implements Decoder<List<RedisClusterNode>> 
                     if(parts.length == 1) {
                         slotsCollection.add(Integer.valueOf(parts[0]));
                     } else if(parts.length == 2) {
-                        for (int j = Integer.valueOf(parts[0]); j < Integer.valueOf(parts[1]) + 1; j++) {
+                        for (int j = Integer.parseInt(parts[0]); j < Integer.parseInt(parts[1]) + 1; j++) {
                             slotsCollection.add(j);
                         }
                     }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-34/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-34/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
@@ -281,8 +281,8 @@ public class RedissonStreamCommands implements RedisStreamCommands {
         public PendingMessage decode(List<Object> parts, State state) {
             PendingMessage pm = new PendingMessage(RecordId.of(parts.get(0).toString()),
                     Consumer.from(groupName, parts.get(1).toString()),
-                    Duration.of(Long.valueOf(parts.get(2).toString()), ChronoUnit.MILLIS),
-                    Long.valueOf(parts.get(3).toString()));
+                    Duration.of(Long.parseLong(parts.get(2).toString()), ChronoUnit.MILLIS),
+                    Long.parseLong(parts.get(3).toString()));
             return pm;
         }
     }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-34/src/test/java/org/redisson/RedisDockerTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-34/src/test/java/org/redisson/RedisDockerTest.java
@@ -413,7 +413,7 @@ public class RedisDockerTest {
 
                         if (mappedPort != null
                                 && s.getIpAddress().equals(uri.getHost())) {
-                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.valueOf(mappedPort[0].getHostPortSpec()));
+                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.parseInt(mappedPort[0].getHostPortSpec()));
                         }
                     }
                     return uri;

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-35/src/main/java/org/redisson/spring/data/connection/RedisClusterNodeDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-35/src/main/java/org/redisson/spring/data/connection/RedisClusterNodeDecoder.java
@@ -96,7 +96,7 @@ public class RedisClusterNodeDecoder implements Decoder<List<RedisClusterNode>> 
                     if(parts.length == 1) {
                         slotsCollection.add(Integer.valueOf(parts[0]));
                     } else if(parts.length == 2) {
-                        for (int j = Integer.valueOf(parts[0]); j < Integer.valueOf(parts[1]) + 1; j++) {
+                        for (int j = Integer.parseInt(parts[0]); j < Integer.parseInt(parts[1]) + 1; j++) {
                             slotsCollection.add(j);
                         }
                     }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-35/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-35/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
@@ -281,8 +281,8 @@ public class RedissonStreamCommands implements RedisStreamCommands {
         public PendingMessage decode(List<Object> parts, State state) {
             PendingMessage pm = new PendingMessage(RecordId.of(parts.get(0).toString()),
                     Consumer.from(groupName, parts.get(1).toString()),
-                    Duration.of(Long.valueOf(parts.get(2).toString()), ChronoUnit.MILLIS),
-                    Long.valueOf(parts.get(3).toString()));
+                    Duration.of(Long.parseLong(parts.get(2).toString()), ChronoUnit.MILLIS),
+                    Long.parseLong(parts.get(3).toString()));
             return pm;
         }
     }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-35/src/test/java/org/redisson/RedisDockerTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-35/src/test/java/org/redisson/RedisDockerTest.java
@@ -413,7 +413,7 @@ public class RedisDockerTest {
 
                         if (mappedPort != null
                                 && s.getIpAddress().equals(uri.getHost())) {
-                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.valueOf(mappedPort[0].getHostPortSpec()));
+                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.parseInt(mappedPort[0].getHostPortSpec()));
                         }
                     }
                     return uri;

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-40/src/main/java/org/redisson/spring/data/connection/RedisClusterNodeDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-40/src/main/java/org/redisson/spring/data/connection/RedisClusterNodeDecoder.java
@@ -96,7 +96,7 @@ public class RedisClusterNodeDecoder implements Decoder<List<RedisClusterNode>> 
                     if(parts.length == 1) {
                         slotsCollection.add(Integer.valueOf(parts[0]));
                     } else if(parts.length == 2) {
-                        for (int j = Integer.valueOf(parts[0]); j < Integer.valueOf(parts[1]) + 1; j++) {
+                        for (int j = Integer.parseInt(parts[0]); j < Integer.parseInt(parts[1]) + 1; j++) {
                             slotsCollection.add(j);
                         }
                     }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-40/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-40/src/main/java/org/redisson/spring/data/connection/RedissonStreamCommands.java
@@ -281,8 +281,8 @@ public class RedissonStreamCommands implements RedisStreamCommands {
         public PendingMessage decode(List<Object> parts, State state) {
             PendingMessage pm = new PendingMessage(RecordId.of(parts.get(0).toString()),
                     Consumer.from(groupName, parts.get(1).toString()),
-                    Duration.of(Long.valueOf(parts.get(2).toString()), ChronoUnit.MILLIS),
-                    Long.valueOf(parts.get(3).toString()));
+                    Duration.of(Long.parseLong(parts.get(2).toString()), ChronoUnit.MILLIS),
+                    Long.parseLong(parts.get(3).toString()));
             return pm;
         }
     }

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-40/src/test/java/org/redisson/RedisDockerTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-40/src/test/java/org/redisson/RedisDockerTest.java
@@ -413,7 +413,7 @@ public class RedisDockerTest {
 
                         if (mappedPort != null
                                 && s.getIpAddress().equals(uri.getHost())) {
-                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.valueOf(mappedPort[0].getHostPortSpec()));
+                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.parseInt(mappedPort[0].getHostPortSpec()));
                         }
                     }
                     return uri;

--- a/redisson-spring/redisson-spring-transaction/src/test/java/org/redisson/RedisDockerTest.java
+++ b/redisson-spring/redisson-spring-transaction/src/test/java/org/redisson/RedisDockerTest.java
@@ -194,7 +194,7 @@ public class RedisDockerTest {
 
                         if (mappedPort != null
                                 && s.getIpAddress().equals(uri.getHost())) {
-                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.valueOf(mappedPort[0].getHostPortSpec()));
+                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.parseInt(mappedPort[0].getHostPortSpec()));
                         }
                     }
                     return uri;

--- a/redisson/src/main/java/org/redisson/RedissonAtomicDouble.java
+++ b/redisson/src/main/java/org/redisson/RedissonAtomicDouble.java
@@ -149,7 +149,7 @@ public class RedissonAtomicDouble extends RedissonExpirable implements RAtomicDo
 
     @Override
     public RFuture<Double> getAndAddAsync(final double delta) {
-        return commandExecutor.writeAsync(getRawName(), StringCodec.INSTANCE, new RedisStrictCommand<Double>("INCRBYFLOAT", obj -> Double.valueOf(obj.toString()) - delta), getRawName(), BigDecimal.valueOf(delta).toPlainString());
+        return commandExecutor.writeAsync(getRawName(), StringCodec.INSTANCE, new RedisStrictCommand<Double>("INCRBYFLOAT", obj -> Double.parseDouble(obj.toString()) - delta), getRawName(), BigDecimal.valueOf(delta).toPlainString());
     }
 
 

--- a/redisson/src/main/java/org/redisson/RedissonBloomFilter.java
+++ b/redisson/src/main/java/org/redisson/RedissonBloomFilter.java
@@ -366,8 +366,8 @@ public class RedissonBloomFilter<T> extends RedissonExpirable implements RBloomF
                 || config.get("size") == null) {
             throw new IllegalStateException("Bloom filter is not initialized!");
         }
-        size = Long.valueOf(config.get("size"));
-        hashIterations = Integer.valueOf(config.get("hashIterations"));
+        size = Long.parseLong(config.get("size"));
+        hashIterations = Integer.parseInt(config.get("hashIterations"));
     }
 
     protected long getMaxSize() {

--- a/redisson/src/main/java/org/redisson/client/handler/CommandDecoder.java
+++ b/redisson/src/main/java/org/redisson/client/handler/CommandDecoder.java
@@ -383,14 +383,14 @@ public class CommandDecoder extends ReplayingDecoder<State> {
                 }
             } else if (error.startsWith("MOVED")) {
                 String[] errorParts = error.split(" ");
-                int slot = Integer.valueOf(errorParts[1]);
+                int slot = Integer.parseInt(errorParts[1]);
                 String addr = errorParts[2];
                 if (data != null) {
                     data.tryFailure(new RedisMovedException(slot, new RedisURI(scheme + "://" + addr)));
                 }
             } else if (error.startsWith("ASK")) {
                 String[] errorParts = error.split(" ");
-                int slot = Integer.valueOf(errorParts[1]);
+                int slot = Integer.parseInt(errorParts[1]);
                 String addr = errorParts[2];
                 if (data != null) {
                     data.tryFailure(new RedisAskException(slot, new RedisURI(scheme + "://" + addr)));

--- a/redisson/src/main/java/org/redisson/client/protocol/convertor/StreamIdConvertor.java
+++ b/redisson/src/main/java/org/redisson/client/protocol/convertor/StreamIdConvertor.java
@@ -29,7 +29,7 @@ public class StreamIdConvertor implements Convertor<StreamMessageId> {
     @Override
     public StreamMessageId convert(Object id) {
         String[] parts = id.toString().split("-");
-        return new StreamMessageId(Long.valueOf(parts[0]), Long.valueOf(parts[1]));
+        return new StreamMessageId(Long.parseLong(parts[0]), Long.parseLong(parts[1]));
     }
 
 }

--- a/redisson/src/main/java/org/redisson/client/protocol/decoder/ClusterNodesDecoder.java
+++ b/redisson/src/main/java/org/redisson/client/protocol/decoder/ClusterNodesDecoder.java
@@ -89,9 +89,9 @@ public class ClusterNodesDecoder implements Decoder<List<ClusterNodeInfo>> {
 
                     String[] parts = slots.split("-");
                     if (parts.length == 1) {
-                        node.addSlotRange(new ClusterSlotRange(Integer.valueOf(parts[0]), Integer.valueOf(parts[0])));
+                        node.addSlotRange(new ClusterSlotRange(Integer.parseInt(parts[0]), Integer.parseInt(parts[0])));
                     } else if (parts.length == 2) {
-                        node.addSlotRange(new ClusterSlotRange(Integer.valueOf(parts[0]), Integer.valueOf(parts[1])));
+                        node.addSlotRange(new ClusterSlotRange(Integer.parseInt(parts[0]), Integer.parseInt(parts[1])));
                     }
                 }
             }

--- a/redisson/src/main/java/org/redisson/client/protocol/decoder/ListIteratorReplayDecoder.java
+++ b/redisson/src/main/java/org/redisson/client/protocol/decoder/ListIteratorReplayDecoder.java
@@ -28,7 +28,7 @@ public class ListIteratorReplayDecoder implements MultiDecoder<ListIteratorResul
 
     @Override
     public ListIteratorResult<Object> decode(List<Object> parts, State state) {
-        return new ListIteratorResult<>(parts.get(0), Long.valueOf(parts.get(1).toString()));
+        return new ListIteratorResult<>(parts.get(0), Long.parseLong(parts.get(1).toString()));
     }
 
 }

--- a/redisson/src/main/java/org/redisson/client/protocol/decoder/PendingEntryDecoder.java
+++ b/redisson/src/main/java/org/redisson/client/protocol/decoder/PendingEntryDecoder.java
@@ -36,7 +36,7 @@ public class PendingEntryDecoder implements MultiDecoder<Object> {
             return parts;
         }
         return new PendingEntry(convertor.convert(parts.get(0)), parts.get(1).toString(), 
-                Long.valueOf(parts.get(2).toString()), Long.valueOf(parts.get(3).toString()));
+                Long.parseLong(parts.get(2).toString()), Long.parseLong(parts.get(3).toString()));
     }
 
 }

--- a/redisson/src/main/java/org/redisson/client/protocol/decoder/RedisURIDecoder.java
+++ b/redisson/src/main/java/org/redisson/client/protocol/decoder/RedisURIDecoder.java
@@ -46,7 +46,7 @@ public class RedisURIDecoder implements MultiDecoder<RedisURI> {
         if (parts.isEmpty()) {
             return null;
         }
-        return new RedisURI(scheme, (String) parts.get(0), Integer.valueOf((String) parts.get(1)));
+        return new RedisURI(scheme, (String) parts.get(0), Integer.parseInt((String) parts.get(1)));
     }
 
 }

--- a/redisson/src/main/java/org/redisson/client/protocol/decoder/StreamIdDecoder.java
+++ b/redisson/src/main/java/org/redisson/client/protocol/decoder/StreamIdDecoder.java
@@ -38,7 +38,7 @@ public class StreamIdDecoder implements Decoder<Object> {
         if (parts.length == 1) {
             return null;
         }
-        return new StreamMessageId(Long.valueOf(parts[0]), Long.valueOf(parts[1]));
+        return new StreamMessageId(Long.parseLong(parts[0]), Long.parseLong(parts[1]));
     }
 
 }

--- a/redisson/src/main/java/org/redisson/command/RedisExecutor.java
+++ b/redisson/src/main/java/org/redisson/command/RedisExecutor.java
@@ -439,15 +439,15 @@ public class RedisExecutor<V, R> {
             if (RedisCommands.BLOCKING_COMMANDS.contains(command)) {
                 for (int i = 0; i < params.length-1; i++) {
                     if ("BLOCK".equals(params[i])) {
-                        popTimeout = Long.valueOf(params[i+1].toString());
+                        popTimeout = Long.parseLong(params[i+1].toString());
                         break;
                     }
                 }
             } else {
                 if (RedisCommands.BZMPOP.getName().equals(command.getName())) {
-                    popTimeout = Long.valueOf(params[0].toString()) * 1000;
+                    popTimeout = Long.parseLong(params[0].toString()) * 1000;
                 } else {
-                    popTimeout = Long.valueOf(params[params.length - 1].toString()) * 1000;
+                    popTimeout = Long.parseLong(params[params.length - 1].toString()) * 1000;
                 }
             }
 

--- a/redisson/src/main/java/org/redisson/config/HostPortNatMapper.java
+++ b/redisson/src/main/java/org/redisson/config/HostPortNatMapper.java
@@ -39,7 +39,7 @@ public class HostPortNatMapper implements NatMapper {
         int lastColonIdx = hostPort.lastIndexOf(":");
         String host = hostPort.substring(0, lastColonIdx);
         String port = hostPort.substring(lastColonIdx + 1);
-        return new RedisURI(uri.getScheme(), host, Integer.valueOf(port));
+        return new RedisURI(uri.getScheme(), host, Integer.parseInt(port));
     }
 
     /**

--- a/redisson/src/main/java/org/redisson/connection/ClusterConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/ClusterConnectionManager.java
@@ -760,7 +760,7 @@ public class ClusterConnectionManager extends MasterSlaveConnectionManager {
             log.info("{} slots removed", removedSlots.size());
         }
 
-        Integer addedSlots = 0;
+        int addedSlots = 0;
         for (ClusterPartition clusterPartition : newPartitions) {
             MasterSlaveEntry entry = getEntry(clusterPartition.getMasterAddress());
             for (Integer slot : clusterPartition.getSlots()) {

--- a/redisson/src/main/java/org/redisson/jcache/JCache.java
+++ b/redisson/src/main/java/org/redisson/jcache/JCache.java
@@ -384,11 +384,11 @@ public class JCache<K, V> extends RedissonObject implements Cache<K, V>, CacheAs
         if (config.getExpiryPolicy().getExpiryForAccess() == null) {
             return -1L;
         }
-        Long accessTimeout = config.getExpiryPolicy().getExpiryForAccess().getAdjustedTime(baseTime);
+        long accessTimeout = config.getExpiryPolicy().getExpiryForAccess().getAdjustedTime(baseTime);
 
         if (config.getExpiryPolicy().getExpiryForAccess().isZero()) {
             accessTimeout = 0L;
-        } else if (accessTimeout.longValue() == Long.MAX_VALUE) {
+        } else if (accessTimeout == Long.MAX_VALUE) {
             accessTimeout = -1L;
         }
         return accessTimeout;
@@ -823,10 +823,10 @@ public class JCache<K, V> extends RedissonObject implements Cache<K, V>, CacheAs
             return -1L;
         }
 
-        Long updateTimeout = config.getExpiryPolicy().getExpiryForUpdate().getAdjustedTime(baseTime);
+        long updateTimeout = config.getExpiryPolicy().getExpiryForUpdate().getAdjustedTime(baseTime);
         if (config.getExpiryPolicy().getExpiryForUpdate().isZero()) {
             updateTimeout = 0L;
-        } else if (updateTimeout.longValue() == Long.MAX_VALUE) {
+        } else if (updateTimeout == Long.MAX_VALUE) {
             updateTimeout = -1L;
         }
         return updateTimeout;
@@ -840,10 +840,10 @@ public class JCache<K, V> extends RedissonObject implements Cache<K, V>, CacheAs
         if (config.getExpiryPolicy().getExpiryForCreation() == null) {
             return -1L;
         }
-        Long creationTimeout = config.getExpiryPolicy().getExpiryForCreation().getAdjustedTime(baseTime);
+        long creationTimeout = config.getExpiryPolicy().getExpiryForCreation().getAdjustedTime(baseTime);
         if (config.getExpiryPolicy().getExpiryForCreation().isZero()) {
             creationTimeout = 0L;
-        } else if (creationTimeout.longValue() == Long.MAX_VALUE) {
+        } else if (creationTimeout == Long.MAX_VALUE) {
             creationTimeout = -1L;
         }
         return creationTimeout;

--- a/redisson/src/main/java/org/redisson/misc/LogHelper.java
+++ b/redisson/src/main/java/org/redisson/misc/LogHelper.java
@@ -28,8 +28,8 @@ import java.util.Collection;
  */
 public final class LogHelper {
 
-    private static final int MAX_COLLECTION_LOG_SIZE = Integer.valueOf(System.getProperty("redisson.maxCollectionLogSize", "10"));
-    private static final int MAX_STRING_LOG_SIZE = Integer.valueOf(System.getProperty("redisson.maxStringLogSize", "1000"));
+    private static final int MAX_COLLECTION_LOG_SIZE = Integer.parseInt(System.getProperty("redisson.maxCollectionLogSize", "10"));
+    private static final int MAX_STRING_LOG_SIZE = Integer.parseInt(System.getProperty("redisson.maxStringLogSize", "1000"));
 //    private static final int MAX_BYTEBUF_LOG_SIZE = Integer.valueOf(System.getProperty("redisson.maxByteBufLogSize", "1000"));
 
     private LogHelper() {

--- a/redisson/src/test/java/org/redisson/DockerRedisStackTest.java
+++ b/redisson/src/test/java/org/redisson/DockerRedisStackTest.java
@@ -111,7 +111,7 @@ public class DockerRedisStackTest {
 
                         if (mappedPort != null
                                 && s.getIpAddress().equals(uri.getHost())) {
-                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.valueOf(mappedPort[0].getHostPortSpec()));
+                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.parseInt(mappedPort[0].getHostPortSpec()));
                         }
                     }
                     return uri;

--- a/redisson/src/test/java/org/redisson/RedisDockerTest.java
+++ b/redisson/src/test/java/org/redisson/RedisDockerTest.java
@@ -398,7 +398,7 @@ public class RedisDockerTest {
 
                         if (mappedPort != null
                                 && s.getIpAddress().equals(uri.getHost())) {
-                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.valueOf(mappedPort[0].getHostPortSpec()));
+                            return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.parseInt(mappedPort[0].getHostPortSpec()));
                         }
                     }
                     return uri;
@@ -479,7 +479,7 @@ public class RedisDockerTest {
 
                             if (mappedPort != null
                                     && s.getIpAddress().equals(uri.getHost())) {
-                                return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.valueOf(mappedPort[0].getHostPortSpec()));
+                                return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.parseInt(mappedPort[0].getHostPortSpec()));
                             }
                         }
                         return uri;

--- a/redisson/src/test/java/org/redisson/RedissonFasterMultiLockTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonFasterMultiLockTest.java
@@ -105,11 +105,11 @@ public class RedissonFasterMultiLockTest extends BaseConcurrentTest {
         String lockName = ((RedissonFasterMultiLock) lock).getLockName(Thread.currentThread().getId());
         lock.lock();
         RedissonObject redissonObject = (RedissonObject) (lock);
-        long fieldExpireTime1 = Long.valueOf(mapCache.get(hashValue(redissonObject, field1) + ":" + lockName + ":expire_time"));
-        long fieldExpireTime2 = Long.valueOf(mapCache.get(hashValue(redissonObject, field2) + ":" + lockName + ":expire_time"));
+        long fieldExpireTime1 = Long.parseLong(mapCache.get(hashValue(redissonObject, field1) + ":" + lockName + ":expire_time"));
+        long fieldExpireTime2 = Long.parseLong(mapCache.get(hashValue(redissonObject, field2) + ":" + lockName + ":expire_time"));
         Thread.sleep(Duration.ofSeconds(17));
-        long fieldExpireTime11 = Long.valueOf(mapCache.get(hashValue(redissonObject, field1) + ":" + lockName + ":expire_time"));
-        long fieldExpireTime22 = Long.valueOf(mapCache.get(hashValue(redissonObject, field2) + ":" + lockName + ":expire_time"));
+        long fieldExpireTime11 = Long.parseLong(mapCache.get(hashValue(redissonObject, field1) + ":" + lockName + ":expire_time"));
+        long fieldExpireTime22 = Long.parseLong(mapCache.get(hashValue(redissonObject, field2) + ":" + lockName + ":expire_time"));
 
         assertThat(fieldExpireTime11 > fieldExpireTime1).isTrue();
         assertThat(fieldExpireTime22 > fieldExpireTime2).isTrue();

--- a/redisson/src/test/java/org/redisson/RedissonMapReactiveTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonMapReactiveTest.java
@@ -128,12 +128,12 @@ public class RedissonMapReactiveTest extends BaseReactiveTest {
     public void testIteratorSequence() throws InterruptedException {
         RMapReactive<Long, Long> map = redisson.getMap("map");
         for (int i = 0; i < 1000; i++) {
-            sync(map.put(Long.valueOf(i), Long.valueOf(i)));
+            sync(map.put((long) i, (long) i));
         }
 
         Map<Long, Long> setCopy = new HashMap<>();
         for (int i = 0; i < 1000; i++) {
-            setCopy.put(Long.valueOf(i), Long.valueOf(i));
+            setCopy.put((long) i, (long) i);
         }
 
         checkIterator(map, setCopy);
@@ -161,9 +161,9 @@ public class RedissonMapReactiveTest extends BaseReactiveTest {
         Assertions.assertEquals(112, (int)res);
 
         RMapReactive<Integer, Double> map2 = redisson.getMap("getAll2", new CompositeCodec(redisson.getConfig().getCodec(), DoubleCodec.INSTANCE));
-        sync(map2.put(1, new Double(100.2)));
+        sync(map2.put(1, 100.2));
 
-        Double res2 = sync(map2.addAndGet(1, new Double(12.1)));
+        Double res2 = sync(map2.addAndGet(1, 12.1));
         Assertions.assertTrue(new Double(112.3).compareTo(res2) == 0);
         res2 = sync(map2.get(1));
         Assertions.assertTrue(new Double(112.3).compareTo(res2) == 0);

--- a/redisson/src/test/java/org/redisson/RedissonPriorityQueueTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonPriorityQueueTest.java
@@ -129,12 +129,12 @@ public class RedissonPriorityQueueTest extends RedisDockerTest {
     public void testIteratorSequence() {
         RPriorityQueue<Integer> set = redisson.getPriorityQueue("set");
         for (int i = 0; i < 1000; i++) {
-            set.add(Integer.valueOf(i));
+            set.add(i);
         }
 
         Queue<Integer> setCopy = new PriorityQueue<Integer>();
         for (int i = 0; i < 1000; i++) {
-            setCopy.add(Integer.valueOf(i));
+            setCopy.add(i);
         }
         
         checkIterator(set, setCopy);

--- a/redisson/src/test/java/org/redisson/RedissonScoredSortedSetReactiveTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonScoredSortedSetReactiveTest.java
@@ -118,12 +118,12 @@ public class RedissonScoredSortedSetReactiveTest extends BaseReactiveTest {
     public void testIteratorSequence() {
         RScoredSortedSetReactive<Integer> set = redisson.getScoredSortedSet("simple");
         for (int i = 0; i < 1000; i++) {
-            sync(set.add(i, Integer.valueOf(i)));
+            sync(set.add(i, i));
         }
 
         Set<Integer> setCopy = new HashSet<Integer>();
         for (int i = 0; i < 1000; i++) {
-            setCopy.add(Integer.valueOf(i));
+            setCopy.add(i);
         }
 
         checkIterator(set, setCopy);
@@ -327,7 +327,7 @@ public class RedissonScoredSortedSetReactiveTest extends BaseReactiveTest {
         RScoredSortedSetReactive<Integer> set2 = redisson.getScoredSortedSet("simple", StringCodec.INSTANCE);
         sync(set2.add(100.2, 1));
 
-        Double res2 = sync(set2.addScore(1, new Double(12.1)));
+        Double res2 = sync(set2.addScore(1, 12.1));
         Assertions.assertTrue(new Double(112.3).compareTo(res2) == 0);
         res2 = sync(set2.getScore(1));
         Assertions.assertTrue(new Double(112.3).compareTo(res2) == 0);

--- a/redisson/src/test/java/org/redisson/RedissonScoredSortedSetTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonScoredSortedSetTest.java
@@ -1128,12 +1128,12 @@ public class RedissonScoredSortedSetTest extends RedisDockerTest {
     public void testIteratorSequence() {
         RScoredSortedSet<Integer> set = redisson.getScoredSortedSet("simple");
         for (int i = 0; i < 1000; i++) {
-            set.add(i, Integer.valueOf(i));
+            set.add(i, i);
         }
 
         Set<Integer> setCopy = new HashSet<>();
         for (int i = 0; i < 1000; i++) {
-            setCopy.add(Integer.valueOf(i));
+            setCopy.add(i);
         }
 
         checkIterator(set, setCopy);

--- a/redisson/src/test/java/org/redisson/RedissonScriptTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonScriptTest.java
@@ -67,10 +67,10 @@ public class RedissonScriptTest extends RedisDockerTest {
     public void testMulti() {
         RLexSortedSet idx2 = redisson.getLexSortedSet("ABCD17436");
         
-        Long l = Long.valueOf("1506524856000");
+        long l = Long.parseLong("1506524856000");
         for (int i = 0; i < 100; i++) {
             String s = "DENY" + "\t" + "TESTREDISSON" + "\t"
-                    + Long.valueOf(l) + "\t" + "helloworld_hongqin";
+                    + l + "\t" + "helloworld_hongqin";
             idx2.add(s);
             l = l + 1;
         }

--- a/redisson/src/test/java/org/redisson/RedissonSetCacheReactiveTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonSetCacheReactiveTest.java
@@ -134,7 +134,7 @@ public class RedissonSetCacheReactiveTest extends BaseReactiveTest {
     public void testIteratorSequence() throws InterruptedException {
         RSetCacheReactive<Long> set = redisson.getSetCache("set");
         for (int i = 0; i < 1000; i++) {
-            sync(set.add(Long.valueOf(i)));
+            sync(set.add((long) i));
         }
 
         Thread.sleep(1000);
@@ -142,7 +142,7 @@ public class RedissonSetCacheReactiveTest extends BaseReactiveTest {
         
         Set<Long> setCopy = new HashSet<Long>();
         for (int i = 0; i < 1000; i++) {
-            setCopy.add(Long.valueOf(i));
+            setCopy.add((long) i);
         }
 
         checkIterator(set, setCopy);

--- a/redisson/src/test/java/org/redisson/RedissonSetCacheTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonSetCacheTest.java
@@ -332,12 +332,12 @@ public class RedissonSetCacheTest extends RedisDockerTest {
     public void testIteratorSequence() {
         RSetCache<Long> set = redisson.getSetCache("set");
         for (int i = 0; i < 1000; i++) {
-            set.add(Long.valueOf(i));
+            set.add((long) i);
         }
 
         Set<Long> setCopy = new HashSet<Long>();
         for (int i = 0; i < 1000; i++) {
-            setCopy.add(Long.valueOf(i));
+            setCopy.add((long) i);
         }
 
         checkIterator(set, setCopy);
@@ -359,7 +359,7 @@ public class RedissonSetCacheTest extends RedisDockerTest {
     public void testIteratorAsync() {
         RSetCache<Long> set = redisson.getSetCache("set");
         for (int i = 0; i < 1000; i++) {
-            set.add(Long.valueOf(i));
+            set.add((long) i);
         }
 
         AsyncIterator<Long> iterator = set.iteratorAsync(5);

--- a/redisson/src/test/java/org/redisson/RedissonSetReactiveTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonSetReactiveTest.java
@@ -115,12 +115,12 @@ public class RedissonSetReactiveTest extends BaseReactiveTest {
     public void testIteratorSequence() {
         RSetReactive<Long> set = redisson.getSet("set");
         for (int i = 0; i < 1000; i++) {
-            sync(set.add(Long.valueOf(i)));
+            sync(set.add((long) i));
         }
 
         Set<Long> setCopy = new HashSet<Long>();
         for (int i = 0; i < 1000; i++) {
-            setCopy.add(Long.valueOf(i));
+            setCopy.add((long) i);
         }
 
         checkIterator(set, setCopy);

--- a/redisson/src/test/java/org/redisson/RedissonSetTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonSetTest.java
@@ -513,12 +513,12 @@ public class RedissonSetTest extends RedisDockerTest {
     public void testIteratorSequence() {
         Set<Long> set = redisson.getSet("set");
         for (int i = 0; i < 1000; i++) {
-            set.add(Long.valueOf(i));
+            set.add((long) i);
         }
 
         Set<Long> setCopy = new HashSet<Long>();
         for (int i = 0; i < 1000; i++) {
-            setCopy.add(Long.valueOf(i));
+            setCopy.add((long) i);
         }
 
         checkIterator(set, setCopy);
@@ -539,7 +539,7 @@ public class RedissonSetTest extends RedisDockerTest {
     public void testIteratorAsync() {
         RSet<Long> set = redisson.getSet("set");
         for (int i = 0; i < 1000; i++) {
-            set.add(Long.valueOf(i));
+            set.add((long) i);
         }
 
         AsyncIterator<Long> iterator = set.iteratorAsync(5);

--- a/redisson/src/test/java/org/redisson/RedissonSortedSetTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonSortedSetTest.java
@@ -154,12 +154,12 @@ public class RedissonSortedSetTest extends RedisDockerTest {
     public void testIteratorSequence() {
         Set<Integer> set = redisson.getSortedSet("set");
         for (int i = 0; i < 1000; i++) {
-            set.add(Integer.valueOf(i));
+            set.add(i);
         }
 
         Set<Integer> setCopy = new HashSet<Integer>();
         for (int i = 0; i < 1000; i++) {
-            setCopy.add(Integer.valueOf(i));
+            setCopy.add(i);
         }
         
         checkIterator(set, setCopy);

--- a/redisson/src/test/java/org/redisson/RedissonTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonTest.java
@@ -947,7 +947,7 @@ public class RedissonTest extends RedisDockerTest {
             String key = null;
             int slot = 0;
             String res = execute(source, "redis-cli", "cluster", "slots");
-            int sourceSlot = Integer.valueOf(res.split("\\n")[1]);
+            int sourceSlot = Integer.parseInt(res.split("\\n")[1]);
             for (int i = 0; i < 100000; i++) {
                 key = "" + i;
                 slot = CRC16.crc16(key.getBytes()) % MasterSlaveConnectionManager.MAX_SLOT;

--- a/redisson/src/test/java/org/redisson/RedissonTopicTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonTopicTest.java
@@ -900,8 +900,8 @@ public class RedissonTopicTest extends RedisDockerTest {
             Runnable rLockPayload =
                     () -> {
                         try {
-                            Integer randomLock = ThreadLocalRandom.current().nextInt(100);
-                            RLock lock = redissonClient.getLock(randomLock.toString());
+                            int randomLock = ThreadLocalRandom.current().nextInt(100);
+                            RLock lock = redissonClient.getLock(Integer.toString(randomLock));
                             lock.lock(10, TimeUnit.SECONDS);
                             lock.unlock();
                             status.add("ok");
@@ -1305,8 +1305,8 @@ public class RedissonTopicTest extends RedisDockerTest {
             Runnable rLockPayload =
                     () -> {
                         try {
-                            Integer randomLock = ThreadLocalRandom.current().nextInt(100);
-                            RLock lock = redissonClient.getLock(randomLock.toString());
+                            int randomLock = ThreadLocalRandom.current().nextInt(100);
+                            RLock lock = redissonClient.getLock(Integer.toString(randomLock));
                             lock.lock(10, TimeUnit.SECONDS);
                             lock.unlock();
 

--- a/redisson/src/test/java/org/redisson/misc/SoftCacheMapTest.java
+++ b/redisson/src/test/java/org/redisson/misc/SoftCacheMapTest.java
@@ -56,7 +56,7 @@ public class SoftCacheMapTest {
     public void testSoftReferences() {
         Cache<Integer, Integer> map = ReferenceCacheMap.soft(0, 0);
         for(int i=0;i<100000;i++) {
-            map.put(i, new Integer(i));
+            map.put(i, i);
         }
 
         assertThat(map.values().stream().filter(Objects::nonNull).count()).isEqualTo(100000);

--- a/redisson/src/test/java/org/redisson/rx/RedissonMapRxTest.java
+++ b/redisson/src/test/java/org/redisson/rx/RedissonMapRxTest.java
@@ -134,9 +134,9 @@ public class RedissonMapRxTest extends BaseRxTest {
         Assertions.assertEquals(112, (int)res);
 
         RMapRx<Integer, Double> map2 = redisson.getMap("getAll2", new CompositeCodec(redisson.getConfig().getCodec(), DoubleCodec.INSTANCE));
-        sync(map2.put(1, new Double(100.2)));
+        sync(map2.put(1, 100.2));
 
-        Double res2 = sync(map2.addAndGet(1, new Double(12.1)));
+        Double res2 = sync(map2.addAndGet(1, 12.1));
         Assertions.assertTrue(new Double(112.3).compareTo(res2) == 0);
         res2 = sync(map2.get(1));
         Assertions.assertTrue(new Double(112.3).compareTo(res2) == 0);

--- a/redisson/src/test/java/org/redisson/rx/RedissonScoredSortedSetRxTest.java
+++ b/redisson/src/test/java/org/redisson/rx/RedissonScoredSortedSetRxTest.java
@@ -132,12 +132,12 @@ public class RedissonScoredSortedSetRxTest extends BaseRxTest {
     public void testIteratorSequence() {
         RScoredSortedSetRx<Integer> set = redisson.getScoredSortedSet("simple");
         for (int i = 0; i < 1000; i++) {
-            sync(set.add(i, Integer.valueOf(i)));
+            sync(set.add(i, i));
         }
 
         Set<Integer> setCopy = new HashSet<Integer>();
         for (int i = 0; i < 1000; i++) {
-            setCopy.add(Integer.valueOf(i));
+            setCopy.add(i);
         }
 
         checkIterator(set, setCopy);
@@ -341,7 +341,7 @@ public class RedissonScoredSortedSetRxTest extends BaseRxTest {
         RScoredSortedSetRx<Integer> set2 = redisson.getScoredSortedSet("simple", StringCodec.INSTANCE);
         sync(set2.add(100.2, 1));
 
-        Double res2 = sync(set2.addScore(1, new Double(12.1)));
+        Double res2 = sync(set2.addScore(1, 12.1));
         Assertions.assertTrue(new Double(112.3).compareTo(res2) == 0);
         res2 = sync(set2.getScore(1));
         Assertions.assertTrue(new Double(112.3).compareTo(res2) == 0);

--- a/redisson/src/test/java/org/redisson/rx/RedissonSetCacheRxTest.java
+++ b/redisson/src/test/java/org/redisson/rx/RedissonSetCacheRxTest.java
@@ -105,7 +105,7 @@ public class RedissonSetCacheRxTest extends BaseRxTest {
     public void testIteratorSequence() throws InterruptedException {
         RSetCacheRx<Long> set = redisson.getSetCache("set");
         for (int i = 0; i < 1000; i++) {
-            sync(set.add(Long.valueOf(i)));
+            sync(set.add((long) i));
         }
 
         Thread.sleep(1000);
@@ -113,7 +113,7 @@ public class RedissonSetCacheRxTest extends BaseRxTest {
         
         Set<Long> setCopy = new HashSet<Long>();
         for (int i = 0; i < 1000; i++) {
-            setCopy.add(Long.valueOf(i));
+            setCopy.add((long) i);
         }
 
         checkIterator(set, setCopy);

--- a/redisson/src/test/java/org/redisson/rx/RedissonSetRxTest.java
+++ b/redisson/src/test/java/org/redisson/rx/RedissonSetRxTest.java
@@ -116,12 +116,12 @@ public class RedissonSetRxTest extends BaseRxTest {
     public void testIteratorSequence() {
         RSetRx<Long> set = redisson.getSet("set");
         for (int i = 0; i < 1000; i++) {
-            sync(set.add(Long.valueOf(i)));
+            sync(set.add((long) i));
         }
 
         Set<Long> setCopy = new HashSet<Long>();
         for (int i = 0; i < 1000; i++) {
-            setCopy.add(Long.valueOf(i));
+            setCopy.add((long) i);
         }
 
         checkIterator(set, setCopy);


### PR DESCRIPTION
Mainly `${Type}.valueOf` -> `${Type}.parse${Type}`