### PR TITLE
Add field name to map listeners

### DIFF
--- a/docs/data-and-services/collections.md
+++ b/docs/data-and-services/collections.md
@@ -471,8 +471,8 @@ Redisson allows binding listeners per `RMap` object. This requires the `notify-k
 |Listener class name|Event description | Valkey or Redis<br/>`notify-keyspace-events` value|
 |:--:|:--:|:--:|
 |org.redisson.api.listener.TrackingListener|Entry created/removed/updated after read operation| - |
-|org.redisson.api.listener.MapPutListener|Entry created/updated|Eh|
-|org.redisson.api.listener.MapRemoveListener|Entry removed|Eh|
+|org.redisson.api.listener.MapPutListener|Entry created/updated|Eh or Th|
+|org.redisson.api.listener.MapRemoveListener|Entry removed|Eh or Th|
 |org.redisson.api.ExpiredObjectListener|`RMap` object expired|Ex|
 |org.redisson.api.DeletedObjectListener|`RMap` object deleted|Eg|
 
@@ -496,14 +496,14 @@ int listenerId = map.addListener(new ExpiredObjectListener() {
 
 int listenerId = map.addListener(new MapPutListener() {
      @Override
-     public void onPut(String name) {
+     public void onPut(String name, String fieldName) {
         // ...
      }
 });
 
 int listenerId = map.addListener(new MapRemoveListener() {
      @Override
-     public void onRemove(String name) {
+     public void onRemove(String name, String fieldName) {
         // ...
      }
 });
@@ -776,8 +776,8 @@ Redisson allows binding listeners per `RSetMultimap` or `RListMultimap` object. 
 |org.redisson.api.DeletedObjectListener|`RSetMultimap` object deleted| Eg|
 |org.redisson.api.listener.SetAddListener|Element added to entry| Es|
 |org.redisson.api.listener.SetRemoveListener|Element removed from entry| Es|
-|org.redisson.api.listener.MapPutListener|Entry created|Eh|
-|org.redisson.api.listener.MapRemoveListener|Entry removed|Eh|
+|org.redisson.api.listener.MapPutListener|Entry created|Eh or Th|
+|org.redisson.api.listener.MapRemoveListener|Entry removed|Eh or Th|
 
 `RListMultimap` listeners:
 
@@ -787,8 +787,8 @@ Redisson allows binding listeners per `RSetMultimap` or `RListMultimap` object. 
 |org.redisson.api.DeletedObjectListener|`RListMultimap` object deleted| Eg|
 |org.redisson.api.listener.ListAddListener|Element added to entry| Es|
 |org.redisson.api.listener.ListRemoveListener|Element removed from entry| Es|
-|org.redisson.api.listener.MapPutListener|Entry created|Eh|
-|org.redisson.api.listener.MapRemoveListener|Entry removed|Eh|
+|org.redisson.api.listener.MapPutListener|Entry created|Eh or Th|
+|org.redisson.api.listener.MapRemoveListener|Entry removed|Eh or Th|
 
 Usage example:
 
@@ -797,7 +797,7 @@ RListMultimap<Integer, Integer> lmap = redisson.getListMultimap("mymap");
 
 int listenerId = lmap.addListener(new MapPutListener() {
      @Override
-     public void onPut(String name) {
+     public void onPut(String name, String fieldName) {
         // ...
      }
 });

--- a/redisson/src/main/java/org/redisson/RedissonMap.java
+++ b/redisson/src/main/java/org/redisson/RedissonMap.java
@@ -1885,13 +1885,16 @@ public class RedissonMap<K, V> extends RedissonExpirable implements RMap<K, V> {
     @Override
     public int addListener(ObjectListener listener) {
         if (listener instanceof MapPutListener) {
-            return addListener("__keyevent@*:hset", (MapPutListener) listener, MapPutListener::onPut);
+            return addMapFieldListener("__subkeyevent@*:hset", "__keyevent@*:hset",
+                    (MapPutListener) listener, MapPutListener::onPut);
         }
         if (listener instanceof MapIncrListener) {
-            return addListener("__keyevent@*:hincrbyfloat", (MapIncrListener) listener, MapIncrListener::onIncrement);
+            return addMapFieldListener("__subkeyevent@*:hincrbyfloat", "__keyevent@*:hincrbyfloat",
+                    (MapIncrListener) listener, MapIncrListener::onIncrement);
         }
         if (listener instanceof MapRemoveListener) {
-            return addListener("__keyevent@*:hdel", (MapRemoveListener) listener, MapRemoveListener::onRemove);
+            return addMapFieldListener("__subkeyevent@*:hdel", "__keyevent@*:hdel",
+                    (MapRemoveListener) listener, MapRemoveListener::onRemove);
         }
         if (listener instanceof TrackingListener) {
             return addTrackingListener((TrackingListener) listener);
@@ -1903,13 +1906,16 @@ public class RedissonMap<K, V> extends RedissonExpirable implements RMap<K, V> {
     @Override
     public RFuture<Integer> addListenerAsync(ObjectListener listener) {
         if (listener instanceof MapPutListener) {
-            return addListenerAsync("__keyevent@*:hset", (MapPutListener) listener, MapPutListener::onPut);
+            return addMapFieldListenerAsync("__subkeyevent@*:hset", "__keyevent@*:hset",
+                    (MapPutListener) listener, MapPutListener::onPut);
         }
         if (listener instanceof MapIncrListener) {
-            return addListenerAsync("__keyevent@*:hincrbyfloat", (MapIncrListener) listener, MapIncrListener::onIncrement);
+            return addMapFieldListenerAsync("__subkeyevent@*:hincrbyfloat", "__keyevent@*:hincrbyfloat",
+                    (MapIncrListener) listener, MapIncrListener::onIncrement);
         }
         if (listener instanceof MapRemoveListener) {
-            return addListenerAsync("__keyevent@*:hdel", (MapRemoveListener) listener, MapRemoveListener::onRemove);
+            return addMapFieldListenerAsync("__subkeyevent@*:hdel", "__keyevent@*:hdel",
+                    (MapRemoveListener) listener, MapRemoveListener::onRemove);
         }
         if (listener instanceof TrackingListener) {
             return addTrackingListenerAsync((TrackingListener) listener);
@@ -1921,13 +1927,18 @@ public class RedissonMap<K, V> extends RedissonExpirable implements RMap<K, V> {
     @Override
     public void removeListener(int listenerId) {
         removeTrackingListener(listenerId);
-        removeListener(listenerId, "__keyevent@*:hset", "__keyevent@*:hincrbyfloat", "__keyevent@*:hdel");
+        removeListener(listenerId, "__subkeyevent@*:hset", "__keyevent@*:hset",
+                "__subkeyevent@*:hincrbyfloat", "__keyevent@*:hincrbyfloat",
+                "__subkeyevent@*:hdel", "__keyevent@*:hdel");
         super.removeListener(listenerId);
     }
 
     @Override
     public RFuture<Void> removeListenerAsync(int listenerId) {
-        return removeListenerAsync(removeTrackingListenerAsync(listenerId), listenerId, "__keyevent@*:hset", "__keyevent@*:hdel");
+        return removeListenerAsync(removeTrackingListenerAsync(listenerId), listenerId,
+                "__subkeyevent@*:hset", "__keyevent@*:hset",
+                "__subkeyevent@*:hincrbyfloat", "__keyevent@*:hincrbyfloat",
+                "__subkeyevent@*:hdel", "__keyevent@*:hdel");
     }
 
 }

--- a/redisson/src/main/java/org/redisson/RedissonMapCacheNative.java
+++ b/redisson/src/main/java/org/redisson/RedissonMapCacheNative.java
@@ -665,10 +665,12 @@ public class RedissonMapCacheNative<K, V> extends RedissonMap<K, V> implements R
     @Override
     public int addListener(ObjectListener listener) {
         if (listener instanceof MapExpiredListener) {
-            return addListener("__keyevent@*:hexpired", (MapExpiredListener) listener, MapExpiredListener::onExpired);
+            return addMapFieldListener("__subkeyevent@*:hexpired", "__keyevent@*:hexpired",
+                    (MapExpiredListener) listener, MapExpiredListener::onExpired);
         }
         if (listener instanceof MapClearExpireListener) {
-            return addListener("__keyevent@*:hpersist", (MapClearExpireListener) listener, MapClearExpireListener::onClearExpire);
+            return addMapFieldListener("__subkeyevent@*:hpersist", "__keyevent@*:hpersist",
+                    (MapClearExpireListener) listener, MapClearExpireListener::onClearExpire);
         }
 
         return super.addListener(listener);
@@ -677,10 +679,12 @@ public class RedissonMapCacheNative<K, V> extends RedissonMap<K, V> implements R
     @Override
     public RFuture<Integer> addListenerAsync(ObjectListener listener) {
         if (listener instanceof MapExpiredListener) {
-            return addListenerAsync("__keyevent@*:hexpired", (MapExpiredListener) listener, MapExpiredListener::onExpired);
+            return addMapFieldListenerAsync("__subkeyevent@*:hexpired", "__keyevent@*:hexpired",
+                    (MapExpiredListener) listener, MapExpiredListener::onExpired);
         }
         if (listener instanceof MapClearExpireListener) {
-            return addListenerAsync("__keyevent@*:hpersist", (MapClearExpireListener) listener, MapClearExpireListener::onClearExpire);
+            return addMapFieldListenerAsync("__subkeyevent@*:hpersist", "__keyevent@*:hpersist",
+                    (MapClearExpireListener) listener, MapClearExpireListener::onClearExpire);
         }
 
         return super.addListenerAsync(listener);
@@ -688,13 +692,16 @@ public class RedissonMapCacheNative<K, V> extends RedissonMap<K, V> implements R
 
     @Override
     public void removeListener(int listenerId) {
-        removeListener(listenerId, "__keyevent@*:hexpired", "__keyevent@*:hpersist");
+        removeListener(listenerId, "__subkeyevent@*:hexpired", "__keyevent@*:hexpired",
+                "__subkeyevent@*:hpersist", "__keyevent@*:hpersist");
         super.removeListener(listenerId);
     }
 
     @Override
     public RFuture<Void> removeListenerAsync(int listenerId) {
-        return removeListenerAsync(super.removeListenerAsync(listenerId), listenerId, "__keyevent@*:hexpired", "__keyevent@*:hpersist");
+        return removeListenerAsync(super.removeListenerAsync(listenerId), listenerId,
+                "__subkeyevent@*:hexpired", "__keyevent@*:hexpired",
+                "__subkeyevent@*:hpersist", "__keyevent@*:hpersist");
     }
 
     @Override

--- a/redisson/src/main/java/org/redisson/RedissonMultimap.java
+++ b/redisson/src/main/java/org/redisson/RedissonMultimap.java
@@ -582,10 +582,12 @@ public abstract class RedissonMultimap<K, V> extends RedissonExpirable implement
     @Override
     public int addListener(ObjectListener listener) {
         if (listener instanceof MapPutListener) {
-            return addListener("__keyevent@*:hset", (MapPutListener) listener, MapPutListener::onPut);
+            return addMapFieldListener("__subkeyevent@*:hset", "__keyevent@*:hset",
+                    (MapPutListener) listener, MapPutListener::onPut);
         }
         if (listener instanceof MapRemoveListener) {
-            return addListener("__keyevent@*:hdel", (MapRemoveListener) listener, MapRemoveListener::onRemove);
+            return addMapFieldListener("__subkeyevent@*:hdel", "__keyevent@*:hdel",
+                    (MapRemoveListener) listener, MapRemoveListener::onRemove);
         }
 
         return super.addListener(listener);
@@ -594,10 +596,12 @@ public abstract class RedissonMultimap<K, V> extends RedissonExpirable implement
     @Override
     public RFuture<Integer> addListenerAsync(ObjectListener listener) {
         if (listener instanceof MapPutListener) {
-            return addListenerAsync("__keyevent@*:hset", (MapPutListener) listener, MapPutListener::onPut);
+            return addMapFieldListenerAsync("__subkeyevent@*:hset", "__keyevent@*:hset",
+                    (MapPutListener) listener, MapPutListener::onPut);
         }
         if (listener instanceof MapRemoveListener) {
-            return addListenerAsync("__keyevent@*:hdel", (MapRemoveListener) listener, MapRemoveListener::onRemove);
+            return addMapFieldListenerAsync("__subkeyevent@*:hdel", "__keyevent@*:hdel",
+                    (MapRemoveListener) listener, MapRemoveListener::onRemove);
         }
 
         return super.addListenerAsync(listener);
@@ -605,13 +609,15 @@ public abstract class RedissonMultimap<K, V> extends RedissonExpirable implement
 
     @Override
     public void removeListener(int listenerId) {
-        removeListener(listenerId, "__keyevent@*:hset", "__keyevent@*:hdel");
+        removeListener(listenerId, "__subkeyevent@*:hset", "__keyevent@*:hset",
+                "__subkeyevent@*:hdel", "__keyevent@*:hdel");
         super.removeListener(listenerId);
     }
 
     @Override
     public RFuture<Void> removeListenerAsync(int listenerId) {
-        return removeListenerAsync(listenerId, "__keyevent@*:hset", "__keyevent@*:hdel");
+        return removeListenerAsync(listenerId, "__subkeyevent@*:hset", "__keyevent@*:hset",
+                "__subkeyevent@*:hdel", "__keyevent@*:hdel");
     }
 
 

--- a/redisson/src/main/java/org/redisson/RedissonObject.java
+++ b/redisson/src/main/java/org/redisson/RedissonObject.java
@@ -20,6 +20,7 @@ import io.netty.util.ReferenceCountUtil;
 import org.redisson.api.*;
 import org.redisson.api.listener.TrackingListener;
 import org.redisson.client.ChannelName;
+import org.redisson.client.RedisPubSubListener;
 import org.redisson.client.codec.ByteArrayCodec;
 import org.redisson.client.codec.Codec;
 import org.redisson.client.codec.StringCodec;
@@ -33,11 +34,16 @@ import org.redisson.misc.CompletableFutureWrapper;
 import org.redisson.misc.Hash;
 import org.redisson.pubsub.PublishSubscribeService;
 
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -53,10 +59,64 @@ import java.util.stream.StreamSupport;
  */
 public abstract class RedissonObject implements RObject {
 
+    private static final long MAP_FIELD_EVENT_DEDUPLICATION_TIMEOUT = 50;
+    private static final long MAP_FIELD_EVENT_DEDUPLICATION_TIMEOUT_NANOS =
+            TimeUnit.MILLISECONDS.toNanos(MAP_FIELD_EVENT_DEDUPLICATION_TIMEOUT);
+
     protected CommandAsyncExecutor commandExecutor;
     protected String name;
     protected final Codec codec;
     private final Map<String, Collection<Integer>> listeners = new ConcurrentHashMap<>();
+
+    @FunctionalInterface
+    protected interface MapFieldListener<T extends ObjectListener> {
+
+        void accept(T listener, String name, String fieldName);
+
+    }
+
+    private static final class SubkeyEventMessage {
+
+        private final String name;
+        private final List<String> fieldNames;
+
+        private SubkeyEventMessage(String name, List<String> fieldNames) {
+            this.name = name;
+            this.fieldNames = fieldNames;
+        }
+
+    }
+
+    private static final class MapFieldEvent {
+
+        private final long sequence;
+        private final long timestamp;
+
+        private MapFieldEvent(long sequence, long timestamp) {
+            this.sequence = sequence;
+            this.timestamp = timestamp;
+        }
+
+    }
+
+    private static final class MapFieldListenerContext<T extends ObjectListener> {
+
+        private final T listener;
+        private final MapFieldListener<T> consumer;
+        private final String keyEventName;
+        private final AtomicInteger listenerId = new AtomicInteger();
+        private final AtomicBoolean keyEventUnsubscribed = new AtomicBoolean();
+        private final AtomicLong sequence = new AtomicLong();
+        private final ConcurrentMap<String, MapFieldEvent> keyEvents = new ConcurrentHashMap<>();
+        private final ConcurrentMap<String, MapFieldEvent> subkeyEvents = new ConcurrentHashMap<>();
+
+        private MapFieldListenerContext(T listener, MapFieldListener<T> consumer, String keyEventName) {
+            this.listener = listener;
+            this.consumer = consumer;
+            this.keyEventName = keyEventName;
+        }
+
+    }
 
     public RedissonObject(Codec codec, CommandAsyncExecutor commandExecutor, String name) {
         this.codec = commandExecutor.getServiceManager().getCodec(codec);
@@ -806,6 +866,25 @@ public abstract class RedissonObject implements RObject {
         return id;
     }
 
+    protected final <T extends ObjectListener> int addMapFieldListener(String subkeyEventName, String keyEventName,
+                                                                       T listener, MapFieldListener<T> consumer) {
+        MapFieldListenerContext<T> context = new MapFieldListenerContext<>(listener, consumer, keyEventName);
+        RedisPubSubListener<byte[]> pubSubListener = createMapFieldPubSubListener(subkeyEventName, keyEventName,
+                context);
+        int id = System.identityHashCode(pubSubListener);
+        context.listenerId.set(id);
+
+        CompletableFuture<?> subkeyFuture = getSubscribeService().psubscribe(new ChannelName(subkeyEventName),
+                ByteArrayCodec.INSTANCE, pubSubListener);
+        CompletableFuture<?> keyFuture = getSubscribeService().psubscribe(new ChannelName(keyEventName),
+                ByteArrayCodec.INSTANCE, pubSubListener);
+        commandExecutor.get(CompletableFuture.allOf(subkeyFuture, keyFuture));
+
+        addListenerId(subkeyEventName, id);
+        addListenerId(keyEventName, id);
+        return id;
+    }
+
     protected <T extends ObjectListener> RFuture<Integer> addListenerAsync(String name, T listener,
                                                                            BiConsumer<T, String> consumer) {
         return addListenerAsync(name, listener, consumer, m -> m.equals(getRawName()));
@@ -825,6 +904,184 @@ public abstract class RedissonObject implements RObject {
             return id;
         });
         return new CompletableFutureWrapper<>(r);
+    }
+
+    protected final <T extends ObjectListener> RFuture<Integer> addMapFieldListenerAsync(String subkeyEventName, String keyEventName,
+                                                                                         T listener, MapFieldListener<T> consumer) {
+        MapFieldListenerContext<T> context = new MapFieldListenerContext<>(listener, consumer, keyEventName);
+        RedisPubSubListener<byte[]> pubSubListener = createMapFieldPubSubListener(subkeyEventName, keyEventName,
+                context);
+        int listenerId = System.identityHashCode(pubSubListener);
+        context.listenerId.set(listenerId);
+
+        CompletableFuture<?> subkeyFuture = getSubscribeService().psubscribe(new ChannelName(subkeyEventName),
+                ByteArrayCodec.INSTANCE, pubSubListener);
+        CompletableFuture<?> keyFuture = getSubscribeService().psubscribe(new ChannelName(keyEventName),
+                ByteArrayCodec.INSTANCE, pubSubListener);
+        CompletableFuture<Integer> f = CompletableFuture.allOf(subkeyFuture, keyFuture).thenApply(r -> {
+            addListenerId(subkeyEventName, listenerId);
+            addListenerId(keyEventName, listenerId);
+            return listenerId;
+        });
+        return new CompletableFutureWrapper<>(f);
+    }
+
+    private <T extends ObjectListener> RedisPubSubListener<byte[]> createMapFieldPubSubListener(String subkeyEventName,
+                                                                                                 String keyEventName,
+                                                                                                 MapFieldListenerContext<T> context) {
+        return new RedisPubSubListener<byte[]>() {
+            @Override
+            public void onMessage(CharSequence channel, byte[] msg) {
+            }
+
+            @Override
+            public void onPatternMessage(CharSequence pattern, CharSequence channel, byte[] msg) {
+                String patternName = pattern.toString();
+                if (subkeyEventName.equals(patternName) || keyEventName.equals(patternName)) {
+                    onMapFieldMessage(channel, msg, context);
+                }
+            }
+        };
+    }
+
+    private <T extends ObjectListener> void onMapFieldMessage(CharSequence channel, byte[] msg,
+                                                              MapFieldListenerContext<T> context) {
+        if (!channel.toString().startsWith("__subkeyevent@")) {
+            onKeyEventMapFieldMessage(channel, msg, context);
+            return;
+        }
+
+        SubkeyEventMessage message = decodeSubkeyEventMessage(msg);
+        if (message != null && message.name.equals(getRawName())) {
+            String eventName = getEventName(channel);
+            long sequence = context.sequence.incrementAndGet();
+            long timestamp = System.nanoTime();
+            context.subkeyEvents.put(eventName, new MapFieldEvent(sequence, timestamp));
+            if (isDuplicateEvent(context.keyEvents.get(eventName), sequence, timestamp)) {
+                removeKeyEventMapFieldListener(context);
+            }
+            message.fieldNames.forEach(fieldName -> context.consumer.accept(context.listener, message.name, fieldName));
+        }
+    }
+
+    private <T extends ObjectListener> void onKeyEventMapFieldMessage(CharSequence channel, byte[] msg,
+                                                                      MapFieldListenerContext<T> context) {
+        String name = new String(msg, StandardCharsets.UTF_8);
+        if (!name.equals(getRawName())) {
+            return;
+        }
+
+        String eventName = getEventName(channel);
+        long sequence = context.sequence.incrementAndGet();
+        long timestamp = System.nanoTime();
+        context.keyEvents.put(eventName, new MapFieldEvent(sequence, timestamp));
+        if (isDuplicateEvent(context.subkeyEvents.get(eventName), sequence, timestamp)) {
+            removeKeyEventMapFieldListener(context);
+            return;
+        }
+
+        getServiceManager().newTimeout(timeout -> {
+            if (!isDuplicateEvent(context.subkeyEvents.get(eventName), sequence, timestamp)) {
+                context.consumer.accept(context.listener, name, null);
+            }
+        }, MAP_FIELD_EVENT_DEDUPLICATION_TIMEOUT, TimeUnit.MILLISECONDS);
+    }
+
+    private void removeKeyEventMapFieldListener(MapFieldListenerContext<?> context) {
+        if (!context.keyEventUnsubscribed.compareAndSet(false, true)) {
+            return;
+        }
+
+        CompletableFuture<Void> f = getSubscribeService().removeListenerAsync(PubSubType.PUNSUBSCRIBE,
+                ChannelName.newList(context.keyEventName), context.listenerId.get());
+        f.whenComplete((r, e) -> {
+            if (e == null) {
+                removeListenerId(context.keyEventName, context.listenerId.get());
+                return;
+            }
+            context.keyEventUnsubscribed.set(false);
+        });
+    }
+
+    private static boolean isDuplicateEvent(MapFieldEvent event, long sequence, long timestamp) {
+        return event != null
+                && event.sequence != sequence
+                && Math.abs(timestamp - event.timestamp) <= MAP_FIELD_EVENT_DEDUPLICATION_TIMEOUT_NANOS;
+    }
+
+    private static String getEventName(CharSequence channel) {
+        String name = channel.toString();
+        int index = name.lastIndexOf(':');
+        if (index == -1 || index == name.length() - 1) {
+            return name;
+        }
+        return name.substring(index + 1);
+    }
+
+    private static SubkeyEventMessage decodeSubkeyEventMessage(byte[] msg) {
+        int keyLengthEndIndex = indexOf(msg, (byte) ':', 0);
+        int keyLength = parseLength(msg, 0, keyLengthEndIndex);
+        int keyStartIndex = keyLengthEndIndex + 1;
+        int keyEndIndex = keyStartIndex + keyLength;
+        if (keyLength < 0 || keyEndIndex >= msg.length || msg[keyEndIndex] != '|') {
+            return null;
+        }
+
+        String name = new String(msg, keyStartIndex, keyLength, StandardCharsets.UTF_8);
+        List<String> fieldNames = decodeSubkeyNames(msg, keyEndIndex + 1);
+        if (fieldNames.isEmpty()) {
+            return null;
+        }
+        return new SubkeyEventMessage(name, fieldNames);
+    }
+
+    private static List<String> decodeSubkeyNames(byte[] msg, int startIndex) {
+        List<String> result = new ArrayList<>();
+        int index = startIndex;
+        while (index < msg.length) {
+            int fieldLengthEndIndex = indexOf(msg, (byte) ':', index);
+            int fieldLength = parseLength(msg, index, fieldLengthEndIndex);
+            int fieldStartIndex = fieldLengthEndIndex + 1;
+            int fieldEndIndex = fieldStartIndex + fieldLength;
+            if (fieldLength < 0 || fieldEndIndex > msg.length) {
+                return Collections.emptyList();
+            }
+
+            result.add(new String(msg, fieldStartIndex, fieldLength, StandardCharsets.UTF_8));
+            if (fieldEndIndex == msg.length) {
+                return result;
+            }
+            if (msg[fieldEndIndex] != ',') {
+                return Collections.emptyList();
+            }
+            index = fieldEndIndex + 1;
+        }
+        return Collections.emptyList();
+    }
+
+    private static int indexOf(byte[] value, byte separator, int startIndex) {
+        for (int i = startIndex; i < value.length; i++) {
+            if (value[i] == separator) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static int parseLength(byte[] value, int startIndex, int endIndex) {
+        if (startIndex >= endIndex || endIndex > value.length) {
+            return -1;
+        }
+
+        try {
+            long result = Long.parseLong(new String(value, startIndex, endIndex - startIndex, StandardCharsets.US_ASCII));
+            if (result > Integer.MAX_VALUE) {
+                return -1;
+            }
+            return (int) result;
+        } catch (NumberFormatException e) {
+            return -1;
+        }
     }
 
     protected final void addListenerId(String name, Integer id) {

--- a/redisson/src/main/java/org/redisson/api/listener/MapClearExpireListener.java
+++ b/redisson/src/main/java/org/redisson/api/listener/MapClearExpireListener.java
@@ -20,7 +20,7 @@ import org.redisson.api.ObjectListener;
 /**
  * Redisson Object Event listener for <b>hpersist</b> event published by Valkey or Redis.
  * <p>
- * Redis notify-keyspace-events setting should contain Eh letters
+ * Redis notify-keyspace-events setting should contain Eh or Th letters
  *
  * @author Nikita Koksharov
  */
@@ -31,7 +31,8 @@ public interface MapClearExpireListener extends ObjectListener {
      * Invoked when entry's expiration is cleared
      *
      * @param name object name
+     * @param fieldName map entry field name. Can be null for keyevent notification.
      */
-    void onClearExpire(String name);
+    void onClearExpire(String name, String fieldName);
 
 }

--- a/redisson/src/main/java/org/redisson/api/listener/MapExpiredListener.java
+++ b/redisson/src/main/java/org/redisson/api/listener/MapExpiredListener.java
@@ -20,7 +20,7 @@ import org.redisson.api.ObjectListener;
 /**
  * Redisson Object Event listener for <b>hexpired</b> event published by Valkey or Redis.
  * <p>
- * Redis notify-keyspace-events setting should contain Eh letters
+ * Redis notify-keyspace-events setting should contain Eh or Th letters
  *
  * @author Nikita Koksharov
  */
@@ -31,7 +31,8 @@ public interface MapExpiredListener extends ObjectListener {
      * Invoked when entry expired
      *
      * @param name object name
+     * @param fieldName map entry field name. Can be null for keyevent notification.
      */
-    void onExpired(String name);
+    void onExpired(String name, String fieldName);
 
 }

--- a/redisson/src/main/java/org/redisson/api/listener/MapIncrListener.java
+++ b/redisson/src/main/java/org/redisson/api/listener/MapIncrListener.java
@@ -20,7 +20,7 @@ import org.redisson.api.ObjectListener;
 /**
  * Redisson Object Event listener for <b>hincrbyfloat</b> event published by Valkey or Redis.
  * <p>
- * Redis notify-keyspace-events setting should contain Eh letters
+ * Redis notify-keyspace-events setting should contain Eh or Th letters
  *
  * @author nhancdt2602
  */
@@ -30,6 +30,7 @@ public interface MapIncrListener extends ObjectListener {
      * Invoked when entry incremented
      *
      * @param name object name
+     * @param fieldName map entry field name. Can be null for keyevent notification.
      */
-    void onIncrement(String name);
+    void onIncrement(String name, String fieldName);
 }

--- a/redisson/src/main/java/org/redisson/api/listener/MapPutListener.java
+++ b/redisson/src/main/java/org/redisson/api/listener/MapPutListener.java
@@ -20,7 +20,7 @@ import org.redisson.api.ObjectListener;
 /**
  * Redisson Object Event listener for <b>hset</b> event published by Valkey or Redis.
  * <p>
- * Redis notify-keyspace-events setting should contain Eh letters
+ * Redis notify-keyspace-events setting should contain Eh or Th letters
  *
  * @author Nikita Koksharov
  */
@@ -31,7 +31,8 @@ public interface MapPutListener extends ObjectListener {
      * Invoked when entry added to RMap object
      *
      * @param name object name
+     * @param fieldName map entry field name. Can be null for keyevent notification.
      */
-    void onPut(String name);
+    void onPut(String name, String fieldName);
 
 }

--- a/redisson/src/main/java/org/redisson/api/listener/MapRemoveListener.java
+++ b/redisson/src/main/java/org/redisson/api/listener/MapRemoveListener.java
@@ -20,7 +20,7 @@ import org.redisson.api.ObjectListener;
 /**
  * Redisson Object Event listener for <b>hdel</b> event published by Valkey or Redis.
  * <p>
- * Redis notify-keyspace-events setting should contain Eh letters
+ * Redis notify-keyspace-events setting should contain Eh or Th letters
  *
  * @author Nikita Koksharov
  */
@@ -31,7 +31,8 @@ public interface MapRemoveListener extends ObjectListener {
      * Invoked when entry removed from RMap object
      *
      * @param name object name
+     * @param fieldName map entry field name. Can be null for keyevent notification.
      */
-    void onRemove(String name);
+    void onRemove(String name, String fieldName);
 
 }

--- a/redisson/src/main/java/org/redisson/client/ChannelName.java
+++ b/redisson/src/main/java/org/redisson/client/ChannelName.java
@@ -102,7 +102,8 @@ public class ChannelName implements CharSequence {
     }
 
     public boolean isKeyspace() {
-        return str.startsWith("__keyspace") || str.startsWith("__keyevent");
+        return str.startsWith("__keyspace") || str.startsWith("__keyevent")
+                || str.startsWith("__subkeyspace") || str.startsWith("__subkeyevent");
     }
 
     public boolean isTracking() {
@@ -110,4 +111,3 @@ public class ChannelName implements CharSequence {
     }
 
 }
-

--- a/redisson/src/test/java/org/redisson/RedissonListMultimapTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonListMultimapTest.java
@@ -329,8 +329,8 @@ public class RedissonListMultimapTest extends RedisDockerTest {
         testWithParams(redisson -> {
             Queue<Integer> nfs = new ConcurrentLinkedQueue<>();
             RListMultimap<Integer, Integer> map = redisson.getListMultimap("test1");
-            map.addListener((MapPutListener) name -> nfs.add(1));
-            map.addListener((MapRemoveListener) name -> nfs.add(2));
+            map.addListener((MapPutListener) (name, fieldName) -> nfs.add(1));
+            map.addListener((MapRemoveListener) (name, fieldName) -> nfs.add(2));
             map.addListener((ListAddListener) name -> nfs.add(3));
             map.addListener((ListRemoveListener) name -> nfs.add(4));
             map.put(1, 5);
@@ -340,7 +340,7 @@ public class RedissonListMultimapTest extends RedisDockerTest {
 
             Awaitility.waitAtMost(Duration.ofSeconds(1))
                     .untilAsserted(() -> assertThat(nfs).containsExactlyInAnyOrder(1, 3, 3, 2, 4, 4));
-        }, NOTIFY_KEYSPACE_EVENTS, "Ehl");
+        }, NOTIFY_KEYSPACE_EVENTS, "TEhl");
     }
 
     @Test

--- a/redisson/src/test/java/org/redisson/RedissonMapCacheNativeTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonMapCacheNativeTest.java
@@ -1,7 +1,5 @@
 package org.redisson;
 
-import java.time.Instant;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -18,9 +16,10 @@ import org.redisson.client.codec.LongCodec;
 import org.redisson.client.codec.StringCodec;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.*;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -200,15 +199,16 @@ public class RedissonMapCacheNativeTest extends BaseMapTest {
     @Test
     public void testRemoveListener() {
         testWithParams(redisson -> {
-            RMapCacheNative<Long, String> rMapCache = redisson.getMapCacheNative("test");
-            AtomicBoolean removed = new AtomicBoolean();
-            rMapCache.addListener((MapRemoveListener) name -> removed.set(true));
+            RMapCacheNative<String, String> rMapCache = redisson.getMapCacheNative("testRemoveListener", StringCodec.INSTANCE);
+            Queue<String> removed = new ConcurrentLinkedQueue<>();
+            rMapCache.addListener((MapRemoveListener) (name, fieldName) -> removed.add(name + ":" + fieldName));
 
-            rMapCache.put(1L, "1");
-            rMapCache.remove(1L);
+            rMapCache.put("1", "1");
+            rMapCache.remove("1");
 
-            Awaitility.await().atMost(Duration.ofSeconds(5)).untilTrue(removed);
-        }, NOTIFY_KEYSPACE_EVENTS, "Eh");
+            Awaitility.await().atMost(Duration.ofSeconds(5))
+                    .untilAsserted(() -> assertThat(removed).contains("testRemoveListener:1"));
+        }, NOTIFY_KEYSPACE_EVENTS, "Th");
 
     }
 
@@ -752,27 +752,28 @@ public class RedissonMapCacheNativeTest extends BaseMapTest {
     @Test
     public void testExpiration() {
         testWithParams(redisson -> {
-            AtomicInteger executedCount = new AtomicInteger();
-            RMapCacheNative<String, String> map = redisson.getMapCacheNative("simple");
-            map.addListener((MapExpiredListener) name -> executedCount.incrementAndGet());
+            Queue<String> expired = new ConcurrentLinkedQueue<>();
+            RMapCacheNative<String, String> map = redisson.getMapCacheNative("simple", StringCodec.INSTANCE);
+            map.addListener((MapExpiredListener) (name, fieldName) -> expired.add(fieldName));
             map.put("1", "2", Duration.ofSeconds(1));
             map.put("3", "4", Instant.now().plusSeconds(2));
 
-            Awaitility.await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> assertThat(executedCount.get()).isGreaterThanOrEqualTo(2));
+            Awaitility.await().atMost(Duration.ofSeconds(10))
+                    .untilAsserted(() -> assertThat(expired).contains("1", "3"));
 
             redisson.shutdown();
-        }, NOTIFY_KEYSPACE_EVENTS, "Eh");
+        }, NOTIFY_KEYSPACE_EVENTS, "Th");
     }
 
     @Test
     public void testClearExpireListener() {
         testWithParams(redisson -> {
-            AtomicInteger executedCount = new AtomicInteger();
-            RMapCacheNative<String, String> map = redisson.getMapCacheNative("simple");
+            Queue<String> clearExpire = new ConcurrentLinkedQueue<>();
+            RMapCacheNative<String, String> map = redisson.getMapCacheNative("simple", StringCodec.INSTANCE);
             map.addListener(new MapClearExpireListener() {
                 @Override
-                public void onClearExpire(String name) {
-                    executedCount.incrementAndGet();
+                public void onClearExpire(String name, String fieldName) {
+                    clearExpire.add(fieldName);
                 }
             });
             map.put("1", "2", Duration.ofSeconds(60));
@@ -781,10 +782,11 @@ public class RedissonMapCacheNativeTest extends BaseMapTest {
             map.clearExpire("1");
             map.clearExpire(new HashSet<>(Arrays.asList("3")));
 
-            Awaitility.await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> assertThat(executedCount.get()).isGreaterThanOrEqualTo(2));
+            Awaitility.await().atMost(Duration.ofSeconds(10))
+                    .untilAsserted(() -> assertThat(clearExpire).contains("1", "3"));
 
             redisson.shutdown();
-        }, NOTIFY_KEYSPACE_EVENTS, "Eh");
+        }, NOTIFY_KEYSPACE_EVENTS, "Th");
     }
 
     @Test
@@ -1461,4 +1463,3 @@ public class RedissonMapCacheNativeTest extends BaseMapTest {
     }
 
 }
-

--- a/redisson/src/test/java/org/redisson/RedissonMapTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonMapTest.java
@@ -12,6 +12,8 @@ import org.redisson.api.RedissonClient;
 import org.redisson.api.map.MapLoader;
 import org.redisson.api.map.MapWriter;
 import org.redisson.api.listener.MapIncrListener;
+import org.redisson.api.listener.MapPutListener;
+import org.redisson.api.listener.MapRemoveListener;
 import org.redisson.client.codec.Codec;
 import org.redisson.client.codec.LongCodec;
 import org.redisson.client.codec.StringCodec;
@@ -46,13 +48,14 @@ public class RedissonMapTest extends BaseMapTest {
     @Test
     public void testIncrListener() {
         testWithParams(redisson -> {
-            Queue<Integer> nfs = new ConcurrentLinkedQueue<>();
-            RMap<String, Double> map = redisson.getMap("testIncrListener");
+            Queue<String> nfs = new ConcurrentLinkedQueue<>();
+            RMap<String, Double> map = redisson.getMap("testIncrListener", StringCodec.INSTANCE);
 
-            int id = map.addListener((MapIncrListener) name -> nfs.add(1));
+            int id = map.addListener((MapIncrListener) (name, fieldName) -> nfs.add(name + ":" + fieldName));
 
             map.addAndGet("1", 1D);
-            Awaitility.waitAtMost(Durations.ONE_SECOND).untilAsserted(() -> assertThat(nfs).contains(1));
+            Awaitility.waitAtMost(Durations.ONE_SECOND)
+                    .untilAsserted(() -> assertThat(nfs).contains("testIncrListener:1"));
 
             nfs.clear();
             map.removeListener(id);
@@ -62,20 +65,21 @@ public class RedissonMapTest extends BaseMapTest {
                     .during(Duration.ofMillis(500))
                     .atMost(Duration.ofSeconds(1))
                     .until(nfs::isEmpty);
-        }, NOTIFY_KEYSPACE_EVENTS, "Eh");
+        }, NOTIFY_KEYSPACE_EVENTS, "Th");
     }
 
     @Test
     public void testIncrListenerAsync() {
         testWithParams(redisson -> {
-            Queue<Integer> nfs = new ConcurrentLinkedQueue<>();
-            RMap<String, Double> map = redisson.getMap("testIncrListenerAsync");
+            Queue<String> nfs = new ConcurrentLinkedQueue<>();
+            RMap<String, Double> map = redisson.getMap("testIncrListenerAsync", StringCodec.INSTANCE);
 
-            int id = map.addListenerAsync((MapIncrListener) name -> nfs.add(1))
+            int id = map.addListenerAsync((MapIncrListener) (name, fieldName) -> nfs.add(name + ":" + fieldName))
                     .toCompletableFuture().join();
 
             map.addAndGet("1", 1D);
-            Awaitility.waitAtMost(Durations.ONE_SECOND).untilAsserted(() -> assertThat(nfs).contains(1));
+            Awaitility.waitAtMost(Durations.ONE_SECOND)
+                    .untilAsserted(() -> assertThat(nfs).contains("testIncrListenerAsync:1"));
 
             nfs.clear();
             map.removeListenerAsync(id).toCompletableFuture().join();
@@ -85,7 +89,59 @@ public class RedissonMapTest extends BaseMapTest {
                     .during(Duration.ofMillis(500))
                     .atMost(Duration.ofSeconds(1))
                     .until(nfs::isEmpty);
+        }, NOTIFY_KEYSPACE_EVENTS, "Th");
+    }
+
+    @Test
+    public void testPutRemoveListener() {
+        testWithParams(redisson -> {
+            Queue<String> nfs = new ConcurrentLinkedQueue<>();
+            RMap<String, String> map = redisson.getMap("testPutRemoveListener", StringCodec.INSTANCE);
+
+            map.addListener((MapPutListener) (name, fieldName) -> nfs.add("put:" + name + ":" + fieldName));
+            map.addListener((MapRemoveListener) (name, fieldName) -> nfs.add("remove:" + name + ":" + fieldName));
+
+            map.put("1", "2");
+            map.remove("1");
+
+            Awaitility.waitAtMost(Durations.ONE_SECOND)
+                    .untilAsserted(() -> assertThat(nfs)
+                            .contains("put:testPutRemoveListener:1", "remove:testPutRemoveListener:1"));
+        }, NOTIFY_KEYSPACE_EVENTS, "Th");
+    }
+
+    @Test
+    public void testPutListenerWithKeyevent() {
+        testWithParams(redisson -> {
+            Queue<String> nfs = new ConcurrentLinkedQueue<>();
+            RMap<String, String> map = redisson.getMap("testPutListenerWithKeyevent", StringCodec.INSTANCE);
+
+            map.addListener((MapPutListener) (name, fieldName) -> nfs.add(name + ":" + fieldName));
+
+            map.put("1", "2");
+
+            Awaitility.waitAtMost(Durations.ONE_SECOND)
+                    .untilAsserted(() -> assertThat(nfs).contains("testPutListenerWithKeyevent:null"));
         }, NOTIFY_KEYSPACE_EVENTS, "Eh");
+    }
+
+    @Test
+    public void testPutListenerWithKeyeventAndSubkeyevent() {
+        testWithParams(redisson -> {
+            Queue<String> nfs = new ConcurrentLinkedQueue<>();
+            RMap<String, String> map = redisson.getMap("testPutListenerWithKeyeventAndSubkeyevent", StringCodec.INSTANCE);
+
+            map.addListener((MapPutListener) (name, fieldName) -> nfs.add(name + ":" + fieldName));
+
+            map.put("1", "2");
+
+            Awaitility.waitAtMost(Durations.ONE_SECOND)
+                    .untilAsserted(() -> assertThat(nfs).containsExactly("testPutListenerWithKeyeventAndSubkeyevent:1"));
+            Awaitility.await()
+                    .during(Duration.ofMillis(200))
+                    .atMost(Duration.ofSeconds(1))
+                    .untilAsserted(() -> assertThat(nfs).containsExactly("testPutListenerWithKeyeventAndSubkeyevent:1"));
+        }, NOTIFY_KEYSPACE_EVENTS, "TEh");
     }
 
     protected <K, V> MapWriter<K, V> createMapWriter(Map<K, V> map) {

--- a/redisson/src/test/java/org/redisson/RedissonReactiveListMultimapTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonReactiveListMultimapTest.java
@@ -304,8 +304,8 @@ public class RedissonReactiveListMultimapTest extends BaseReactiveTest {
         testWithParams(redisson -> {
             Queue<Integer> nfs = new ConcurrentLinkedQueue<>();
             RListMultimapReactive<Object, Object> map = redisson.reactive().getListMultimap("test1");
-            sync(map.addListener((MapPutListener) name -> nfs.add(1)));
-            sync(map.addListener((MapRemoveListener) name -> nfs.add(2)));
+            sync(map.addListener((MapPutListener) (name, fieldName) -> nfs.add(1)));
+            sync(map.addListener((MapRemoveListener) (name, fieldName) -> nfs.add(2)));
             sync(map.addListener((ListAddListener) name -> nfs.add(3)));
             sync(map.addListener((ListRemoveListener) name -> nfs.add(4)));
             sync(map.put(1, 5));
@@ -315,7 +315,7 @@ public class RedissonReactiveListMultimapTest extends BaseReactiveTest {
 
             Awaitility.waitAtMost(Duration.ofSeconds(1))
                     .untilAsserted(() -> assertThat(nfs).containsExactlyInAnyOrder(1, 3, 3, 2, 4, 4));
-        }, NOTIFY_KEYSPACE_EVENTS, "Ehl");
+        }, NOTIFY_KEYSPACE_EVENTS, "TEhl");
     }
 
     @Test


### PR DESCRIPTION
## What

Adds the affected map field name to `Map*Listener` callbacks.
Updated listener methods:
- `MapPutListener#onPut(String name, String fieldName)`
- `MapRemoveListener#onRemove(String name, String fieldName)`
- `MapIncrListener#onIncrement(String name, String fieldName)`
- `MapExpiredListener#onExpired(String name, String fieldName)`
- `MapClearExpireListener#onClearExpire(String name, String fieldName)`

## How

Redis hash field notifications were introduced in redis/redis#14958.
Redisson now checks `notify-keyspace-events` when registering map listeners:
- if subkeyevent notifications are enabled, subscribe to `__subkeyevent@*:<event>` and pass the actual `fieldName`
- otherwise, fallback to old `__keyevent@*:<event>` notifications and pass `fieldName = null`

This avoids registering both notification types at the same time while keeping compatibility with existing keyevent-based configurations.
