### PR TITLE
Fix UUID type metadata leak in TypedJsonJacksonCodec #7154

### DIFF
--- a/redisson/src/main/java/org/redisson/codec/JsonJacksonCodec.java
+++ b/redisson/src/main/java/org/redisson/codec/JsonJacksonCodec.java
@@ -162,6 +162,7 @@ public class JsonJacksonCodec extends BaseCodec {
     }
 
     protected void initTypeInclusion(ObjectMapper mapObjectMapper) {
+        mapObjectMapper.addMixIn(UUID.class, UuidMixin.class);
         TypeResolverBuilder<?> mapTyper = new DefaultTypeResolverBuilder(DefaultTyping.NON_FINAL) {
             public boolean useForType(JavaType t) {
                 switch (_appliesFor) {
@@ -208,7 +209,6 @@ public class JsonJacksonCodec extends BaseCodec {
         objectMapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
         objectMapper.enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY);
         objectMapper.addMixIn(Throwable.class, ThrowableMixIn.class);
-        objectMapper.addMixIn(UUID.class, UuidMixin.class);
     }
 
     @Override

--- a/redisson/src/test/java/org/redisson/codec/JsonJacksonCodecTest.java
+++ b/redisson/src/test/java/org/redisson/codec/JsonJacksonCodecTest.java
@@ -1,6 +1,7 @@
 package org.redisson.codec;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -8,8 +9,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import io.netty.buffer.ByteBuf;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.redisson.client.handler.State;
 
 public class JsonJacksonCodecTest {
 
@@ -61,5 +64,19 @@ public class JsonJacksonCodecTest {
 
         Assertions.assertFalse(objectMapper.getDeserializationConfig().isEnabled(DeserializationFeature.UNWRAP_ROOT_VALUE));
         Assertions.assertFalse(codec.getObjectMapper().getDeserializationConfig().isEnabled(DeserializationFeature.UNWRAP_ROOT_VALUE));
+    }
+
+    @Test
+    public void shouldRoundTripUuidViaUntypedDecoder() throws IOException {
+        UUID uuid = UUID.randomUUID();
+        JsonJacksonCodec codec = new JsonJacksonCodec();
+
+        ByteBuf encoded = codec.getValueEncoder().encode(uuid);
+        try {
+            Object decoded = codec.getValueDecoder().decode(encoded, new State());
+            Assertions.assertEquals(uuid, decoded);
+        } finally {
+            encoded.release();
+        }
     }
 }

--- a/redisson/src/test/java/org/redisson/codec/TypedJsonJacksonCodecTest.java
+++ b/redisson/src/test/java/org/redisson/codec/TypedJsonJacksonCodecTest.java
@@ -102,4 +102,32 @@ public class TypedJsonJacksonCodecTest extends RedisDockerTest {
         assertThat(mapCodec.getMapValueEncoder().encode("foo").toString(CharsetUtil.UTF_8))
                 .isEqualTo("\"foo\"");
     }
+
+    @Test
+    public void shouldSerializeUuidWithoutClassMetadata() throws Exception {
+        UUID uuid = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        TypedJsonJacksonCodec uuidCodec = new TypedJsonJacksonCodec(UUID.class);
+
+        ByteBuf encoded = uuidCodec.getValueEncoder().encode(uuid);
+        try {
+            assertThat(encoded.toString(CharsetUtil.UTF_8))
+                    .isEqualTo("\"" + uuid.toString() + "\"");
+        } finally {
+            encoded.release();
+        }
+    }
+
+    @Test
+    public void shouldRoundTripUuidValue() throws Exception {
+        UUID uuid = UUID.randomUUID();
+        TypedJsonJacksonCodec uuidCodec = new TypedJsonJacksonCodec(UUID.class);
+
+        ByteBuf encoded = uuidCodec.getValueEncoder().encode(uuid);
+        try {
+            assertThat(uuidCodec.getValueDecoder().decode(encoded, new State()))
+                    .isEqualTo(uuid);
+        } finally {
+            encoded.release();
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #7154 — regression introduced in 3.55.0 (#6828) where `TypedJsonJacksonCodec`
unexpectedly serializes `UUID` values with class metadata
(`["java.util.UUID","..."]`) instead of the plain string they used to serialize
to in 3.52.x.

## Root cause

#6828 added `UuidMixin` (annotated with `@JsonTypeInfo(use = Id.CLASS)`) so that
`UUID`s declared as `Object` would round-trip through `JsonJacksonCodec`.
The mixin is registered inside `init()`, which runs even for subclasses.
`TypedJsonJacksonCodec` already overrides `initTypeInclusion()` to a no-op to
disable default typing, 但 the `UUID` mixin still slipped through, so typed
codecs leak the class tag for any `UUID` they encode/decode.

## Fix

Move `addMixIn(UUID.class, UuidMixin.class)` from `init()` into
`initTypeInclusion()`. The parent codec still calls `initTypeInclusion()` right
after `init()`, so its behavior is unchanged. `TypedJsonJacksonCodec`'s no-op
override now also drops the UUID mixin, and UUID values serialize back to plain
strings.