### PR TITLE
Typed server rejection exceptions to enable client-side rate limiting and retry logic

### DIFF
--- a/redisson/src/main/java/org/redisson/client/RedisConnectionBootstrapException.java
+++ b/redisson/src/main/java/org/redisson/client/RedisConnectionBootstrapException.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2013-2026 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.client;
+
+/**
+ * Thrown when a Redis connection fails during the bootstrap pipeline —
+ * AUTH/HELLO, SELECT, CLIENT SETNAME, READONLY, or the initial PING —
+ * before the connection is handed to the pool.
+ * <p>
+ * The {@link #getPhase()} field identifies which command in the pipeline
+ * triggered the failure, so callers (metrics interceptors, circuit breakers,
+ * connection-pool init) can distinguish e.g. an auth rejection from a
+ * database-select error without parsing the message string.
+ * <p>
+ * The causing exception (accessible via {@link #getCause()}) preserves the
+ * original typed exception, which may itself carry a
+ * {@link RedisException#getServerError()} value for server-side errors.
+ *
+ * @author Nikita Koksharov
+ */
+public class RedisConnectionBootstrapException extends RedisConnectionException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The logical phase of the bootstrap pipeline that failed.
+     */
+    public enum Phase {
+        /** AUTH or HELLO AUTH command */
+        AUTH,
+        /** HELLO command (RESP3 negotiation) */
+        HELLO,
+        /** SELECT command (database selection) */
+        SELECT,
+        /** CLIENT SETNAME command */
+        CLIENT_SETNAME,
+        /** CLIENT CAPA command */
+        CLIENT_CAPA,
+        /** READONLY command (replica routing) */
+        READONLY,
+        /** Initial PING (ping connection interval check) */
+        PING,
+        /** Multiple pipeline steps failed simultaneously, or failure point unknown */
+        UNKNOWN
+    }
+
+    private final Phase phase;
+
+    public RedisConnectionBootstrapException(String message, Phase phase, Throwable cause) {
+        super(message, cause);
+        this.phase = phase;
+    }
+
+    /**
+     * Returns the bootstrap phase that failed.
+     *
+     * @return phase, never null
+     */
+    public Phase getPhase() {
+        return phase;
+    }
+
+}

--- a/redisson/src/main/java/org/redisson/client/RedisException.java
+++ b/redisson/src/main/java/org/redisson/client/RedisException.java
@@ -24,19 +24,58 @@ public class RedisException extends RuntimeException {
 
     private static final long serialVersionUID = 3389820652701696154L;
 
+    /**
+     * The raw error string returned by the Redis server on the wire (e.g.
+     * {@code "ERR Exceeded limit of IAM Authentication requests"}), without
+     * the channel/command suffix that appears in {@link #getMessage()}.
+     * <p>
+     * Null when the exception was not produced from a server error response
+     * (e.g. client-side connection failures).
+     */
+    private final String serverError;
+
     public RedisException() {
+        this.serverError = null;
     }
 
     public RedisException(Throwable cause) {
         super(cause);
+        this.serverError = null;
     }
 
     public RedisException(String message, Throwable cause) {
         super(message, cause);
+        this.serverError = null;
     }
 
     public RedisException(String message) {
         super(message);
+        this.serverError = null;
+    }
+
+    /**
+     * Constructs an exception with both a full display message and the raw
+     * server-error prefix. Use this constructor (or subclass it) when the
+     * caller needs to inspect the server error without parsing
+     * {@link #getMessage()}.
+     *
+     * @param message    full display message (may include channel/command context)
+     * @param serverError raw error string from the Redis wire protocol
+     */
+    public RedisException(String message, String serverError) {
+        super(message);
+        this.serverError = serverError;
+    }
+
+    /**
+     * Returns the raw error string from the Redis wire protocol, or
+     * {@code null} if this exception was not created from a server error
+     * response.
+     *
+     * @return raw server error, e.g. {@code "ERR Exceeded limit of IAM Authentication requests"}
+     */
+    public String getServerError() {
+        return serverError;
     }
 
 }

--- a/redisson/src/main/java/org/redisson/client/RedisServerRejectionException.java
+++ b/redisson/src/main/java/org/redisson/client/RedisServerRejectionException.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2013-2026 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.client;
+
+/**
+ * Thrown when a Redis server rejects a command due to server-side resource limits or
+ * rate throttling — as opposed to a protocol error, cluster redirect, or auth failure.
+ * <p>
+ * Examples of server-side rejections covered by this exception:
+ * <ul>
+ *   <li>Max-clients limit reached ({@code ERR max number of clients reached})</li>
+ *   <li>IAM authentication rate limit from AWS ElastiCache
+ *       ({@code ERR Exceeded limit of IAM Authentication requests})</li>
+ *   <li>Generic server-side rate limits or resource-exhaustion errors not matched
+ *       by any other typed {@link RedisException} subclass</li>
+ * </ul>
+ * <p>
+ * Use {@link #getReason()} to branch on the specific cause without parsing the message
+ * string. Use {@link #getServerError()} (inherited from {@link RedisException}) to access
+ * the raw wire error for logging or metrics.
+ */
+public class RedisServerRejectionException extends RedisException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Broad category of the server-side rejection reason.
+     */
+    public enum Reason {
+        /**
+         * Redis's configured {@code maxclients} limit was reached.
+         * Wire error typically starts with {@code "ERR max number of clients reached"}.
+         */
+        MAX_CLIENTS,
+
+        /**
+         * AWS ElastiCache IAM authentication request rate limit was exceeded.
+         * Wire error typically starts with {@code "ERR Exceeded limit of IAM Authentication requests"}.
+         */
+        IAM_THROTTLE,
+
+        /**
+         * A server-side rate limit or resource quota was hit, but not one of the
+         * specifically enumerated cases above.
+         */
+        RATE_LIMITED,
+
+        /**
+         * Server-side rejection that does not match any recognized pattern.
+         * Inspect {@link RedisServerRejectionException#getServerError()} for details.
+         */
+        OTHER
+    }
+
+    private final Reason reason;
+
+    public RedisServerRejectionException(String message, String serverError, Reason reason) {
+        super(message, serverError);
+        this.reason = reason;
+    }
+
+    /**
+     * Returns the classified rejection reason. Never null.
+     */
+    public Reason getReason() {
+        return reason;
+    }
+
+    /**
+     * Classifies a raw Redis wire-error string into a {@link Reason}.
+     * The wire error is the text that follows the {@code '-'} prefix in the RESP protocol,
+     * before any channel/command context is appended.
+     *
+     * @param serverError the raw server error string; must not be null
+     * @return the matching {@link Reason}, never null
+     */
+    public static Reason classifyReason(String serverError) {
+        if (serverError == null) {
+            return Reason.OTHER;
+        }
+        // Normalize to lowercase for case-insensitive matching
+        String lower = serverError.toLowerCase();
+
+        if (lower.contains("max number of clients reached")
+                || lower.contains("maxclients")) {
+            return Reason.MAX_CLIENTS;
+        }
+        if (lower.contains("exceeded limit of iam authentication")
+                || lower.contains("iam authentication requests")) {
+            return Reason.IAM_THROTTLE;
+        }
+        if (lower.contains("rate limit")
+                || lower.contains("ratelimit")
+                || lower.contains("too many connections")
+                || lower.contains("too many requests")
+                || lower.contains("request limit")) {
+            return Reason.RATE_LIMITED;
+        }
+        return Reason.OTHER;
+    }
+}

