### PR TITLE
Improve configPath error message for nested jar/classpath resources

### DIFF
--- a/redisson-tomcat/redisson-tomcat-10/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-10/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -371,7 +371,12 @@ public class RedissonSessionManager extends ManagerBase {
             try {
                 config = Config.fromYAML(new File(configPath), getClass().getClassLoader());
             } catch (IOException e) {
-                throw new LifecycleException("Can't parse yaml config " + configPath, e);
+                throw new LifecycleException(
+                        "Can't parse yaml config: " + configPath
+                                + ". Nested jar/classpath resources are not supported via configPath. "
+                                + "Use setConfig(Config) with a classpath resource InputStream instead.",
+                        e
+                );
             }
         }
 

--- a/redisson-tomcat/redisson-tomcat-11/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-11/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -371,7 +371,12 @@ public class RedissonSessionManager extends ManagerBase {
             try {
                 config = Config.fromYAML(new File(configPath), getClass().getClassLoader());
             } catch (IOException e) {
-                throw new LifecycleException("Can't parse yaml config " + configPath, e);
+                throw new LifecycleException(
+                        "Can't parse yaml config: " + configPath
+                                + ". Nested jar/classpath resources are not supported via configPath. "
+                                + "Use setConfig(Config) with a classpath resource InputStream instead.",
+                        e
+                );
             }
         }
 

--- a/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-7/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -371,7 +371,12 @@ public class RedissonSessionManager extends ManagerBase {
             try {
                 config = Config.fromYAML(new File(configPath), getClass().getClassLoader());
             } catch (Exception e) {
-                throw new LifecycleException("Can't parse yaml config " + configPath, e);
+                throw new LifecycleException(
+                        "Can't parse yaml config: " + configPath
+                                + ". Nested jar/classpath resources are not supported via configPath. "
+                                + "Use setConfig(Config) with a classpath resource InputStream instead.",
+                        e
+                );
             }
         }
 

--- a/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -371,7 +371,12 @@ public class RedissonSessionManager extends ManagerBase {
             try {
                 config = Config.fromYAML(new File(configPath), getClass().getClassLoader());
             } catch (Exception e) {
-                throw new LifecycleException("Can't parse yaml config " + configPath, e);
+                throw new LifecycleException(
+                        "Can't parse yaml config: " + configPath
+                                + ". Nested jar/classpath resources are not supported via configPath. "
+                                + "Use setConfig(Config) with a classpath resource InputStream instead.",
+                        e
+                );
             }
         }
 

--- a/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-9/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -371,7 +371,12 @@ public class RedissonSessionManager extends ManagerBase {
             try {
                 config = Config.fromYAML(new File(configPath), getClass().getClassLoader());
             } catch (Exception e) {
-                throw new LifecycleException("Can't parse yaml config " + configPath, e);
+                throw new LifecycleException(
+                        "Can't parse yaml config: " + configPath
+                                + ". Nested jar/classpath resources are not supported via configPath. "
+                                + "Use setConfig(Config) with a classpath resource InputStream instead.",
+                        e
+                );
             }
         }
 


### PR DESCRIPTION
## Summary

Improve the `configPath` parsing error message for nested jar/classpath resource usage.

## Background

`configPath` currently delegates to:

`Config.fromYAML(new File(configPath), ...)`

which expects a real filesystem path.

In Spring Boot fat jars and nested-jar environments, users may accidentally provide values such as:

`jar:nested:/app.jar!/redisson.yml`

which results in a `FileNotFoundException` with limited guidance.

## Change

Adds a more descriptive `LifecycleException` message suggesting the already-supported alternative:

`setConfig(Config)` with a classpath resource InputStream.

No functional behavior was changed.
