### PR TITLE
Fixed - cluster lazy initialization can park caller threads indefinitely

### DIFF
--- a/redisson/src/main/java/org/redisson/connection/ClusterConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/ClusterConnectionManager.java
@@ -136,7 +136,9 @@ public class ClusterConnectionManager extends MasterSlaveConnectionManager {
                     break;
                 }
 
-                List<CompletableFuture<Void>> masterFutures = new ArrayList<>();
+                // Build entries first, then register slots only after the bounded wait succeeds, so a
+                // slow entry can't deadlock init and a straggler can't mutate manager state post-timeout.
+                Map<ClusterPartition, CompletableFuture<MasterSlaveEntry>> buildFutures = new LinkedHashMap<>();
                 for (ClusterPartition partition : partitions) {
                     if (partition.isMasterFail()) {
                         failedMasters.add(partition.getMasterAddress().toURIString());
@@ -146,15 +148,42 @@ public class ClusterConnectionManager extends MasterSlaveConnectionManager {
                         throw new IllegalStateException("Master node: " + partition.getNodeId() + " doesn't have an address.");
                     }
 
-                    CompletionStage<Void> masterFuture = addMasterEntry(partition, cfg);
-                    masterFutures.add(masterFuture.toCompletableFuture());
+                    buildFutures.put(partition, buildMasterEntry(partition, cfg));
                 }
 
-                CompletableFuture<Void> masterFuture = CompletableFuture.allOf(masterFutures.toArray(new CompletableFuture[0]));
+                CompletableFuture<Void> all = CompletableFuture.allOf(buildFutures.values().toArray(new CompletableFuture[0]));
+                long timeoutMillis = (long) config.getConnectTimeout()
+                        * (Math.max(1, config.getMasterConnectionMinimumIdleSize())
+                         + Math.max(1, config.getSlaveConnectionMinimumIdleSize())
+                         + Math.max(1, config.getSubscriptionConnectionMinimumIdleSize()));
+                Throwable initException = null;
                 try {
-                    masterFuture.join();
-                } catch (CompletionException e) {
-                    lastException = e.getCause();
+                    all.get(timeoutMillis, TimeUnit.MILLISECONDS);
+                } catch (ExecutionException e) {
+                    initException = e.getCause();
+                } catch (TimeoutException e) {
+                    initException = new RedisConnectionException(
+                            "Timed out after " + timeoutMillis
+                                    + "ms waiting for cluster master entries to initialize", e);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    initException = new RedisConnectionException(e);
+                }
+
+                if (initException != null) {
+                    lastException = initException;
+                    // Shut down built pools, including stragglers that finish after the deadline.
+                    for (CompletableFuture<MasterSlaveEntry> bf : buildFutures.values()) {
+                        bf.whenComplete((entry, ex) -> {
+                            if (entry != null) {
+                                entry.shutdownAsync();
+                            }
+                        });
+                    }
+                } else {
+                    for (Map.Entry<ClusterPartition, CompletableFuture<MasterSlaveEntry>> e : buildFutures.entrySet()) {
+                        registerMasterEntry(e.getValue().join(), e.getKey());
+                    }
                 }
                 break;
             } catch (Exception e) {
@@ -322,6 +351,13 @@ public class ClusterConnectionManager extends MasterSlaveConnectionManager {
     }
     
     private CompletionStage<Void> addMasterEntry(ClusterPartition partition, ClusterServersConfig cfg) {
+        return buildMasterEntry(partition, cfg).thenAccept(entry -> registerMasterEntry(entry, partition));
+    }
+
+    // Builds a master entry (master + slave pools) WITHOUT registering its slots. The caller registers
+    // via registerMasterEntry once the build is known to have succeeded. A failed build shuts down its
+    // own entry so a partially-built pool doesn't linger.
+    private CompletableFuture<MasterSlaveEntry> buildMasterEntry(ClusterPartition partition, ClusterServersConfig cfg) {
         if (partition.isMasterFail()) {
             RedisException e = new RedisException("Failed to add master: " +
                     partition.getMasterAddress() + " for slot ranges: " +
@@ -331,7 +367,7 @@ public class ClusterConnectionManager extends MasterSlaveConnectionManager {
                 e = new RedisException("Failed to add master: " +
                         partition.getMasterAddress() + ". Reason - server has FAIL flag");
             }
-            CompletableFuture<Void> result = new CompletableFuture<>();
+            CompletableFuture<MasterSlaveEntry> result = new CompletableFuture<>();
             result.completeExceptionally(e);
             return result;
         }
@@ -355,18 +391,10 @@ public class ClusterConnectionManager extends MasterSlaveConnectionManager {
             }
 
             CompletableFuture<RedisClient> f = entry.setupMasterEntry(new RedisURI(config.getMasterAddress()), configEndpointHostName);
-            return f.thenCompose(masterClient -> {
-                for (Integer slot : partition.getSlots()) {
-                    addEntry(slot, entry);
-                    addPartition(slot, partition);
-                }
-                if (partition.getSlotsAmount() > 0) {
-                    lastUri2Partition.put(partition.getMasterAddress(), partition);
-                }
-
+            CompletableFuture<MasterSlaveEntry> entryFuture = f.thenCompose(masterClient -> {
                 if (!config.isSlaveNotUsed()) {
                     CompletableFuture<Void> fs = entry.initSlaveBalancer(r -> configEndpointHostName);
-                    return fs.thenAccept(r -> {
+                    return fs.thenApply(r -> {
                         if (!partition.getSlaveAddresses().isEmpty()) {
                             log.info("slaves: {} added for master: {} slot ranges: {}",
                                     partition.getSlaveAddresses(), partition.getMasterAddress(), partition.getSlotRanges());
@@ -377,13 +405,30 @@ public class ClusterConnectionManager extends MasterSlaveConnectionManager {
                         }
 
                         log.info("master: {} added for slot ranges: {}", partition.getMasterAddress(), partition.getSlotRanges());
+                        return entry;
                     });
                 }
 
                 log.info("master: {} added for slot ranges: {}", partition.getMasterAddress(), partition.getSlotRanges());
-                return CompletableFuture.completedFuture(null);
+                return CompletableFuture.completedFuture(entry);
             });
-        });
+            entryFuture.whenComplete((e, ex) -> {
+                if (ex != null) {
+                    entry.shutdownAsync();
+                }
+            });
+            return entryFuture;
+        }).toCompletableFuture();
+    }
+
+    private void registerMasterEntry(MasterSlaveEntry entry, ClusterPartition partition) {
+        for (Integer slot : partition.getSlots()) {
+            addEntry(slot, entry);
+            addPartition(slot, partition);
+        }
+        if (partition.getSlotsAmount() > 0) {
+            lastUri2Partition.put(partition.getMasterAddress(), partition);
+        }
     }
 
     private void addPartition(Integer slot, ClusterPartition partition) {

--- a/redisson/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
@@ -529,6 +529,10 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
     }
 
     private NodeType getNodeType(NodeType type, InetSocketAddress address) {
+        if (!isInitialized()) {
+            // pre-init getEntry() can trigger lazyConnect and park the caller on the latch held by the connecting thread.
+            return type;
+        }
         if (getServiceManager().getCfg().isSingleConfig()) {
             return NodeType.MASTER;
         }

--- a/redisson/src/test/java/org/redisson/connection/MasterSlaveConnectionManagerTest.java
+++ b/redisson/src/test/java/org/redisson/connection/MasterSlaveConnectionManagerTest.java
@@ -1,12 +1,15 @@
 package org.redisson.connection;
 
+import mockit.Expectations;
 import mockit.Invocation;
 import mockit.Mock;
 import mockit.MockUp;
+import mockit.Mocked;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.redisson.api.NodeType;
 import org.redisson.client.RedisClient;
+import org.redisson.client.RedisClientConfig;
 import org.redisson.client.RedisConnectionException;
 import org.redisson.config.*;
 
@@ -14,6 +17,9 @@ import org.redisson.misc.RedisURI;
 
 import java.net.InetSocketAddress;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 
 
 public class MasterSlaveConnectionManagerTest {
@@ -85,6 +91,166 @@ public class MasterSlaveConnectionManagerTest {
             Assertions.assertThat(Thread.currentThread().isInterrupted()).isTrue();
         } finally {
             Thread.interrupted(); // restore clean interrupt state
+            manager.shutdown(0, 0, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void testLazyConnectRetriesAfterFailedInitialization() {
+        Config config = new Config();
+        config.setLazyInitialization(true);
+        MasterSlaveServersConfig msConfig = config.useMasterSlaveServers();
+        msConfig.setMasterAddress("redis://127.0.0.1:6379");
+        msConfig.setReadMode(ReadMode.MASTER);
+        msConfig.setRetryAttempts(0);
+
+        AtomicInteger doConnectInvocations = new AtomicInteger();
+        MasterSlaveConnectionManager manager = new MasterSlaveConnectionManager(msConfig, config) {
+            @Override
+            protected void doConnect(Function<RedisURI, String> hostnameMapper) {
+                if (doConnectInvocations.incrementAndGet() == 1) {
+                    // mimics ClusterConnectionManager.doConnect surfacing a bounded-wait timeout:
+                    // a stuck master entry setup must not park lazyConnect callers indefinitely.
+                    throw new RedisConnectionException(
+                            "Timed out waiting for cluster master entries to initialize");
+                }
+                // second attempt succeeds — no exception thrown
+            }
+        };
+
+        try {
+            Assertions.assertThatThrownBy(manager::getEntrySet)
+                    .isInstanceOf(RedisConnectionException.class)
+                    .hasMessageContaining("Timed out");
+
+            // exceptional latch must be replaceable so a subsequent call retries initialization
+            Assertions.assertThatCode(manager::getEntrySet).doesNotThrowAnyException();
+            Assertions.assertThat(doConnectInvocations.get()).isEqualTo(2);
+        } finally {
+            manager.shutdown(0, 0, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void testListenerNodeTypeResolutionDoesNotTriggerLazyConnect() {
+        Config config = new Config();
+        config.setLazyInitialization(true);
+        MasterSlaveServersConfig msConfig = config.useMasterSlaveServers();
+        msConfig.setMasterAddress("redis://127.0.0.1:6379");
+        msConfig.setReadMode(ReadMode.MASTER);
+
+        AtomicInteger doConnectInvocations = new AtomicInteger();
+        MasterSlaveConnectionManager manager = new MasterSlaveConnectionManager(msConfig, config) {
+            @Override
+            protected void doConnect(Function<RedisURI, String> hostnameMapper) {
+                doConnectInvocations.incrementAndGet();
+                throw new AssertionError(
+                        "lazyConnect must not run on the connection lifecycle listener path");
+            }
+        };
+
+        try {
+            AtomicReference<NodeType> emittedNodeType = new AtomicReference<>();
+            manager.getServiceManager()
+                    .getConnectionEventsHub()
+                    .addListener(new ConnectionListener() {
+                        @Override
+                        public void onConnect(InetSocketAddress address) {
+                        }
+
+                        @Override
+                        public void onConnect(InetSocketAddress address, NodeType nodeType) {
+                            emittedNodeType.set(nodeType);
+                        }
+
+                        @Override
+                        public void onDisconnect(InetSocketAddress address) {
+                        }
+                    });
+
+            NodeType[] types = {NodeType.MASTER, NodeType.SLAVE};
+            for (int i = 0; i < types.length; i++) {
+                NodeType type = types[i];
+                // distinct address per iteration: ConnectionEventsHub suppresses a repeat connect for an already-CONNECTED address
+                int port = 6379 + i;
+                InetSocketAddress addr = new InetSocketAddress("127.0.0.1", port);
+                emittedNodeType.set(null);
+
+                RedisClientConfig redisConfig = manager.createRedisConfig(
+                        type, new RedisURI("redis://127.0.0.1:" + port), 1000, 1000, null);
+                redisConfig.getConnectedListener().accept(addr);
+                // pre-init resolution must echo the passed-in type without consulting entries
+                Assertions.assertThat(emittedNodeType.get()).isEqualTo(type);
+            }
+
+            Assertions.assertThat(doConnectInvocations.get()).isZero();
+        } finally {
+            manager.shutdown(0, 0, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void listenerResolvesActualNodeTypeAfterLazyInitialization(
+            @Mocked MasterSlaveEntry entry, @Mocked RedisClient client) {
+        Config config = new Config();
+        config.setLazyInitialization(true);
+        MasterSlaveServersConfig msConfig = config.useMasterSlaveServers();
+        msConfig.setMasterAddress("redis://127.0.0.1:6379");
+        msConfig.setReadMode(ReadMode.MASTER);
+
+        InetSocketAddress addr = new InetSocketAddress("127.0.0.1", 6379);
+        AtomicReference<NodeType> emittedNodeType = new AtomicReference<>();
+
+        MasterSlaveConnectionManager manager = new MasterSlaveConnectionManager(msConfig, config) {
+            @Override
+            protected void doConnect(Function<RedisURI, String> hostnameMapper) {
+                // successful lazy init
+            }
+
+            @Override
+            public MasterSlaveEntry getEntry(InetSocketAddress address) {
+                lazyConnect();
+                return entry;
+            }
+        };
+
+        try {
+            new Expectations() {{
+                entry.isInit(); result = true;
+                entry.getClient(); result = client;
+                client.getAddr(); result = addr;
+            }};
+
+            manager.getServiceManager()
+                    .getConnectionEventsHub()
+                    .addListener(new ConnectionListener() {
+                        @Override
+                        public void onConnect(InetSocketAddress address) {
+                        }
+
+                        @Override
+                        public void onConnect(InetSocketAddress address, NodeType nodeType) {
+                            emittedNodeType.set(nodeType);
+                        }
+
+                        @Override
+                        public void onDisconnect(InetSocketAddress address) {
+                        }
+                    });
+
+            manager.getEntrySet();
+
+            RedisClientConfig redisConfig = manager.createRedisConfig(
+                    NodeType.SLAVE,
+                    new RedisURI("redis://127.0.0.1:6379"),
+                    1000,
+                    1000,
+                    null);
+
+            redisConfig.getConnectedListener().accept(addr);
+
+            Assertions.assertThat(emittedNodeType.get()).isEqualTo(NodeType.MASTER);
+        } finally {
             manager.shutdown(0, 0, TimeUnit.SECONDS);
         }
     }


### PR DESCRIPTION
## Problem

ClusterConnectionManager.doConnect waits on allOf(masterFutures).join() with no timeout. If a master entry never finishes setup, the connecting thread holding lazyConnectLatch never completes and every later caller parks on lazyConnect. A Netty disconnect during that window compounds it: channelInactive -> getNodeType -> getEntry -> lazyConnect parks the event loop on the same latch.

## Fix

1. Bound the allOf(masterFutures) wait by connectTimeout * (master + slave + subscription minimum-idle sizes), mirroring the per-pool semantics already used in MasterSlaveConnectionManager.doConnect. On timeout, set a retryable RedisConnectionException so the latch completes exceptionally and the next caller retries via the existing compareAndSet path.
2. Guard getNodeType: when the manager is not initialized, return the configured type instead of calling getEntry, keeping the connect/disconnect listeners off the latch during the pre-init window. Non-lazy mode is unaffected.
3. Separate entry build from slot registration. An init-attempt token, invalidated when the attempt ends, makes any straggler from a timed-out attempt shut down its own pool instead of registering into a manager that has moved on. Built entries are torn down without closing the shared ServiceManager/event-loop/resolver/timer, so the manager stays reusable and a later command reconnects once the slow node recovers.

## Tests

MasterSlaveConnectionManagerTest: retry-after-failed-init replaces the exceptional latch and recovers; listener node-type resolution returns the configured NodeType without entering lazy init.

## Scope

No behavior change for lazyInitialization=false or non-cluster modes. The two connection-pool accounting fixes originally bundled here are split out: ConnectionsHolder init double-release (#7205) and AsyncSemaphore cancelled-waiter over-increment (#7206). Deadlock reproduction in #7196.

Signed-off-by: yipeng-ma <yipeng.ma@airbnb.com>
