### PR TITLE
Feature: Add COUNT aggregate option for ZUNION, ZINTER, ZUNIONSTORE, ZINTERSTORE

### DIFF
--- a/redisson/src/main/java/org/redisson/api/RScoredSortedSet.java
+++ b/redisson/src/main/java/org/redisson/api/RScoredSortedSet.java
@@ -37,9 +37,16 @@ import java.util.stream.Stream;
 public interface RScoredSortedSet<V> extends RScoredSortedSetAsync<V>, Iterable<V>, RExpirable, RSortable<Set<V>> {
 
     enum Aggregate {
-        
-        SUM, MAX, MIN
-        
+
+        SUM, MAX, MIN,
+
+        /**
+         * Score of each member equals the count of input sets containing it,
+         * optionally scaled by WEIGHTS. Scores from input sets are ignored.
+         * Requires <b>Redis 8.8.0 or higher.</b>
+         */
+        COUNT
+
     }
     
     /**

--- a/redisson/src/test/java/org/redisson/RedissonScoredSortedSetTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonScoredSortedSetTest.java
@@ -2060,6 +2060,78 @@ public class RedissonScoredSortedSetTest extends RedisDockerTest {
         assertThat(out.getScore("three")).isEqualTo(9);
     }
 
+    
+    @Test
+    public void testUnionWithCountAggregate() {
+        RScoredSortedSet<String> set1 = redisson.getScoredSortedSet("simple1");
+        set1.add(1, "one");
+        set1.add(2, "two");
+
+        RScoredSortedSet<String> set2 = redisson.getScoredSortedSet("simple2");
+        set2.add(10, "one");
+        set2.add(20, "two");
+        set2.add(30, "three");
+
+        RScoredSortedSet<String> out = redisson.getScoredSortedSet("out");
+        assertThat(out.union((SetUnionArgs) SetUnionArgs.names(set1.getName(), set2.getName())
+                .aggregate(RScoredSortedSet.Aggregate.COUNT))).isEqualTo(3);
+
+        assertThat(out.readAll()).containsOnly("one", "two", "three");
+        assertThat(out.getScore("one")).isEqualTo(2.0);
+        assertThat(out.getScore("two")).isEqualTo(2.0);
+        assertThat(out.getScore("three")).isEqualTo(1.0);
+    }
+
+    @Test
+    public void testIntersectionWithCountAggregate() {
+        RScoredSortedSet<String> set1 = redisson.getScoredSortedSet("simple1");
+        set1.add(1, "one");
+        set1.add(2, "two");
+
+        RScoredSortedSet<String> set2 = redisson.getScoredSortedSet("simple2");
+        set2.add(10, "one");
+        set2.add(20, "two");
+        set2.add(30, "three");
+
+        RScoredSortedSet<String> out = redisson.getScoredSortedSet("out");
+        assertThat(out.intersection((SetIntersectionArgs) SetIntersectionArgs.names(set1.getName(), set2.getName())
+                .aggregate(RScoredSortedSet.Aggregate.COUNT))).isEqualTo(2);
+
+        assertThat(out.readAll()).containsOnly("one", "two");
+        assertThat(out.getScore("one")).isEqualTo(2.0);
+        assertThat(out.getScore("two")).isEqualTo(2.0);
+    }
+
+    @Test
+    public void testReadUnionWithCountAggregate() {
+        RScoredSortedSet<String> set1 = redisson.getScoredSortedSet("simple1");
+        set1.add(1, "one");
+        set1.add(2, "two");
+
+        RScoredSortedSet<String> set2 = redisson.getScoredSortedSet("simple2");
+        set2.add(10, "one");
+        set2.add(30, "three");
+
+        Collection<String> result = set1.readUnion((SetUnionArgs) SetUnionArgs.names(set2.getName())
+                .aggregate(RScoredSortedSet.Aggregate.COUNT));
+        assertThat(result).containsExactlyInAnyOrder("one", "two", "three");
+    }
+
+    @Test
+    public void testReadIntersectionWithCountAggregate() {
+        RScoredSortedSet<String> set1 = redisson.getScoredSortedSet("simple1");
+        set1.add(1, "one");
+        set1.add(2, "two");
+
+        RScoredSortedSet<String> set2 = redisson.getScoredSortedSet("simple2");
+        set2.add(10, "one");
+        set2.add(30, "three");
+
+        Collection<String> result = set1.readIntersection((SetIntersectionArgs) SetIntersectionArgs.names(set2.getName())
+                .aggregate(RScoredSortedSet.Aggregate.COUNT));
+        assertThat(result).containsExactly("one");
+    }
+
     @Test
     public void testDistributedIterator() {
         RScoredSortedSet<String> set = redisson.getScoredSortedSet("set", StringCodec.INSTANCE);


### PR DESCRIPTION
Closes #7064

## What
Added `COUNT` as a new value to `RScoredSortedSet.Aggregate` enum to support the COUNT aggregation mode introduced in [redis/redis#14892](https://github.com/redis/redis/pull/14892), merged into Redis 8.8.

## How
With `AGGREGATE COUNT`, each member's score equals the number of input sets containing it, optionally scaled by `WEIGHTS`. Scores from input sets are ignored entirely.

**Example:**
```
set1: {one=1, two=2}
set2: {one=99, three=50}

ZUNIONSTORE out 2 set1 set2 AGGREGATE COUNT
→ one   = 2  (appears in 2 sets)
→ two   = 1  (appears in set1 only)
→ three = 1  (appears in set2 only)
```

No additional code changes are needed beyond the enum — the existing command builders already pass `aggregate.name()` directly to Redis for all affected commands (ZUNION, ZINTER, ZUNIONSTORE, ZINTERSTORE).

## Tests
Added 4 test cases covering all affected commands with `AGGREGATE COUNT`:
- `testUnionWithCountAggregate` — ZUNIONSTORE
- `testIntersectionWithCountAggregate` — ZINTERSTORE
- `testReadUnionWithCountAggregate` — ZUNION
- `testReadIntersectionWithCountAggregate` — ZINTER

Tests verified locally against `redis:8.8-m03` (4/4 passed). Requires Redis 8.8+.