### PR TITLE
Add YIELD_DISTANCE_AS and SHARD_K_RATIO to FT.HYBRID KNN clause

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonSearch.java
+++ b/redisson/src/main/java/org/redisson/RedissonSearch.java
@@ -1223,6 +1223,14 @@ public class RedissonSearch implements RSearch {
                 knnArgs.add("EF_RUNTIME");
                 knnArgs.add(vsimParams.getEfRuntime());
             }
+            if (vsimParams.getYieldDistanceAs() != null) {
+                knnArgs.add("YIELD_DISTANCE_AS");
+                knnArgs.add(vsimParams.getYieldDistanceAs());
+            }
+            if (vsimParams.getShardKRatio() != null) {
+                knnArgs.add("SHARD_K_RATIO");
+                knnArgs.add(vsimParams.getShardKRatio());
+            }
             cmdArgs.add("KNN");
             cmdArgs.add(knnArgs.size());
             cmdArgs.addAll(knnArgs);

--- a/redisson/src/main/java/org/redisson/api/search/query/hybrid/VectorSimilarityNearestNeighbors.java
+++ b/redisson/src/main/java/org/redisson/api/search/query/hybrid/VectorSimilarityNearestNeighbors.java
@@ -31,4 +31,21 @@ public interface VectorSimilarityNearestNeighbors extends VectorSimilarity {
      */
     VectorSimilarity efRuntime(int efRuntime);
 
+    /**
+     * Sets the alias for the distance field returned in the result set.
+     *
+     * @param field distance field alias
+     * @return vector similarity for further configuration
+     */
+    VectorSimilarity yieldDistanceAs(String field);
+
+    /**
+     * Sets the ratio of the shard K parameter for distributed KNN search.
+     * Determines how many extra candidates to fetch per shard.
+     *
+     * @param ratio shard K ratio value
+     * @return vector similarity for further configuration
+     */
+    VectorSimilarity shardKRatio(double ratio);
+
 }

--- a/redisson/src/main/java/org/redisson/api/search/query/hybrid/VectorSimilarityParams.java
+++ b/redisson/src/main/java/org/redisson/api/search/query/hybrid/VectorSimilarityParams.java
@@ -33,7 +33,9 @@ public final class VectorSimilarityParams implements VectorSimilarityRange, Vect
     
     private Integer knnK;
     private Integer efRuntime;
-    
+    private String yieldDistanceAs;
+    private Double shardKRatio;
+
     private Double rangeRadius;
     private Double rangeEpsilon;
     
@@ -73,6 +75,18 @@ public final class VectorSimilarityParams implements VectorSimilarityRange, Vect
     }
 
     @Override
+    public VectorSimilarity yieldDistanceAs(String field) {
+        this.yieldDistanceAs = field;
+        return this;
+    }
+
+    @Override
+    public VectorSimilarity shardKRatio(double ratio) {
+        this.shardKRatio = ratio;
+        return this;
+    }
+
+    @Override
     public VectorSimilarityBasic scoreAlias(String value) {
         this.scoreAlias = value;
         return this;
@@ -102,6 +116,14 @@ public final class VectorSimilarityParams implements VectorSimilarityRange, Vect
 
     public Integer getEfRuntime() {
         return efRuntime;
+    }
+
+    public String getYieldDistanceAs() {
+        return yieldDistanceAs;
+    }
+
+    public Double getShardKRatio() {
+        return shardKRatio;
     }
 
     public Double getRangeRadius() {


### PR DESCRIPTION
## Summary
- Adds `yieldDistanceAs(String field)` to `VectorSimilarityNearestNeighbors` interface
- Adds `shardKRatio(double ratio)` to `VectorSimilarityNearestNeighbors` interface
- Implements both in `VectorSimilarityParams`
- Serializes both in `RedissonSearch` KNN argument builder

Closes #7066