### PR TITLE
Add shutdownAsync method to RedissonClient

### DIFF
--- a/redisson/src/main/java/org/redisson/Redisson.java
+++ b/redisson/src/main/java/org/redisson/Redisson.java
@@ -1322,7 +1322,7 @@ public final class Redisson implements RedissonClient {
 
     @Override
     public CompletableFuture<Void> shutdownAsync() {
-        return shutdownAsync(0, 2, TimeUnit.SECONDS);
+        return shutdownAsync(Duration.ZERO, Duration.ofSeconds(2));
     }
 
     @Override
@@ -1332,9 +1332,9 @@ public final class Redisson implements RedissonClient {
     }
 
     @Override
-    public CompletableFuture<Void> shutdownAsync(long quietPeriod, long timeout, TimeUnit unit) {
+    public CompletableFuture<Void> shutdownAsync(Duration quietPeriod, Duration timeout) {
         writeBehindService.stop();
-        return connectionManager.shutdownAsync(quietPeriod, timeout, unit);
+        return connectionManager.shutdownAsync(quietPeriod.toNanos(), timeout.toNanos(), TimeUnit.NANOSECONDS);
     }
 
     @Override

--- a/redisson/src/main/java/org/redisson/Redisson.java
+++ b/redisson/src/main/java/org/redisson/Redisson.java
@@ -43,6 +43,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
@@ -1319,11 +1320,21 @@ public final class Redisson implements RedissonClient {
         connectionManager.shutdown();
     }
 
+    @Override
+    public CompletableFuture<Void> shutdownAsync() {
+        return shutdownAsync(0, 2, TimeUnit.SECONDS);
+    }
 
     @Override
     public void shutdown(long quietPeriod, long timeout, TimeUnit unit) {
         writeBehindService.stop();
         connectionManager.shutdown(quietPeriod, timeout, unit);
+    }
+
+    @Override
+    public CompletableFuture<Void> shutdownAsync(long quietPeriod, long timeout, TimeUnit unit) {
+        writeBehindService.stop();
+        return connectionManager.shutdownAsync(quietPeriod, timeout, unit);
     }
 
     @Override

--- a/redisson/src/main/java/org/redisson/api/RedissonClient.java
+++ b/redisson/src/main/java/org/redisson/api/RedissonClient.java
@@ -22,6 +22,7 @@ import org.redisson.client.codec.Codec;
 import org.redisson.codec.JsonCodec;
 import org.redisson.config.Config;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -2238,7 +2239,7 @@ public interface RedissonClient {
     /**
      * Shutdown Redisson instance asynchronously but <b>NOT</b> Redis server
      * 
-     * This equates to invoke shutdownAsync(0, 2, TimeUnit.SECONDS);
+     * This equates to invoke shutdownAsync(Duration.ZERO, Duration.ofSeconds(2));
      */
     CompletableFuture<Void> shutdownAsync();
 
@@ -2266,9 +2267,8 @@ public interface RedissonClient {
      * @param quietPeriod the quiet period as described in the documentation
      * @param timeout     the maximum amount of time to wait until the executor is {@linkplain #shutdown()}
      *                    regardless if a task was submitted during the quiet period
-     * @param unit        the unit of {@code quietPeriod} and {@code timeout}
      */
-    CompletableFuture<Void> shutdownAsync(long quietPeriod, long timeout, TimeUnit unit);
+    CompletableFuture<Void> shutdownAsync(Duration quietPeriod, Duration timeout);
 
     /**
      * Allows to get configuration provided

--- a/redisson/src/main/java/org/redisson/api/RedissonClient.java
+++ b/redisson/src/main/java/org/redisson/api/RedissonClient.java
@@ -23,6 +23,7 @@ import org.redisson.codec.JsonCodec;
 import org.redisson.config.Config;
 
 import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -2235,6 +2236,13 @@ public interface RedissonClient {
     void shutdown();
     
     /**
+     * Shutdown Redisson instance asynchronously but <b>NOT</b> Redis server
+     * 
+     * This equates to invoke shutdownAsync(0, 2, TimeUnit.SECONDS);
+     */
+    CompletableFuture<Void> shutdownAsync();
+
+    /**
      * Shuts down Redisson instance but <b>NOT</b> Redis server
      * 
      * Shutdown ensures that no tasks are submitted for <i>'the quiet period'</i>
@@ -2247,6 +2255,20 @@ public interface RedissonClient {
      * @param unit        the unit of {@code quietPeriod} and {@code timeout}
      */
     void shutdown(long quietPeriod, long timeout, TimeUnit unit);
+
+    /**
+     * Shuts down Redisson instance asynchronously but <b>NOT</b> Redis server
+     * 
+     * Shutdown ensures that no tasks are submitted for <i>'the quiet period'</i>
+     * (usually a couple seconds) before it shuts itself down.  If a task is submitted during the quiet period,
+     * it is guaranteed to be accepted and the quiet period will start over.
+     * 
+     * @param quietPeriod the quiet period as described in the documentation
+     * @param timeout     the maximum amount of time to wait until the executor is {@linkplain #shutdown()}
+     *                    regardless if a task was submitted during the quiet period
+     * @param unit        the unit of {@code quietPeriod} and {@code timeout}
+     */
+    CompletableFuture<Void> shutdownAsync(long quietPeriod, long timeout, TimeUnit unit);
 
     /**
      * Allows to get configuration provided

--- a/redisson/src/main/java/org/redisson/connection/ClusterConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/ClusterConnectionManager.java
@@ -1084,6 +1084,14 @@ public class ClusterConnectionManager extends MasterSlaveConnectionManager {
         super.shutdown(quietPeriod, timeout, unit);
     }
 
+    @Override
+    public CompletableFuture<Void> shutdownAsync(long quietPeriod, long timeout, TimeUnit unit) {
+        if (monitorFuture != null) {
+            monitorFuture.cancel();
+        }
+        return closeNodeConnectionsAsync().thenCompose(v -> super.shutdownAsync(quietPeriod, timeout, unit));
+    }
+
     private Collection<ClusterPartition> getLastPartitions() {
         return lastUri2Partition.values().stream().collect(Collectors.toMap(e -> e.getNodeId(), Function.identity(),
                                                                 BinaryOperator.maxBy(Comparator.comparing(e -> e.getTime())))).values();

--- a/redisson/src/main/java/org/redisson/connection/ConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/ConnectionManager.java
@@ -26,6 +26,7 @@ import org.redisson.pubsub.PublishSubscribeService;
 
 import java.net.InetSocketAddress;
 import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -70,6 +71,8 @@ public interface ConnectionManager {
     void shutdown();
 
     void shutdown(long quietPeriod, long timeout, TimeUnit unit);
+
+    CompletableFuture<Void> shutdownAsync(long quietPeriod, long timeout, TimeUnit unit);
     
     ServiceManager getServiceManager();
 

--- a/redisson/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
@@ -667,6 +667,9 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
                     serviceManager.getTimer().stop();
                     if (serviceManager.getCfg().getEventLoopGroup() == null) {
                         long quietPeriodNanos = unit.toNanos(quietPeriod);
+                        if (timeoutInNanos < quietPeriodNanos) {
+                            quietPeriodNanos = 0;
+                        }
                         io.netty.util.concurrent.Future<?> nettyFuture = serviceManager.getGroup()
                                 .shutdownGracefully(quietPeriodNanos, timeoutInNanos, TimeUnit.NANOSECONDS);
                         CompletableFuture<Void> cf = new CompletableFuture<>();

--- a/redisson/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
@@ -92,6 +92,13 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
                 .forEach(f -> f.toCompletableFuture().join());
     }
 
+    protected CompletableFuture<Void> closeNodeConnectionsAsync() {
+        List<CompletableFuture<Void>> futures = nodeConnections.values().stream()
+                .map(c -> c.getRedisClient().shutdownAsync().toCompletableFuture())
+                .collect(Collectors.toList());
+        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+    }
+
     protected void closeNodeConnection(RedisConnection conn) {
         if (nodeConnections.values().removeAll(Arrays.asList(conn))) {
             conn.closeAsync();
@@ -615,6 +622,65 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
     @Override
     public void shutdown() {
         shutdown(0, 10, TimeUnit.SECONDS); //default netty value
+    }
+
+    @Override
+    public CompletableFuture<Void> shutdownAsync(long quietPeriod, long timeout, TimeUnit unit) {
+        if (dnsMonitor != null) {
+            dnsMonitor.stop();
+        }
+        long timeoutInNanos = unit.toNanos(timeout);
+
+        serviceManager.close();
+        serviceManager.getConnectionWatcher().stop();
+        serviceManager.getResolverGroup().close();
+
+        return serviceManager.shutdownFuturesAsync(timeout, unit)
+                .thenCompose(v -> {
+                    if (!isInitialized()) {
+                        return CompletableFuture.completedFuture(null);
+                    }
+                    List<CompletableFuture<Void>> futures = new ArrayList<>();
+                    for (MasterSlaveEntry entry : getEntrySet()) {
+                        futures.add(entry.shutdownAsync());
+                    }
+                    CompletableFuture<Void> allEntries = CompletableFuture.allOf(
+                            futures.toArray(new CompletableFuture[0]));
+                    serviceManager.newTimeout(t -> allEntries.completeExceptionally(new TimeoutException()),
+                            timeoutInNanos, TimeUnit.NANOSECONDS);
+                    return allEntries.exceptionally(e -> null);
+                })
+                .thenCompose(v -> {
+                    if (serviceManager.getCfg().getExecutor() == null) {
+                        serviceManager.getExecutor().shutdown();
+                        return CompletableFuture.runAsync(() -> {
+                            try {
+                                serviceManager.getExecutor().awaitTermination(timeoutInNanos, TimeUnit.NANOSECONDS);
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                            }
+                        });
+                    }
+                    return CompletableFuture.completedFuture(null);
+                })
+                .thenCompose(v -> {
+                    serviceManager.getTimer().stop();
+                    if (serviceManager.getCfg().getEventLoopGroup() == null) {
+                        long quietPeriodNanos = unit.toNanos(quietPeriod);
+                        io.netty.util.concurrent.Future<?> nettyFuture = serviceManager.getGroup()
+                                .shutdownGracefully(quietPeriodNanos, timeoutInNanos, TimeUnit.NANOSECONDS);
+                        CompletableFuture<Void> cf = new CompletableFuture<>();
+                        nettyFuture.addListener(f -> {
+                            if (f.isSuccess()) {
+                                cf.complete(null);
+                            } else {
+                                cf.completeExceptionally(f.cause());
+                            }
+                        });
+                        return cf;
+                    }
+                    return CompletableFuture.completedFuture(null);
+                });
     }
 
     @Override

--- a/redisson/src/main/java/org/redisson/connection/ReplicatedConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/ReplicatedConnectionManager.java
@@ -291,4 +291,12 @@ public class ReplicatedConnectionManager extends MasterSlaveConnectionManager {
         closeNodeConnections();
         super.shutdown(quietPeriod, timeout, unit);
     }
+
+    @Override
+    public CompletableFuture<Void> shutdownAsync(long quietPeriod, long timeout, TimeUnit unit) {
+        if (monitorFuture != null) {
+            monitorFuture.cancel();
+        }
+        return closeNodeConnectionsAsync().thenCompose(v -> super.shutdownAsync(quietPeriod, timeout, unit));
+    }
 }

--- a/redisson/src/main/java/org/redisson/connection/SentinelConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/SentinelConnectionManager.java
@@ -711,6 +711,18 @@ public class SentinelConnectionManager extends MasterSlaveConnectionManager {
         super.shutdown(quietPeriod, timeout, unit);
     }
 
+    @Override
+    public CompletableFuture<Void> shutdownAsync(long quietPeriod, long timeout, TimeUnit unit) {
+        if (monitorFuture != null) {
+            monitorFuture.cancel();
+        }
+        List<CompletableFuture<Void>> futures = sentinels.values().stream()
+                .map(s -> s.shutdownAsync().toCompletableFuture())
+                .collect(Collectors.toList());
+        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+                .thenCompose(v -> super.shutdownAsync(quietPeriod, timeout, unit));
+    }
+
     private RedisURI applyNatMap(RedisURI address) {
         RedisURI result = cfg.getNatMapper().map(address);
         if (!result.equals(address)) {

--- a/redisson/src/main/java/org/redisson/connection/ServiceManager.java
+++ b/redisson/src/main/java/org/redisson/connection/ServiceManager.java
@@ -413,6 +413,20 @@ public final class ServiceManager {
         lastFutures.clear();
     }
 
+    public CompletableFuture<Void> shutdownFuturesAsync(long timeout, TimeUnit unit) {
+        CompletableFuture<?>[] array = StreamSupport.stream(lastFutures.spliterator(), false)
+                .toArray(CompletableFuture[]::new);
+        CompletableFuture<Void> allFutures = CompletableFuture.allOf(array);
+        Timeout timeoutHandle = newTimeout(t -> allFutures.completeExceptionally(new TimeoutException()), timeout, unit);
+        return allFutures
+                .whenComplete((v, e) -> timeoutHandle.cancel())
+                .exceptionally(e -> null)
+                .thenRun(() -> {
+                    lastFutures.forEach(f -> f.completeExceptionally(new RedissonShutdownException("Redisson is shutdown")));
+                    lastFutures.clear();
+                });
+    }
+
     public void close() {
         shutdownLatch.set(true);
     }


### PR DESCRIPTION
## Summary

- Adds `shutdownAsync()` — delegates to `shutdownAsync(0, 2, TimeUnit.SECONDS)`
- Adds `shutdownAsync(long quietPeriod, long timeout, TimeUnit unit)` — truly async shutdown that never blocks the caller thread

## What changed from previous attempt

The previous implementation wrapped the blocking `shutdown()` in `CompletableFuture.runAsync()`, which merely offloaded the blocking call to a ForkJoinPool thread. This version pushes the async path down the full connection manager stack:

| Component | Before | After |
|---|---|---|
| `serviceManager.shutdownFutures()` | `future.get(timeout)` — blocks | `HashedWheelTimer` + `exceptionally` — non-blocking |
| `entry.shutdownAsync()` results | `CompletableFuture.allOf().get()` — blocks | `allOf()` + timer-based cancel — non-blocking |
| `executor.awaitTermination()` | Blocks caller thread | Runs on `ForkJoinPool.commonPool()` (separate from shutting-down executor) |
| Netty `shutdownGracefully()` | `.syncUninterruptibly()` — blocks | `.addListener()` — non-blocking |

## Files changed

- `ConnectionManager` — added `shutdownAsync(long, long, TimeUnit)` to interface
- `ServiceManager` — added `shutdownFuturesAsync()` (timer-based, non-blocking)
- `MasterSlaveConnectionManager` — implemented `shutdownAsync()` + `closeNodeConnectionsAsync()`
- `ClusterConnectionManager`, `ReplicatedConnectionManager`, `SentinelConnectionManager` — overridden `shutdownAsync()` to handle pre-shutdown steps asynchronously before delegating to `super`

Closes #698