### PR TITLE
Fixed - Regression in 4.4.0: WRONGPASS on cluster slaves with TLS when password is set at root Config level (works in 4.3.1) #7157

### DIFF
--- a/redisson/src/main/java/org/redisson/connection/ClusterConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/ClusterConnectionManager.java
@@ -139,7 +139,7 @@ public class ClusterConnectionManager extends MasterSlaveConnectionManager {
                 List<CompletableFuture<Void>> masterFutures = new ArrayList<>();
                 for (ClusterPartition partition : partitions) {
                     if (partition.isMasterFail()) {
-                        failedMasters.add(partition.getMasterAddress().toString());
+                        failedMasters.add(partition.getMasterAddress().toURIString());
                         continue;
                     }
                     if (partition.getMasterAddress() == null) {
@@ -339,7 +339,7 @@ public class ClusterConnectionManager extends MasterSlaveConnectionManager {
         CompletionStage<RedisConnection> connectionFuture = connectToNode(cfg, partition.getMasterAddress(), configEndpointHostName);
         return connectionFuture.thenCompose(connection -> {
             MasterSlaveServersConfig config = create(cfg);
-            config.setMasterAddress(partition.getMasterAddress().toString());
+            config.setMasterAddress(partition.getMasterAddress().toURIString());
 
             MasterSlaveEntry entry;
             if (config.isSlaveNotUsed()) {
@@ -347,7 +347,7 @@ public class ClusterConnectionManager extends MasterSlaveConnectionManager {
             } else {
                 Set<String> slaveAddresses = partition.getSlaveAddresses().stream()
                                                                             .filter(r -> !partition.getFailedSlaveAddresses().contains(r))
-                                                                            .map(r -> r.toString())
+                                                                            .map(r -> r.toURIString())
                                                                             .collect(Collectors.toSet());
                 config.setSlaveAddresses(slaveAddresses);
 

--- a/redisson/src/main/java/org/redisson/connection/ReplicatedConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/ReplicatedConnectionManager.java
@@ -100,10 +100,10 @@ public class ReplicatedConnectionManager extends MasterSlaveConnectionManager {
             if (Role.master.equals(role)) {
                 currentMaster.set(connection.getRedisClient().getAddr());
                 log.info("{} is the master", addr);
-                this.config.setMasterAddress(addr.toString());
+                this.config.setMasterAddress(addr.toURIString());
             } else {
                 log.info("{} is a slave", addr);
-                this.config.addSlaveAddress(addr.toString());
+                this.config.addSlaveAddress(addr.toURIString());
             }
         }
 

--- a/redisson/src/main/java/org/redisson/connection/SentinelConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/SentinelConnectionManager.java
@@ -112,7 +112,7 @@ public class SentinelConnectionManager extends MasterSlaveConnectionManager {
                     if (!master.isIP()) {
                         uri2hostname.put(masterUri, master.getHost());
                     }
-                    this.config.setMasterAddress(masterUri.toString());
+                    this.config.setMasterAddress(masterUri.toURIString());
                     currentMaster.set(masterUri);
                     log.info("master: {} added", masterHost);
 
@@ -138,7 +138,7 @@ public class SentinelConnectionManager extends MasterSlaveConnectionManager {
                         if (isDown(flags, masterLinkStatus)) {
                             log.warn("slave: {} is down", slaveAddr);
                         } else {
-                            this.config.addSlaveAddress(uri.toString());
+                            this.config.addSlaveAddress(uri.toURIString());
                             log.info("slave: {} added", slaveAddr);
                         }
                     }

--- a/redisson/src/main/java/org/redisson/misc/RedisURI.java
+++ b/redisson/src/main/java/org/redisson/misc/RedisURI.java
@@ -184,6 +184,15 @@ public final class RedisURI {
         return hashCode;
     }
 
+    public String toURIString() {
+        if (username != null && password != null) {
+            return getScheme() + "://" + username + ":" + password + "@" + trimIpv6Brackets(host) + ":" + port;
+        } else if (password != null) {
+            return getScheme() + "://" + password + "@" + trimIpv6Brackets(host) + ":" + port;
+        }
+        return getScheme() + "://" + trimIpv6Brackets(host) + ":" + port;
+    }
+
     @Override
     public String toString() {
         if (username != null && password != null) {

--- a/redisson/src/test/java/org/redisson/connection/ReplicatedConnectionManagerTest.java
+++ b/redisson/src/test/java/org/redisson/connection/ReplicatedConnectionManagerTest.java
@@ -80,7 +80,7 @@ public class ReplicatedConnectionManagerTest {
 
         try {
             ReplicatedServersConfig serversConfig = new ReplicatedServersConfig();
-            serversConfig.addNodeAddress(uri.toString());
+            serversConfig.addNodeAddress(uri.toURIString());
 
             Set<InetSocketAddress> slaveIPs = Collections.newSetFromMap(new ConcurrentHashMap<>());
             CompletableFuture<?> future = manager.checkNode(uri, serversConfig, slaveIPs);


### PR DESCRIPTION
[issues/7157](https://github.com/redisson/redisson/issues/7157)

test case:
`RedissonTest.testClusterWithPasswordInURL()`