--- a/redisson/src/main/java/org/redisson/client/handler/BaseConnectionHandler.java
+++ b/redisson/src/main/java/org/redisson/client/handler/BaseConnectionHandler.java
@@ -23,6 +23,8 @@ import org.redisson.client.RedisConnection;
 import org.redisson.client.RedisConnectionBootstrapException;
 import org.redisson.client.RedisConnectionBootstrapException.Phase;
 import org.redisson.client.RedisRetryException;
+import org.redisson.client.RedisServerRejectionException;
+import org.redisson.client.WriteRedisConnectionException;
 import org.redisson.client.protocol.QueueCommand;
 import org.redisson.client.protocol.RedisCommands;
 import org.redisson.config.Protocol;
@@ -132,16 +134,29 @@ public abstract class BaseConnectionHandler<C extends RedisConnection> extends C
     /**
      * Wraps a bootstrap pipeline failure in a {@link RedisConnectionBootstrapException}
      * that identifies which phase failed, so callers don't need to parse the message string.
-     * Scans the individual phase futures to find the first failed one; falls back to
-     * {@link Phase#UNKNOWN} if none can be identified.
+     * <p>
+     * If the channel received an unsolicited server error before any command was sent
+     * (e.g. "ERR max number of clients reached"), that error is stored on the channel
+     * attribute {@link CommandDecoder#UNSOLICITED_ERROR_KEY}. We prefer it as the cause
+     * over a generic channel-closed exception, since it carries the real server reason.
      */
     private RedisConnectionBootstrapException wrapBootstrapFailure(
             List<CompletableFuture<?>> futures, List<Phase> phases, Throwable cause) {
+        // Check if an unsolicited server error arrived before bootstrap started
+        // (e.g. ERR max number of clients reached sent by the server on connect)
+        RedisServerRejectionException unsolicitedError =
+                connection.getChannel().attr(CommandDecoder.UNSOLICITED_ERROR_KEY).get();
+
         for (int i = 0; i < futures.size(); i++) {
             CompletableFuture<?> f = futures.get(i);
             if (f.isCompletedExceptionally()) {
                 Throwable phaseCause = cause(f);
                 Phase phase = phases.get(i);
+                // Prefer the unsolicited server error as the cause when the per-phase
+                // failure is a generic channel-close exception (WriteRedisConnectionException)
+                if (unsolicitedError != null && phaseCause instanceof WriteRedisConnectionException) {
+                    phaseCause = unsolicitedError;
+                }
                 return new RedisConnectionBootstrapException(
                         "Bootstrap failed at phase " + phase + ": " + phaseCause.getMessage(),
                         phase,
@@ -150,6 +165,9 @@ public abstract class BaseConnectionHandler<C extends RedisConnection> extends C
         }
         // cause here is a CompletionException wrapping the real cause; getMessage() may be null
         Throwable rootCause = cause.getCause() != null ? cause.getCause() : cause;
+        if (unsolicitedError != null && rootCause instanceof WriteRedisConnectionException) {
+            rootCause = unsolicitedError;
+        }
         return new RedisConnectionBootstrapException(
                 "Bootstrap failed: " + rootCause.getMessage(),
                 Phase.UNKNOWN,

--- a/redisson/src/main/java/org/redisson/client/handler/BaseConnectionHandler.java
+++ b/redisson/src/main/java/org/redisson/client/handler/BaseConnectionHandler.java
@@ -20,6 +20,8 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import org.redisson.client.RedisClient;
 import org.redisson.client.RedisClientConfig;
 import org.redisson.client.RedisConnection;
+import org.redisson.client.RedisConnectionBootstrapException;
+import org.redisson.client.RedisConnectionBootstrapException.Phase;
 import org.redisson.client.RedisRetryException;
 import org.redisson.client.protocol.QueueCommand;
 import org.redisson.client.protocol.RedisCommands;
@@ -64,36 +66,46 @@ public abstract class BaseConnectionHandler<C extends RedisConnection> extends C
     @Override
     public void channelActive(ChannelHandlerContext ctx) {
         List<CompletableFuture<?>> futures = new ArrayList<>(5);
+        // Parallel list tracking the bootstrap phase for each future, so we can
+        // identify which step failed without parsing the exception message.
+        List<Phase> phases = new ArrayList<>(5);
 
-        CompletableFuture<Void> f = authWithCredential();
-        futures.add(f);
+        CompletableFuture<Void> authFuture = authWithCredential();
+        futures.add(authFuture);
+        phases.add(Phase.AUTH);
 
         RedisClientConfig config = redisClient.getConfig();
 
         if (config.getProtocol() == Protocol.RESP3) {
             CompletionStage<Object> f1 = connection.async(RedisCommands.HELLO, "3");
             futures.add(f1.toCompletableFuture());
+            phases.add(Phase.HELLO);
         }
 
         if (config.getDatabase() != 0) {
             CompletionStage<Object> future = connection.async(RedisCommands.SELECT, config.getDatabase());
             futures.add(future.toCompletableFuture());
+            phases.add(Phase.SELECT);
         }
         if (config.getClientName() != null) {
             CompletionStage<Object> future = connection.async(RedisCommands.CLIENT_SETNAME, config.getClientName());
             futures.add(future.toCompletableFuture());
+            phases.add(Phase.CLIENT_SETNAME);
         }
         if (!config.getCapabilities().isEmpty()) {
             CompletionStage<Object> future = connection.async(RedisCommands.CLIENT_CAPA, config.getCapabilities().toArray());
             futures.add(future.toCompletableFuture());
+            phases.add(Phase.CLIENT_CAPA);
         }
         if (config.isReadOnly()) {
             CompletionStage<Object> future = connection.async(RedisCommands.READONLY);
             futures.add(future.toCompletableFuture());
+            phases.add(Phase.READONLY);
         }
         if (config.getPingConnectionInterval() > 0) {
             CompletionStage<Object> future = connection.async(RedisCommands.PING);
             futures.add(future.toCompletableFuture());
+            phases.add(Phase.PING);
         }
 
         CompletableFuture<Void> future = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
@@ -106,7 +118,7 @@ public abstract class BaseConnectionHandler<C extends RedisConnection> extends C
                     return;
                 }
                 connection.closeAsync();
-                connectionPromise.completeExceptionally(e);
+                connectionPromise.completeExceptionally(wrapBootstrapFailure(futures, phases, e));
                 return;
             }
 
@@ -115,6 +127,33 @@ public abstract class BaseConnectionHandler<C extends RedisConnection> extends C
             ctx.fireChannelActive();
             connectionPromise.complete(connection);
         });
+    }
+
+    /**
+     * Wraps a bootstrap pipeline failure in a {@link RedisConnectionBootstrapException}
+     * that identifies which phase failed, so callers don't need to parse the message string.
+     * Scans the individual phase futures to find the first failed one; falls back to
+     * {@link Phase#UNKNOWN} if none can be identified.
+     */
+    private RedisConnectionBootstrapException wrapBootstrapFailure(
+            List<CompletableFuture<?>> futures, List<Phase> phases, Throwable cause) {
+        for (int i = 0; i < futures.size(); i++) {
+            CompletableFuture<?> f = futures.get(i);
+            if (f.isCompletedExceptionally()) {
+                Throwable phaseCause = cause(f);
+                Phase phase = phases.get(i);
+                return new RedisConnectionBootstrapException(
+                        "Bootstrap failed at phase " + phase + ": " + phaseCause.getMessage(),
+                        phase,
+                        phaseCause);
+            }
+        }
+        // cause here is a CompletionException wrapping the real cause; getMessage() may be null
+        Throwable rootCause = cause.getCause() != null ? cause.getCause() : cause;
+        return new RedisConnectionBootstrapException(
+                "Bootstrap failed: " + rootCause.getMessage(),
+                Phase.UNKNOWN,
+                rootCause);
     }
 
     private CompletionStage<Void> startRenewal(ChannelHandlerContext ctx, RedisClientConfig config) {

--- a/redisson/src/main/java/org/redisson/client/handler/CommandDecoder.java
+++ b/redisson/src/main/java/org/redisson/client/handler/CommandDecoder.java
@@ -58,13 +58,23 @@ import java.util.concurrent.CompletableFuture;
  *
  */
 public class CommandDecoder extends ReplayingDecoder<State> {
-    
+
     final Logger log = LoggerFactory.getLogger(getClass());
 
     private static final char CR = '\r';
     private static final char LF = '\n';
     private static final char ZERO = '0';
-    
+
+    /**
+     * Channel attribute that holds the last unsolicited server error (i.e. an error frame
+     * received when no command is pending on the queue). Stored so that handlers further
+     * up the pipeline — particularly {@link BaseConnectionHandler} — can use the original
+     * typed error when failing the connection promise on channel close, instead of producing
+     * a generic {@link org.redisson.client.RedisConnectionException}.
+     */
+    public static final io.netty.util.AttributeKey<RedisServerRejectionException>
+            UNSOLICITED_ERROR_KEY = io.netty.util.AttributeKey.valueOf("REDISSON_UNSOLICITED_ERROR");
+
     final String scheme;
 
     public CommandDecoder(String scheme) {
@@ -499,6 +509,12 @@ public class CommandDecoder extends ReplayingDecoder<State> {
 
     protected void onError(Channel channel, String error) {
         log.error("Error message from Redis: {} channel: {}", error, channel);
+        // Store on the channel so BaseConnectionHandler can surface it as a typed exception
+        // instead of a generic RedisConnectionException when the channel closes.
+        RedisServerRejectionException.Reason reason = RedisServerRejectionException.classifyReason(error);
+        RedisServerRejectionException ex = new RedisServerRejectionException(
+                "Server error: " + error + ". channel: " + channel, error, reason);
+        channel.attr(UNSOLICITED_ERROR_KEY).set(ex);
     }
 
     private String readString(ByteBuf in, Charset charset) {

--- a/redisson/src/main/java/org/redisson/client/handler/CommandDecoder.java
+++ b/redisson/src/main/java/org/redisson/client/handler/CommandDecoder.java
@@ -436,7 +436,11 @@ public class CommandDecoder extends ReplayingDecoder<State> {
                         + ". channel: " + channel + " data: " + data));
             } else {
                 if (data != null) {
-                    data.tryFailure(new RedisException(error + ". channel: " + channel + " command: " + LogHelper.toString(data)));
+                    RedisServerRejectionException.Reason reason = RedisServerRejectionException.classifyReason(error);
+                    data.tryFailure(new RedisServerRejectionException(
+                            error + ". channel: " + channel + " command: " + LogHelper.toString(data),
+                            error,
+                            reason));
                 } else {
                     onError(channel, error);
                 }

--- a/redisson/src/test/java/org/redisson/client/RedisConnectionBootstrapExceptionTest.java
+++ b/redisson/src/test/java/org/redisson/client/RedisConnectionBootstrapExceptionTest.java
@@ -1,0 +1,77 @@
+package org.redisson.client;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RedisConnectionBootstrapExceptionTest {
+
+    @Test
+    void constructor_preservesAllFields() {
+        RuntimeException cause = new RuntimeException("auth rejected");
+        RedisConnectionBootstrapException ex = new RedisConnectionBootstrapException(
+                "Bootstrap failed at phase AUTH: auth rejected",
+                RedisConnectionBootstrapException.Phase.AUTH,
+                cause);
+
+        assertEquals("Bootstrap failed at phase AUTH: auth rejected", ex.getMessage());
+        assertEquals(RedisConnectionBootstrapException.Phase.AUTH, ex.getPhase());
+        assertSame(cause, ex.getCause());
+    }
+
+    @Test
+    void isRedisConnectionException_subtype() {
+        RedisConnectionBootstrapException ex = new RedisConnectionBootstrapException(
+                "Bootstrap failed",
+                RedisConnectionBootstrapException.Phase.UNKNOWN,
+                new RuntimeException("oops"));
+
+        assertInstanceOf(RedisConnectionException.class, ex);
+    }
+
+    @ParameterizedTest
+    @EnumSource(RedisConnectionBootstrapException.Phase.class)
+    void allPhasesRoundTrip(RedisConnectionBootstrapException.Phase phase) {
+        RedisConnectionBootstrapException ex = new RedisConnectionBootstrapException(
+                "Bootstrap failed at phase " + phase,
+                phase,
+                new RuntimeException("cause"));
+
+        assertEquals(phase, ex.getPhase());
+        assertNotNull(ex.getPhase());
+    }
+
+    @Test
+    void causeCanBeRedisServerRejectionException() {
+        // Verify the full chain: IAM throttle wraps correctly
+        String serverError = "ERR Exceeded limit of IAM Authentication requests";
+        RedisServerRejectionException serverEx = new RedisServerRejectionException(
+                serverError + ". channel: [id: 0x01] command: AUTH",
+                serverError,
+                RedisServerRejectionException.Reason.IAM_THROTTLE);
+
+        RedisConnectionBootstrapException bootstrapEx = new RedisConnectionBootstrapException(
+                "Bootstrap failed at phase AUTH: " + serverEx.getMessage(),
+                RedisConnectionBootstrapException.Phase.AUTH,
+                serverEx);
+
+        assertInstanceOf(RedisServerRejectionException.class, bootstrapEx.getCause());
+        RedisServerRejectionException wrapped = (RedisServerRejectionException) bootstrapEx.getCause();
+        assertEquals(RedisServerRejectionException.Reason.IAM_THROTTLE, wrapped.getReason());
+        assertEquals(serverError, wrapped.getServerError());
+        assertEquals(RedisConnectionBootstrapException.Phase.AUTH, bootstrapEx.getPhase());
+    }
+
+    @Test
+    void phaseNeverNull() {
+        RedisConnectionBootstrapException ex = new RedisConnectionBootstrapException(
+                "Bootstrap failed",
+                RedisConnectionBootstrapException.Phase.SELECT,
+                new RuntimeException("db unavailable"));
+
+        assertNotNull(ex.getPhase());
+        assertEquals(RedisConnectionBootstrapException.Phase.SELECT, ex.getPhase());
+    }
+}

--- a/redisson/src/test/java/org/redisson/client/RedisErrorBubblingIntegrationTest.java
+++ b/redisson/src/test/java/org/redisson/client/RedisErrorBubblingIntegrationTest.java
@@ -1,0 +1,242 @@
+package org.redisson.client;
+
+import org.junit.jupiter.api.Test;
+import org.redisson.RedisDockerTest;
+import org.redisson.Redisson;
+import org.redisson.client.codec.StringCodec;
+import org.redisson.client.protocol.RedisCommands;
+import org.redisson.config.Config;
+import org.testcontainers.containers.GenericContainer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests verifying that server-side rejection and bootstrap errors
+ * surface as the correct typed exception classes end-to-end.
+ * <p>
+ * Each test spins up a real Redis container so the full pipeline is exercised:
+ * server sends a RESP error frame → CommandDecoder routes it → caller receives
+ * the typed exception.
+ */
+public class RedisErrorBubblingIntegrationTest extends RedisDockerTest {
+
+    /**
+     * When Redis is configured with requirepass and the client supplies a wrong password,
+     * AUTH fails during the bootstrap pipeline. The exception must:
+     * <ul>
+     *   <li>Be a {@link RedisConnectionBootstrapException}</li>
+     *   <li>Have {@code phase == AUTH}</li>
+     *   <li>Be caused by {@link RedisWrongPasswordException}</li>
+     * </ul>
+     */
+    @Test
+    public void wrongPassword_bootstrapFails_withAuthPhase() {
+        GenericContainer<?> redis = createContainer("--requirepass", "correctpass");
+        redis.start();
+
+        try {
+            Config config = createConfig(redis);
+            config.useSingleServer().setPassword("wrongpassword");
+
+            RedisConnectionException thrown = assertThrows(RedisConnectionException.class,
+                    () -> Redisson.create(config));
+
+            Throwable bootstrapEx = findCause(thrown, RedisConnectionBootstrapException.class);
+            assertNotNull(bootstrapEx,
+                    "Expected RedisConnectionBootstrapException in chain, got: " + thrown);
+
+            RedisConnectionBootstrapException bex = (RedisConnectionBootstrapException) bootstrapEx;
+            assertEquals(RedisConnectionBootstrapException.Phase.AUTH, bex.getPhase(),
+                    "Wrong password must fail at AUTH phase");
+
+            Throwable cause = bex.getCause();
+            assertTrue(cause instanceof RedisWrongPasswordException || cause instanceof RedisAuthRequiredException,
+                    "Cause should be RedisWrongPasswordException or RedisAuthRequiredException, was: "
+                            + (cause != null ? cause.getClass().getSimpleName() : "null"));
+        } finally {
+            redis.stop();
+        }
+    }
+
+    /**
+     * When Redis hits its maxclients limit, a new connection receives
+     * {@code "ERR max number of clients reached"} from the server.
+     * This must surface as a {@link RedisServerRejectionException} with
+     * {@code reason == MAX_CLIENTS}.
+     * <p>
+     * We use {@code --maxclients 1} so the first connection fills the limit
+     * and the second connection is immediately rejected.
+     */
+    @Test
+    public void maxClientsReached_emitsRedisServerRejectionException() throws Exception {
+        // maxclients 1: first connected client fills the slot; second connection rejected
+        GenericContainer<?> redis = createContainer("--maxclients", "1");
+        redis.start();
+
+        RedisClientConfig firstConfig = new RedisClientConfig();
+        firstConfig.setAddress("redis://127.0.0.1:" + redis.getFirstMappedPort());
+        RedisClient firstClient = RedisClient.create(firstConfig);
+        RedisConnection firstConn = firstClient.connect();
+        firstConn.sync(RedisCommands.PING); // establish and hold the slot
+
+        try {
+            RedisClientConfig secondConfig = new RedisClientConfig();
+            secondConfig.setAddress("redis://127.0.0.1:" + redis.getFirstMappedPort());
+            RedisClient secondClient = RedisClient.create(secondConfig);
+
+            try {
+                Exception ex = assertThrows(Exception.class,
+                        () -> secondClient.connectAsync().toCompletableFuture().get());
+
+                Throwable cause = ex.getCause() != null ? ex.getCause() : ex;
+                RedisServerRejectionException rejection =
+                        (RedisServerRejectionException) findCause(cause, RedisServerRejectionException.class);
+
+                assertNotNull(rejection,
+                        "Expected RedisServerRejectionException in chain, got: " + cause);
+                assertEquals(RedisServerRejectionException.Reason.MAX_CLIENTS, rejection.getReason(),
+                        "Max-clients rejection must have MAX_CLIENTS reason");
+                assertNotNull(rejection.getServerError(),
+                        "serverError must not be null");
+                assertTrue(rejection.getServerError().toLowerCase().contains("clients"),
+                        "serverError should mention clients, was: " + rejection.getServerError());
+            } finally {
+                secondClient.shutdown();
+            }
+        } finally {
+            firstConn.closeAsync();
+            firstClient.shutdown();
+            redis.stop();
+        }
+    }
+
+    /**
+     * A Lua script that returns {@code redis.error_reply()} with an unrecognized
+     * prefix exercises the else-branch in CommandDecoder. The exception must be
+     * a {@link RedisServerRejectionException} and {@link RedisException#getServerError()}
+     * must equal the raw wire error string without the channel/command context appended.
+     */
+    @Test
+    public void unrecognizedServerError_preservedInGetServerError() {
+        RedisClientConfig config = new RedisClientConfig();
+        config.setAddress("redis://127.0.0.1:" + CONTAINER.getFirstMappedPort());
+        RedisClient client = RedisClient.create(config);
+
+        try {
+            RedisConnection conn = client.connect();
+            try {
+                RedisException ex = assertThrows(RedisException.class, () ->
+                        conn.sync(StringCodec.INSTANCE, RedisCommands.EVAL_OBJECT,
+                                "return redis.error_reply('ERR rate limit exceeded')",
+                                0));
+
+                assertInstanceOf(RedisServerRejectionException.class, ex,
+                        "Unrecognized server error must be RedisServerRejectionException");
+                RedisServerRejectionException rejection = (RedisServerRejectionException) ex;
+
+                // Raw wire error — no channel/command context
+                assertEquals("ERR rate limit exceeded", rejection.getServerError(),
+                        "getServerError() must be the raw wire error without appended context");
+                assertEquals(RedisServerRejectionException.Reason.RATE_LIMITED, rejection.getReason());
+
+                // getMessage() includes the channel/command context for logging
+                assertTrue(rejection.getMessage().startsWith("ERR rate limit exceeded"),
+                        "getMessage() must start with the raw error");
+                assertTrue(rejection.getMessage().contains("channel:") || rejection.getMessage().contains("command:"),
+                        "getMessage() should contain channel/command context");
+            } finally {
+                conn.closeAsync();
+            }
+        } finally {
+            client.shutdown();
+        }
+    }
+
+    /**
+     * Verifies the IAM throttle string is classified as {@code IAM_THROTTLE}.
+     * We simulate the wire error via a Lua script.
+     */
+    @Test
+    public void iamThrottleError_classifiedAsIamThrottle() {
+        RedisClientConfig config = new RedisClientConfig();
+        config.setAddress("redis://127.0.0.1:" + CONTAINER.getFirstMappedPort());
+        RedisClient client = RedisClient.create(config);
+
+        try {
+            RedisConnection conn = client.connect();
+            try {
+                RedisException ex = assertThrows(RedisException.class, () ->
+                        conn.sync(StringCodec.INSTANCE, RedisCommands.EVAL_OBJECT,
+                                "return redis.error_reply('ERR Exceeded limit of IAM Authentication requests')",
+                                0));
+
+                assertInstanceOf(RedisServerRejectionException.class, ex);
+                RedisServerRejectionException rejection = (RedisServerRejectionException) ex;
+                assertEquals(RedisServerRejectionException.Reason.IAM_THROTTLE, rejection.getReason());
+                assertEquals("ERR Exceeded limit of IAM Authentication requests",
+                        rejection.getServerError());
+            } finally {
+                conn.closeAsync();
+            }
+        } finally {
+            client.shutdown();
+        }
+    }
+
+    /**
+     * Typed error prefixes (NOAUTH, WRONGPASS, etc.) must not be routed to the
+     * else-branch and must NOT become {@link RedisServerRejectionException}.
+     */
+    @Test
+    public void noauthError_isRedisAuthRequiredException_notServerRejection() {
+        GenericContainer<?> redis = createContainer("--requirepass", "secret");
+        redis.start();
+
+        try {
+            // Connect without password — AUTH is skipped in bootstrap; first command triggers NOAUTH
+            RedisClientConfig config = new RedisClientConfig();
+            config.setAddress("redis://127.0.0.1:" + redis.getFirstMappedPort());
+            // No password configured → bootstrap completes (no AUTH sent), first command returns NOAUTH
+            RedisClient client = RedisClient.create(config);
+
+            try {
+                // connectAsync will trigger bootstrap; since no password, no AUTH is sent.
+                // The first command after connect will get NOAUTH.
+                RedisConnection conn = client.connectAsync().toCompletableFuture().join();
+                try {
+                    RedisException ex = assertThrows(RedisException.class, () ->
+                            conn.sync(StringCodec.INSTANCE, RedisCommands.GET, "anykey"));
+
+                    assertInstanceOf(RedisAuthRequiredException.class, ex,
+                            "NOAUTH should be RedisAuthRequiredException");
+                    assertFalse(ex instanceof RedisServerRejectionException,
+                            "NOAUTH must NOT be RedisServerRejectionException");
+                } finally {
+                    conn.closeAsync();
+                }
+            } finally {
+                client.shutdown();
+            }
+        } finally {
+            redis.stop();
+        }
+    }
+
+    /**
+     * Traverses the exception cause chain for an instance of the given type.
+     *
+     * @return first matching cause, or null if not found within 20 levels
+     */
+    private static Throwable findCause(Throwable t, Class<? extends Throwable> type) {
+        Throwable current = t;
+        int depth = 0;
+        while (current != null && depth < 20) {
+            if (type.isInstance(current)) {
+                return current;
+            }
+            current = current.getCause();
+            depth++;
+        }
+        return null;
+    }
+}

--- a/redisson/src/test/java/org/redisson/client/RedisErrorBubblingIntegrationTest.java
+++ b/redisson/src/test/java/org/redisson/client/RedisErrorBubblingIntegrationTest.java
@@ -8,6 +8,8 @@ import org.redisson.client.protocol.RedisCommands;
 import org.redisson.config.Config;
 import org.testcontainers.containers.GenericContainer;
 
+import java.util.concurrent.TimeUnit;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -60,52 +62,61 @@ public class RedisErrorBubblingIntegrationTest extends RedisDockerTest {
 
     /**
      * When Redis hits its maxclients limit, a new connection receives
-     * {@code "ERR max number of clients reached"} from the server.
-     * This must surface as a {@link RedisServerRejectionException} with
-     * {@code reason == MAX_CLIENTS}.
+     * {@code "ERR max number of clients reached"} as an unsolicited pre-command
+     * server message before AUTH or any other bootstrap command can complete.
      * <p>
-     * We use {@code --maxclients 1} so the first connection fills the limit
-     * and the second connection is immediately rejected.
+     * The error is stored on the channel via {@link CommandDecoder#UNSOLICITED_ERROR_KEY}
+     * and surfaced as a {@link RedisConnectionBootstrapException} whose cause is a
+     * {@link RedisServerRejectionException} with {@code reason == MAX_CLIENTS}.
+     * <p>
+     * Strategy: start Redis with a low {@code --maxclients}. Open connections one by one
+     * until one is rejected. Redis reserves a small number of extra slots for admin
+     * connections, so we open up to {@code maxclients + 5} before failing the test.
      */
     @Test
-    public void maxClientsReached_emitsRedisServerRejectionException() throws Exception {
-        // maxclients 1: first connected client fills the slot; second connection rejected
-        GenericContainer<?> redis = createContainer("--maxclients", "1");
+    public void maxClientsReached_bootstrapExceptionContainsServerRejection() throws Exception {
+        final int maxClients = 4;
+        GenericContainer<?> redis = createContainer("--maxclients", String.valueOf(maxClients));
         redis.start();
 
-        RedisClientConfig firstConfig = new RedisClientConfig();
-        firstConfig.setAddress("redis://127.0.0.1:" + redis.getFirstMappedPort());
-        RedisClient firstClient = RedisClient.create(firstConfig);
-        RedisConnection firstConn = firstClient.connect();
-        firstConn.sync(RedisCommands.PING); // establish and hold the slot
+        int port = redis.getFirstMappedPort();
+        java.util.List<RedisClient> openedClients = new java.util.ArrayList<>();
+        java.util.List<RedisConnection> openedConns = new java.util.ArrayList<>();
 
         try {
-            RedisClientConfig secondConfig = new RedisClientConfig();
-            secondConfig.setAddress("redis://127.0.0.1:" + redis.getFirstMappedPort());
-            RedisClient secondClient = RedisClient.create(secondConfig);
-
-            try {
-                Exception ex = assertThrows(Exception.class,
-                        () -> secondClient.connectAsync().toCompletableFuture().get());
-
-                Throwable cause = ex.getCause() != null ? ex.getCause() : ex;
-                RedisServerRejectionException rejection =
-                        (RedisServerRejectionException) findCause(cause, RedisServerRejectionException.class);
-
-                assertNotNull(rejection,
-                        "Expected RedisServerRejectionException in chain, got: " + cause);
-                assertEquals(RedisServerRejectionException.Reason.MAX_CLIENTS, rejection.getReason(),
-                        "Max-clients rejection must have MAX_CLIENTS reason");
-                assertNotNull(rejection.getServerError(),
-                        "serverError must not be null");
-                assertTrue(rejection.getServerError().toLowerCase().contains("clients"),
-                        "serverError should mention clients, was: " + rejection.getServerError());
-            } finally {
-                secondClient.shutdown();
+            Exception rejectionEx = null;
+            // Keep opening connections until we hit the limit (at most maxclients + 5 attempts)
+            for (int attempt = 0; attempt < maxClients + 5; attempt++) {
+                RedisClientConfig cfg = new RedisClientConfig();
+                cfg.setAddress("redis://127.0.0.1:" + port);
+                RedisClient client = RedisClient.create(cfg);
+                openedClients.add(client);
+                try {
+                    RedisConnection conn = client.connectAsync().toCompletableFuture().get(5, TimeUnit.SECONDS);
+                    conn.sync(RedisCommands.PING);
+                    openedConns.add(conn);
+                } catch (Exception e) {
+                    rejectionEx = e;
+                    break;
+                }
             }
+
+            assertNotNull(rejectionEx, "Expected a connection to be rejected after filling maxclients=" + maxClients);
+
+            Throwable cause = rejectionEx.getCause() != null ? rejectionEx.getCause() : rejectionEx;
+            RedisServerRejectionException rejection =
+                    (RedisServerRejectionException) findCause(cause, RedisServerRejectionException.class);
+
+            assertNotNull(rejection,
+                    "Expected RedisServerRejectionException in chain, got: " + cause);
+            assertEquals(RedisServerRejectionException.Reason.MAX_CLIENTS, rejection.getReason(),
+                    "Max-clients rejection must have MAX_CLIENTS reason");
+            assertNotNull(rejection.getServerError(), "serverError must not be null");
+            assertTrue(rejection.getServerError().toLowerCase().contains("clients"),
+                    "serverError should mention clients, was: " + rejection.getServerError());
         } finally {
-            firstConn.closeAsync();
-            firstClient.shutdown();
+            for (RedisConnection c : openedConns) c.closeAsync();
+            for (RedisClient c : openedClients) c.shutdown();
             redis.stop();
         }
     }

--- a/redisson/src/test/java/org/redisson/client/RedisServerRejectionExceptionTest.java
+++ b/redisson/src/test/java/org/redisson/client/RedisServerRejectionExceptionTest.java
@@ -1,0 +1,99 @@
+package org.redisson.client;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RedisServerRejectionExceptionTest {
+
+    // --- classifyReason ---
+
+    @ParameterizedTest(name = "classifyReason(\"{0}\") == MAX_CLIENTS")
+    @CsvSource({
+        "ERR max number of clients reached",
+        "ERR Max number of clients reached",
+        "ERR MAX NUMBER OF CLIENTS REACHED",
+        "ERR maxclients limit exceeded",
+        "MAXCLIENTS"
+    })
+    void classifyReason_maxClients(String serverError) {
+        assertEquals(RedisServerRejectionException.Reason.MAX_CLIENTS,
+                RedisServerRejectionException.classifyReason(serverError));
+    }
+
+    @ParameterizedTest(name = "classifyReason(\"{0}\") == IAM_THROTTLE")
+    @CsvSource({
+        "ERR Exceeded limit of IAM Authentication requests",
+        "ERR exceeded limit of iam authentication requests",
+        "ERR IAM Authentication requests exceeded",
+        "ERR iam authentication requests limit"
+    })
+    void classifyReason_iamThrottle(String serverError) {
+        assertEquals(RedisServerRejectionException.Reason.IAM_THROTTLE,
+                RedisServerRejectionException.classifyReason(serverError));
+    }
+
+    @ParameterizedTest(name = "classifyReason(\"{0}\") == RATE_LIMITED")
+    @CsvSource({
+        "ERR rate limit exceeded",
+        "ERR ratelimit hit",
+        "ERR too many connections",
+        "ERR too many requests",
+        "ERR request limit exceeded"
+    })
+    void classifyReason_rateLimited(String serverError) {
+        assertEquals(RedisServerRejectionException.Reason.RATE_LIMITED,
+                RedisServerRejectionException.classifyReason(serverError));
+    }
+
+    @ParameterizedTest(name = "classifyReason(\"{0}\") == OTHER")
+    @CsvSource({
+        "ERR some unknown error",
+        "ERR syntax error",
+        "WRONGTYPE Operation against a key holding the wrong kind of value",
+        "ERR value is not an integer or out of range"
+    })
+    void classifyReason_other(String serverError) {
+        assertEquals(RedisServerRejectionException.Reason.OTHER,
+                RedisServerRejectionException.classifyReason(serverError));
+    }
+
+    @Test
+    void classifyReason_nullInput_returnsOther() {
+        assertEquals(RedisServerRejectionException.Reason.OTHER,
+                RedisServerRejectionException.classifyReason(null));
+    }
+
+    // --- constructor / accessors ---
+
+    @Test
+    void constructor_preservesAllFields() {
+        String serverError = "ERR max number of clients reached";
+        String message = serverError + ". channel: [id: 0x00] command: GET";
+        RedisServerRejectionException ex = new RedisServerRejectionException(
+                message, serverError, RedisServerRejectionException.Reason.MAX_CLIENTS);
+
+        assertEquals(message, ex.getMessage());
+        assertEquals(serverError, ex.getServerError());
+        assertEquals(RedisServerRejectionException.Reason.MAX_CLIENTS, ex.getReason());
+    }
+
+    @Test
+    void isRedisException_subtype() {
+        RedisServerRejectionException ex = new RedisServerRejectionException(
+                "ERR max number of clients reached", "ERR max number of clients reached",
+                RedisServerRejectionException.Reason.MAX_CLIENTS);
+
+        assertInstanceOf(RedisException.class, ex);
+    }
+
+    @Test
+    void reasonNeverNull() {
+        RedisServerRejectionException ex = new RedisServerRejectionException(
+                "ERR something", "ERR something", RedisServerRejectionException.Reason.OTHER);
+
+        assertNotNull(ex.getReason());
+    }
+}

--- a/redisson/src/test/java/org/redisson/client/handler/CommandDecoderErrorRoutingTest.java
+++ b/redisson/src/test/java/org/redisson/client/handler/CommandDecoderErrorRoutingTest.java
@@ -1,0 +1,190 @@
+package org.redisson.client.handler;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.local.LocalChannel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.redisson.client.RedisAuthRequiredException;
+import org.redisson.client.RedisBusyException;
+import org.redisson.client.RedisClusterDownException;
+import org.redisson.client.RedisException;
+import org.redisson.client.RedisLoadingException;
+import org.redisson.client.RedisMasterDownException;
+import org.redisson.client.RedisNoReplicasException;
+import org.redisson.client.RedisNoScriptException;
+import org.redisson.client.RedisOutOfMemoryException;
+import org.redisson.client.RedisReadonlyException;
+import org.redisson.client.RedisServerRejectionException;
+import org.redisson.client.RedisServerRejectionException.Reason;
+import org.redisson.client.RedisWaitException;
+import org.redisson.client.RedisWrongPasswordException;
+import org.redisson.client.codec.StringCodec;
+import org.redisson.client.protocol.CommandData;
+import org.redisson.client.protocol.RedisCommands;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for the error-response routing in {@link CommandDecoder#decode}.
+ * Calls the protected {@code decode(ByteBuf, CommandData, ...)} method directly
+ * so tests remain fast and don't require a live Redis instance.
+ */
+class CommandDecoderErrorRoutingTest {
+
+    /** Thin subclass that exposes the protected decode method for testing. */
+    static class TestableDecoder extends CommandDecoder {
+        TestableDecoder() {
+            super("redis");
+        }
+
+        void decodeError(ByteBuf buf, CommandData<Object, Object> data, Channel channel)
+                throws IOException {
+            decode(buf, data, null, channel, false, null, 0, new State());
+        }
+    }
+
+    private TestableDecoder decoder;
+    private Channel channel;
+
+    @BeforeEach
+    void setUp() {
+        decoder = new TestableDecoder();
+        channel = new LocalChannel();
+    }
+
+    private ByteBuf errorResponse(String serverError) {
+        // RESP error frame: "-{message}\r\n"
+        String frame = "-" + serverError + "\r\n";
+        return Unpooled.copiedBuffer(frame, StandardCharsets.US_ASCII);
+    }
+
+    private CommandData<Object, Object> newCommand() {
+        return new CommandData<>(new CompletableFuture<>(), StringCodec.INSTANCE,
+                RedisCommands.GET, new Object[]{"key"});
+    }
+
+    // ---- else-branch: RedisServerRejectionException ----
+
+    @Test
+    void elseError_maxClients_emitsRedisServerRejectionException() throws IOException {
+        String serverError = "ERR max number of clients reached";
+        CommandData<Object, Object> cmd = newCommand();
+
+        decoder.decodeError(errorResponse(serverError), cmd, channel);
+
+        Throwable cause = cmd.cause();
+        assertInstanceOf(RedisServerRejectionException.class, cause);
+        RedisServerRejectionException ex = (RedisServerRejectionException) cause;
+        assertEquals(Reason.MAX_CLIENTS, ex.getReason());
+        assertEquals(serverError, ex.getServerError());
+        assertTrue(ex.getMessage().startsWith(serverError));
+    }
+
+    @Test
+    void elseError_iamThrottle_emitsRedisServerRejectionException() throws IOException {
+        String serverError = "ERR Exceeded limit of IAM Authentication requests";
+        CommandData<Object, Object> cmd = newCommand();
+
+        decoder.decodeError(errorResponse(serverError), cmd, channel);
+
+        Throwable cause = cmd.cause();
+        assertInstanceOf(RedisServerRejectionException.class, cause);
+        RedisServerRejectionException ex = (RedisServerRejectionException) cause;
+        assertEquals(Reason.IAM_THROTTLE, ex.getReason());
+        assertEquals(serverError, ex.getServerError());
+    }
+
+    @Test
+    void elseError_unknownError_emitsOtherReason() throws IOException {
+        String serverError = "ERR some completely unknown error";
+        CommandData<Object, Object> cmd = newCommand();
+
+        decoder.decodeError(errorResponse(serverError), cmd, channel);
+
+        Throwable cause = cmd.cause();
+        assertInstanceOf(RedisServerRejectionException.class, cause);
+        assertEquals(Reason.OTHER, ((RedisServerRejectionException) cause).getReason());
+    }
+
+    @Test
+    void elseError_serverErrorPreservedInGetServerError() throws IOException {
+        String serverError = "ERR rate limit exceeded";
+        CommandData<Object, Object> cmd = newCommand();
+
+        decoder.decodeError(errorResponse(serverError), cmd, channel);
+
+        RedisServerRejectionException ex = (RedisServerRejectionException) cmd.cause();
+        assertEquals(serverError, ex.getServerError());
+    }
+
+    @Test
+    void elseError_isRedisExceptionSubtype() throws IOException {
+        CommandData<Object, Object> cmd = newCommand();
+
+        decoder.decodeError(errorResponse("ERR something"), cmd, channel);
+
+        assertInstanceOf(RedisException.class, cmd.cause());
+    }
+
+    // ---- typed branches still emit their typed exceptions ----
+
+    static Stream<Arguments> typedErrorBranches() {
+        return Stream.of(
+            Arguments.of("NOAUTH Authentication required", RedisAuthRequiredException.class),
+            Arguments.of("WRONGPASS invalid username-password pair", RedisWrongPasswordException.class),
+            Arguments.of("OOM command not allowed", RedisOutOfMemoryException.class),
+            Arguments.of("CLUSTERDOWN The cluster is down", RedisClusterDownException.class),
+            Arguments.of("MASTERDOWN Link with MASTER is down", RedisMasterDownException.class),
+            Arguments.of("BUSY Redis is busy running a script", RedisBusyException.class),
+            Arguments.of("READONLY You can't write against a read only replica", RedisReadonlyException.class),
+            Arguments.of("NOSCRIPT No matching script", RedisNoScriptException.class),
+            Arguments.of("NOREPLICAS Not enough replicas connected", RedisNoReplicasException.class),
+            Arguments.of("LOADING Redis is loading the dataset in memory", RedisLoadingException.class),
+            Arguments.of("WAIT numreplicas timeout", RedisWaitException.class)
+        );
+    }
+
+    @ParameterizedTest(name = "\"{0}\" -> {1}")
+    @MethodSource("typedErrorBranches")
+    void typedError_emitsCorrectException(String serverError, Class<? extends RedisException> expectedType)
+            throws IOException {
+        CommandData<Object, Object> cmd = newCommand();
+
+        decoder.decodeError(errorResponse(serverError), cmd, channel);
+
+        assertInstanceOf(expectedType, cmd.cause(),
+                "Expected " + expectedType.getSimpleName() + " for error: " + serverError);
+    }
+
+    @ParameterizedTest(name = "\"{0}\" -> typed, NOT RedisServerRejectionException")
+    @MethodSource("typedErrorBranches")
+    void typedError_isNotRedisServerRejectionException(String serverError, Class<?> ignored)
+            throws IOException {
+        CommandData<Object, Object> cmd = newCommand();
+
+        decoder.decodeError(errorResponse(serverError), cmd, channel);
+
+        assertFalse(cmd.cause() instanceof RedisServerRejectionException,
+                "Typed error should NOT become RedisServerRejectionException: " + serverError);
+    }
+
+    // ---- null data path (no command on queue): must not throw ----
+
+    @Test
+    void elseError_nullData_noException() {
+        String serverError = "ERR max number of clients reached";
+        ByteBuf buf = errorResponse(serverError);
+
+        assertDoesNotThrow(() -> decoder.decodeError(buf, null, channel));
+    }
+}


### PR DESCRIPTION
## Summary
Adds a typed exception hierarchy so callers can implement rate limiting, retry logic, and backoff strategies against specific Redis server-side rejection categories — without parsing error message strings.
Library users can now catch RedisServerRejectionException, inspect getReason(), and take structured action: back off on IAM_THROTTLE, shed load on MAX_CLIENTS, apply a token bucket on RATE_LIMITED. Previously the only option was grepping getMessage(), which is fragile and breaks across Redis versions and providers (e.g. ElastiCache IAM errors differ from vanilla Redis errors).

## Problem
Previously all unrecognized server errors surfaced as a plain RedisException with no structured way to distinguish:
  - IAM authentication throttle (ERR Exceeded limit of IAM Authentication requests)
  - Max clients rejection (ERR max number of clients reached)
  - Rate limiting or other policy errors
Callers were forced to call getMessage() and grep for substrings — fragile and easy to get wrong.
There was also a second bug: when Redis rejects a connection at the TCP level with maxclients exceeded, the error arrives before any command is queued, so the existing onError() path only logged it and the typed reason was lost. The caller received a generic WriteRedisConnectionException with no trace of the real cause.

## Changes

New classes
  - RedisServerRejectionException — extends RedisException; carries a Reason enum (MAX_CLIENTS, IAM_THROTTLE, RATE_LIMITED, OTHER) and a getServerError()
  accessor returning the raw wire error string without appended channel/command context
  - RedisConnectionBootstrapException — extends RedisConnectionException; carries a Phase enum (AUTH, HELLO, SELECT, CLIENT_SETNAME, CLIENT_CAPA, READONLY,
  PING, UNKNOWN) identifying which bootstrap step failed

Modified: RedisException
Added serverError field + getServerError() accessor. All existing constructors set it to null for full backward compatibility.

Modified: CommandDecoder
  - Else-branch now throws RedisServerRejectionException (with classified Reason) instead of plain RedisException
  - onError() (unsolicited errors, data == null) now stores a RedisServerRejectionException on a Netty channel attribute (UNSOLICITED_ERROR_KEY) instead of
  only logging, so it can be recovered downstream

Modified: BaseConnectionHandler
  - channelActive() tracks a parallel phases list alongside the bootstrap futures list
  - New wrapBootstrapFailure() reads UNSOLICITED_ERROR_KEY from the channel and substitutes it as the exception cause whenever the per-phase failure is a
  generic WriteRedisConnectionException (channel closed), preserving the real server reason through to the caller

## Tests
Unit tests and integrations tests added.

  Integration tests cover:
  - Wrong password → RedisConnectionBootstrapException with phase=AUTH, caused by RedisWrongPasswordException
  - Max clients → RedisServerRejectionException with reason=MAX_CLIENTS surfaced through bootstrap
  - Unrecognized error → RedisServerRejectionException with correct getServerError() (raw wire string, no context appended)
  - IAM throttle string → classified as IAM_THROTTLE
  - NOAUTH error → RedisAuthRequiredException, not RedisServerRejectionException
