### PR TITLE
Add FPHA argument support for JSON.SET

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonJsonBucket.java
+++ b/redisson/src/main/java/org/redisson/RedissonJsonBucket.java
@@ -15,6 +15,7 @@
  */
 package org.redisson;
 
+import org.redisson.api.FPHAType;
 import org.redisson.api.JsonType;
 import org.redisson.api.RFuture;
 import org.redisson.api.RJsonBucket;
@@ -180,13 +181,13 @@ public class RedissonJsonBucket<V> extends RedissonExpirable implements RJsonBuc
     }
 
     @Override
-    public boolean setIfAbsent(String path, Object value, RJsonBucket.FpType fpType) {
-        return get(setIfAbsentAsync(path, value, fpType));
+    public boolean setIfAbsent(String path, Object value, FPHAType fphaType) {
+        return get(setIfAbsentAsync(path, value, fphaType));
     }
 
     @Override
-    public RFuture<Boolean> setIfAbsentAsync(String path, Object value, RJsonBucket.FpType fpType) {
-        return commandExecutor.writeAsync(getRawName(), codec, RedisCommands.JSON_SET_BOOLEAN, getRawName(), path, encode(value), "NX", "FPHA", fpType.name());
+    public RFuture<Boolean> setIfAbsentAsync(String path, Object value, FPHAType fphaType) {
+        return commandExecutor.writeAsync(getRawName(), codec, RedisCommands.JSON_SET_BOOLEAN, getRawName(), path, encode(value), "NX", "FPHA", fphaType.name());
     }
 
     @Override
@@ -241,13 +242,13 @@ public class RedissonJsonBucket<V> extends RedissonExpirable implements RJsonBuc
     }
 
     @Override
-    public boolean setIfExists(String path, Object value, RJsonBucket.FpType fpType) {
-        return get(setIfExistsAsync(path, value, fpType));
+    public boolean setIfExists(String path, Object value, FPHAType fphaType) {
+        return get(setIfExistsAsync(path, value, fphaType));
     }
 
     @Override
-    public RFuture<Boolean> setIfExistsAsync(String path, Object value, RJsonBucket.FpType fpType) {
-        return commandExecutor.writeAsync(getRawName(), codec, RedisCommands.JSON_SET_BOOLEAN, getRawName(), path, encode(value), "XX", "FPHA", fpType.name());
+    public RFuture<Boolean> setIfExistsAsync(String path, Object value, FPHAType fphaType) {
+        return commandExecutor.writeAsync(getRawName(), codec, RedisCommands.JSON_SET_BOOLEAN, getRawName(), path, encode(value), "XX", "FPHA", fphaType.name());
     }
 
     @Override
@@ -501,13 +502,13 @@ public class RedissonJsonBucket<V> extends RedissonExpirable implements RJsonBuc
     }
 
     @Override
-    public void set(String path, Object value, RJsonBucket.FpType fpType) {
-        get(setAsync(path, value, fpType));
+    public void set(String path, Object value, FPHAType fphaType) {
+        get(setAsync(path, value, fphaType));
     }
 
     @Override
-    public RFuture<Void> setAsync(String path, Object value, RJsonBucket.FpType fpType) {
-        return commandExecutor.writeAsync(getRawName(), codec, RedisCommands.JSON_SET, getRawName(), path, encode(value), "FPHA", fpType.name());
+    public RFuture<Void> setAsync(String path, Object value, FPHAType fphaType) {
+        return commandExecutor.writeAsync(getRawName(), codec, RedisCommands.JSON_SET, getRawName(), path, encode(value), "FPHA", fphaType.name());
     }
 
     @Override

--- a/redisson/src/main/java/org/redisson/RedissonJsonBucket.java
+++ b/redisson/src/main/java/org/redisson/RedissonJsonBucket.java
@@ -180,6 +180,16 @@ public class RedissonJsonBucket<V> extends RedissonExpirable implements RJsonBuc
     }
 
     @Override
+    public boolean setIfAbsent(String path, Object value, RJsonBucket.FpType fpType) {
+        return get(setIfAbsentAsync(path, value, fpType));
+    }
+
+    @Override
+    public RFuture<Boolean> setIfAbsentAsync(String path, Object value, RJsonBucket.FpType fpType) {
+        return commandExecutor.writeAsync(getRawName(), codec, RedisCommands.JSON_SET_BOOLEAN, getRawName(), path, encode(value), "NX", "FPHA", fpType.name());
+    }
+
+    @Override
     public boolean trySet(String path, Object value) {
         return get(trySetAsync(path, value));
     }
@@ -228,6 +238,16 @@ public class RedissonJsonBucket<V> extends RedissonExpirable implements RJsonBuc
     @Override
     public RFuture<Boolean> setIfExistsAsync(String path, Object value) {
         return commandExecutor.writeAsync(getRawName(), codec, RedisCommands.JSON_SET_BOOLEAN, getRawName(), path, encode(value), "XX");
+    }
+
+    @Override
+    public boolean setIfExists(String path, Object value, RJsonBucket.FpType fpType) {
+        return get(setIfExistsAsync(path, value, fpType));
+    }
+
+    @Override
+    public RFuture<Boolean> setIfExistsAsync(String path, Object value, RJsonBucket.FpType fpType) {
+        return commandExecutor.writeAsync(getRawName(), codec, RedisCommands.JSON_SET_BOOLEAN, getRawName(), path, encode(value), "XX", "FPHA", fpType.name());
     }
 
     @Override
@@ -478,6 +498,16 @@ public class RedissonJsonBucket<V> extends RedissonExpirable implements RJsonBuc
     @Override
     public RFuture<Void> setAsync(String path, Object value) {
         return commandExecutor.writeAsync(getRawName(), codec, RedisCommands.JSON_SET, getRawName(), path, encode(value));
+    }
+
+    @Override
+    public void set(String path, Object value, RJsonBucket.FpType fpType) {
+        get(setAsync(path, value, fpType));
+    }
+
+    @Override
+    public RFuture<Void> setAsync(String path, Object value, RJsonBucket.FpType fpType) {
+        return commandExecutor.writeAsync(getRawName(), codec, RedisCommands.JSON_SET, getRawName(), path, encode(value), "FPHA", fpType.name());
     }
 
     @Override

--- a/redisson/src/main/java/org/redisson/api/FPHAType.java
+++ b/redisson/src/main/java/org/redisson/api/FPHAType.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2013-2026 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.api;
+
+/**
+ * Floating-point homogeneous array precision type for JSON.SET FPHA argument.
+ * Requires <b>Redis 8.8.0 or higher.</b>
+ *
+ * @author Triet Nguyen
+ */
+public enum FPHAType {
+    /** Brain Float 16-bit precision. */
+    BF16,
+    /** 16-bit floating-point precision. */
+    FP16,
+    /** 32-bit floating-point precision. */
+    FP32,
+    /** 64-bit floating-point precision. */
+    FP64
+}

--- a/redisson/src/main/java/org/redisson/api/RJsonBucket.java
+++ b/redisson/src/main/java/org/redisson/api/RJsonBucket.java
@@ -102,6 +102,58 @@ public interface RJsonBucket<V> extends RBucket<V>, RJsonBucketAsync<V> {
     void set(String path, Object value);
 
     /**
+     * Floating-point homogeneous array precision type for JSON.SET FPHA argument.
+     * Requires <b>Redis 8.8.0 or higher.</b>
+     */
+    enum FpType {
+        /** Brain Float 16-bit precision. */
+        BF16,
+        /** 16-bit floating-point precision. */
+        FP16,
+        /** 32-bit floating-point precision. */
+        FP32,
+        /** 64-bit floating-point precision. */
+        FP64
+    }
+
+    /**
+     * Stores object into element by specified JSONPath using FPHA argument
+     * to enforce floating-point array precision.
+     * Requires <b>Redis 8.8.0 or higher.</b>
+     *
+     * @param path JSON path
+     * @param value value to set
+     * @param fpType floating-point precision type
+     */
+    void set(String path, Object value, FpType fpType);
+
+    /**
+     * Sets Json object by JSONPath only if previous value is empty,
+     * using FPHA argument to enforce floating-point array precision.
+     * Requires <b>Redis 8.8.0 or higher.</b>
+     *
+     * @param path JSON path
+     * @param value object
+     * @param fpType floating-point precision type
+     * @return {@code true} if successful, or {@code false} if
+     *         value was already set
+     */
+    boolean setIfAbsent(String path, Object value, FpType fpType);
+
+    /**
+     * Sets Json object by JSONPath only if previous value is non-empty,
+     * using FPHA argument to enforce floating-point array precision.
+     * Requires <b>Redis 8.8.0 or higher.</b>
+     *
+     * @param path JSON path
+     * @param value object
+     * @param fpType floating-point precision type
+     * @return {@code true} if successful, or {@code false} if
+     *         element wasn't set
+     */
+    boolean setIfExists(String path, Object value, FpType fpType);
+
+    /**
      * Returns size of string data by JSONPath
      *
      * @param path JSON path

--- a/redisson/src/main/java/org/redisson/api/RJsonBucket.java
+++ b/redisson/src/main/java/org/redisson/api/RJsonBucket.java
@@ -102,30 +102,15 @@ public interface RJsonBucket<V> extends RBucket<V>, RJsonBucketAsync<V> {
     void set(String path, Object value);
 
     /**
-     * Floating-point homogeneous array precision type for JSON.SET FPHA argument.
-     * Requires <b>Redis 8.8.0 or higher.</b>
-     */
-    enum FpType {
-        /** Brain Float 16-bit precision. */
-        BF16,
-        /** 16-bit floating-point precision. */
-        FP16,
-        /** 32-bit floating-point precision. */
-        FP32,
-        /** 64-bit floating-point precision. */
-        FP64
-    }
-
-    /**
      * Stores object into element by specified JSONPath using FPHA argument
      * to enforce floating-point array precision.
      * Requires <b>Redis 8.8.0 or higher.</b>
      *
      * @param path JSON path
      * @param value value to set
-     * @param fpType floating-point precision type
+     * @param fphaType floating-point precision type
      */
-    void set(String path, Object value, FpType fpType);
+    void set(String path, Object value, FPHAType fphaType);
 
     /**
      * Sets Json object by JSONPath only if previous value is empty,
@@ -134,11 +119,11 @@ public interface RJsonBucket<V> extends RBucket<V>, RJsonBucketAsync<V> {
      *
      * @param path JSON path
      * @param value object
-     * @param fpType floating-point precision type
+     * @param fphaType floating-point precision type
      * @return {@code true} if successful, or {@code false} if
      *         value was already set
      */
-    boolean setIfAbsent(String path, Object value, FpType fpType);
+    boolean setIfAbsent(String path, Object value, FPHAType fphaType);
 
     /**
      * Sets Json object by JSONPath only if previous value is non-empty,
@@ -147,11 +132,11 @@ public interface RJsonBucket<V> extends RBucket<V>, RJsonBucketAsync<V> {
      *
      * @param path JSON path
      * @param value object
-     * @param fpType floating-point precision type
+     * @param fphaType floating-point precision type
      * @return {@code true} if successful, or {@code false} if
      *         element wasn't set
      */
-    boolean setIfExists(String path, Object value, FpType fpType);
+    boolean setIfExists(String path, Object value, FPHAType fphaType);
 
     /**
      * Returns size of string data by JSONPath

--- a/redisson/src/main/java/org/redisson/api/RJsonBucketAsync.java
+++ b/redisson/src/main/java/org/redisson/api/RJsonBucketAsync.java
@@ -109,10 +109,10 @@ public interface RJsonBucketAsync<V> extends RBucketAsync<V> {
      *
      * @param path JSON path
      * @param value value to set
-     * @param fpType floating-point precision type
+     * @param fphaType floating-point precision type
      * @return void
      */
-    RFuture<Void> setAsync(String path, Object value, RJsonBucket.FpType fpType);
+    RFuture<Void> setAsync(String path, Object value, FPHAType fphaType);
 
     /**
      * Sets Json object by JSONPath only if previous value is empty,
@@ -121,11 +121,11 @@ public interface RJsonBucketAsync<V> extends RBucketAsync<V> {
      *
      * @param path JSON path
      * @param value object
-     * @param fpType floating-point precision type
+     * @param fphaType floating-point precision type
      * @return {@code true} if successful, or {@code false} if
      *         value was already set
      */
-    RFuture<Boolean> setIfAbsentAsync(String path, Object value, RJsonBucket.FpType fpType);
+    RFuture<Boolean> setIfAbsentAsync(String path, Object value, FPHAType fphaType);
 
     /**
      * Sets Json object by JSONPath only if previous value is non-empty,
@@ -134,11 +134,11 @@ public interface RJsonBucketAsync<V> extends RBucketAsync<V> {
      *
      * @param path JSON path
      * @param value object
-     * @param fpType floating-point precision type
+     * @param fphaType floating-point precision type
      * @return {@code true} if successful, or {@code false} if
      *         element wasn't set
      */
-    RFuture<Boolean> setIfExistsAsync(String path, Object value, RJsonBucket.FpType fpType);
+    RFuture<Boolean> setIfExistsAsync(String path, Object value, FPHAType fphaType);
 
     /**
      * Returns size of string data by JSONPath

--- a/redisson/src/main/java/org/redisson/api/RJsonBucketAsync.java
+++ b/redisson/src/main/java/org/redisson/api/RJsonBucketAsync.java
@@ -103,6 +103,44 @@ public interface RJsonBucketAsync<V> extends RBucketAsync<V> {
     RFuture<Void> setAsync(String path, Object value);
 
     /**
+     * Stores object into element by specified JSONPath using FPHA argument
+     * to enforce floating-point array precision.
+     * Requires <b>Redis 8.8.0 or higher.</b>
+     *
+     * @param path JSON path
+     * @param value value to set
+     * @param fpType floating-point precision type
+     * @return void
+     */
+    RFuture<Void> setAsync(String path, Object value, RJsonBucket.FpType fpType);
+
+    /**
+     * Sets Json object by JSONPath only if previous value is empty,
+     * using FPHA argument to enforce floating-point array precision.
+     * Requires <b>Redis 8.8.0 or higher.</b>
+     *
+     * @param path JSON path
+     * @param value object
+     * @param fpType floating-point precision type
+     * @return {@code true} if successful, or {@code false} if
+     *         value was already set
+     */
+    RFuture<Boolean> setIfAbsentAsync(String path, Object value, RJsonBucket.FpType fpType);
+
+    /**
+     * Sets Json object by JSONPath only if previous value is non-empty,
+     * using FPHA argument to enforce floating-point array precision.
+     * Requires <b>Redis 8.8.0 or higher.</b>
+     *
+     * @param path JSON path
+     * @param value object
+     * @param fpType floating-point precision type
+     * @return {@code true} if successful, or {@code false} if
+     *         element wasn't set
+     */
+    RFuture<Boolean> setIfExistsAsync(String path, Object value, RJsonBucket.FpType fpType);
+
+    /**
      * Returns size of string data by JSONPath
      *
      * @param path JSON path

--- a/redisson/src/main/java/org/redisson/api/RJsonBucketReactive.java
+++ b/redisson/src/main/java/org/redisson/api/RJsonBucketReactive.java
@@ -71,6 +71,44 @@ public interface RJsonBucketReactive<V> extends RBucketReactive<V> {
     Mono<Boolean> setIfExists(String path, Object value);
 
     /**
+     * Stores object into element by specified JSONPath using FPHA argument
+     * to enforce floating-point array precision.
+     * Requires <b>Redis 8.8.0 or higher.</b>
+     *
+     * @param path JSON path
+     * @param value value to set
+     * @param fphaType floating-point precision type
+     * @return void
+     */
+    Mono<Void> set(String path, Object value, FPHAType fphaType);
+
+    /**
+     * Sets Json object by JSONPath only if previous value is empty,
+     * using FPHA argument to enforce floating-point array precision.
+     * Requires <b>Redis 8.8.0 or higher.</b>
+     *
+     * @param path JSON path
+     * @param value object
+     * @param fphaType floating-point precision type
+     * @return {@code true} if successful, or {@code false} if
+     *         value was already set
+     */
+    Mono<Boolean> setIfAbsent(String path, Object value, FPHAType fphaType);
+
+    /**
+     * Sets Json object by JSONPath only if previous value is non-empty,
+     * using FPHA argument to enforce floating-point array precision.
+     * Requires <b>Redis 8.8.0 or higher.</b>
+     *
+     * @param path JSON path
+     * @param value object
+     * @param fphaType floating-point precision type
+     * @return {@code true} if successful, or {@code false} if
+     *         element wasn't set
+     */
+    Mono<Boolean> setIfExists(String path, Object value, FPHAType fphaType);
+
+    /**
      * Atomically sets the value to the given updated value
      * by given JSONPath, only if serialized state of
      * the current value equals to serialized state of the expected value.

--- a/redisson/src/main/java/org/redisson/api/RJsonBucketRx.java
+++ b/redisson/src/main/java/org/redisson/api/RJsonBucketRx.java
@@ -73,6 +73,44 @@ public interface RJsonBucketRx<V> extends RBucketRx<V> {
     Single<Boolean> setIfExists(String path, Object value);
 
     /**
+     * Stores object into element by specified JSONPath using FPHA argument
+     * to enforce floating-point array precision.
+     * Requires <b>Redis 8.8.0 or higher.</b>
+     *
+     * @param path JSON path
+     * @param value value to set
+     * @param fphaType floating-point precision type
+     * @return void
+     */
+    Completable set(String path, Object value, FPHAType fphaType);
+
+    /**
+     * Sets Json object by JSONPath only if previous value is empty,
+     * using FPHA argument to enforce floating-point array precision.
+     * Requires <b>Redis 8.8.0 or higher.</b>
+     *
+     * @param path JSON path
+     * @param value object
+     * @param fphaType floating-point precision type
+     * @return {@code true} if successful, or {@code false} if
+     *         value was already set
+     */
+    Single<Boolean> setIfAbsent(String path, Object value, FPHAType fphaType);
+
+    /**
+     * Sets Json object by JSONPath only if previous value is non-empty,
+     * using FPHA argument to enforce floating-point array precision.
+     * Requires <b>Redis 8.8.0 or higher.</b>
+     *
+     * @param path JSON path
+     * @param value object
+     * @param fphaType floating-point precision type
+     * @return {@code true} if successful, or {@code false} if
+     *         element wasn't set
+     */
+    Single<Boolean> setIfExists(String path, Object value, FPHAType fphaType);
+
+    /**
      * Atomically sets the value to the given updated value
      * by given JSONPath, only if serialized state of
      * the current value equals to serialized state of the expected value.

--- a/redisson/src/test/java/org/redisson/RedissonJsonBucketTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonJsonBucketTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.redisson.api.FPHAType;
 import org.redisson.api.JsonType;
 import org.redisson.api.RJsonBucket;
 import org.redisson.api.RType;
@@ -534,7 +535,7 @@ public class RedissonJsonBucketTest extends RedisDockerTest {
     public void testSetWithFpha() {
         RJsonBucket<List<Double>> al = redisson.getJsonBucket("test", new JacksonCodec<>(new TypeReference<List<Double>>(){}));
         List<Double> values = Arrays.asList(1.5, 2.5, 3.5);
-        al.set("$", values, RJsonBucket.FpType.FP32);
+        al.set("$", values, FPHAType.FP32);
         List<Double> result = al.get();
         assertThat(result).containsExactly(1.5, 2.5, 3.5);
     }
@@ -544,11 +545,11 @@ public class RedissonJsonBucketTest extends RedisDockerTest {
         RJsonBucket<List<Double>> al = redisson.getJsonBucket("test", new JacksonCodec<>(new TypeReference<List<Double>>(){}));
         List<Double> values = Arrays.asList(1.5, 2.5, 3.5);
 
-        assertThat(al.setIfAbsent("$", values, RJsonBucket.FpType.FP32)).isTrue();
+        assertThat(al.setIfAbsent("$", values, FPHAType.FP32)).isTrue();
         List<Double> result = al.get();
         assertThat(result).containsExactly(1.5, 2.5, 3.5);
 
-        assertThat(al.setIfAbsent("$", Arrays.asList(4.5, 5.5), RJsonBucket.FpType.FP32)).isFalse();
+        assertThat(al.setIfAbsent("$", Arrays.asList(4.5, 5.5), FPHAType.FP32)).isFalse();
         result = al.get();
         assertThat(result).containsExactly(1.5, 2.5, 3.5);
     }
@@ -558,10 +559,10 @@ public class RedissonJsonBucketTest extends RedisDockerTest {
         RJsonBucket<List<Double>> al = redisson.getJsonBucket("test", new JacksonCodec<>(new TypeReference<List<Double>>(){}));
         List<Double> values = Arrays.asList(1.5, 2.5, 3.5);
 
-        assertThat(al.setIfExists("$", values, RJsonBucket.FpType.FP32)).isFalse();
+        assertThat(al.setIfExists("$", values, FPHAType.FP32)).isFalse();
 
-        al.set("$", values, RJsonBucket.FpType.FP32);
-        assertThat(al.setIfExists("$", Arrays.asList(4.5, 5.5), RJsonBucket.FpType.FP32)).isTrue();
+        al.set("$", values, FPHAType.FP32);
+        assertThat(al.setIfExists("$", Arrays.asList(4.5, 5.5), FPHAType.FP32)).isTrue();
         List<Double> result = al.get();
         assertThat(result).containsExactly(4.5, 5.5);
     }

--- a/redisson/src/test/java/org/redisson/RedissonJsonBucketTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonJsonBucketTest.java
@@ -530,5 +530,41 @@ public class RedissonJsonBucketTest extends RedisDockerTest {
         assertThat(n3).containsExactly("t1", "t2");
     }
 
+    @Test
+    public void testSetWithFpha() {
+        RJsonBucket<List<Double>> al = redisson.getJsonBucket("test", new JacksonCodec<>(new TypeReference<List<Double>>(){}));
+        List<Double> values = Arrays.asList(1.5, 2.5, 3.5);
+        al.set("$", values, RJsonBucket.FpType.FP32);
+        List<Double> result = al.get();
+        assertThat(result).containsExactly(1.5, 2.5, 3.5);
+    }
+
+    @Test
+    public void testSetIfAbsentWithFpha() {
+        RJsonBucket<List<Double>> al = redisson.getJsonBucket("test", new JacksonCodec<>(new TypeReference<List<Double>>(){}));
+        List<Double> values = Arrays.asList(1.5, 2.5, 3.5);
+
+        assertThat(al.setIfAbsent("$", values, RJsonBucket.FpType.FP32)).isTrue();
+        List<Double> result = al.get();
+        assertThat(result).containsExactly(1.5, 2.5, 3.5);
+
+        assertThat(al.setIfAbsent("$", Arrays.asList(4.5, 5.5), RJsonBucket.FpType.FP32)).isFalse();
+        result = al.get();
+        assertThat(result).containsExactly(1.5, 2.5, 3.5);
+    }
+
+    @Test
+    public void testSetIfExistsWithFpha() {
+        RJsonBucket<List<Double>> al = redisson.getJsonBucket("test", new JacksonCodec<>(new TypeReference<List<Double>>(){}));
+        List<Double> values = Arrays.asList(1.5, 2.5, 3.5);
+
+        assertThat(al.setIfExists("$", values, RJsonBucket.FpType.FP32)).isFalse();
+
+        al.set("$", values, RJsonBucket.FpType.FP32);
+        assertThat(al.setIfExists("$", Arrays.asList(4.5, 5.5), RJsonBucket.FpType.FP32)).isTrue();
+        List<Double> result = al.get();
+        assertThat(result).containsExactly(4.5, 5.5);
+    }
+
 
 }


### PR DESCRIPTION
Closes #7063

## Changes

- Added `FpType` enum (`BF16`, `FP16`, `FP32`, `FP64`) inside `RJsonBucket`
- Added `set(String path, Object value, FpType fpType)` method to `RJsonBucket` and `RJsonBucketAsync`
- Added `setIfAbsent(String path, Object value, FpType fpType)` method to `RJsonBucket` and `RJsonBucketAsync`
- Added `setIfExists(String path, Object value, FpType fpType)` method to `RJsonBucket` and `RJsonBucketAsync`
- Implemented all methods in `RedissonJsonBucket` by appending `FPHA <type>` to the `JSON.SET` command

All methods require **Redis 8.8.0 or higher**.