### PR TITLE
test: clarify deserialization error assertion

### DIFF
--- a/redisson/src/test/java/org/redisson/BaseMapTest.java
+++ b/redisson/src/test/java/org/redisson/BaseMapTest.java
@@ -650,12 +650,7 @@ public abstract class BaseMapTest extends RedisDockerTest {
         assertThat(object.getTestField()).isEqualTo("test-val");
         map.put("test-key", object);
 
-        try {
-            map.get("test-key");
-            Assertions.fail("Expected exception from map.get() call");
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        Assertions.assertThrows(Exception.class, () -> map.get("test-key"));
         destroy(map);
     }
 


### PR DESCRIPTION
## Summary

Replaces a try/catch + `Assertions.fail(...)` pattern in
`BaseMapTest#testDeserializationErrorReturnsErrorImmediately` with an explicit
`Assertions.assertThrows(...)` assertion.

## Motivation

The test expects `map.get("test-key")` to fail when the stored value cannot be
deserialized by `JsonJacksonCodec`.

Using `assertThrows` makes the expected behavior clearer and avoids catching the
exception only to print its stack trace.

## Testing

- [x] `mvn -pl redisson -Dtest=RedissonMapTest test`