### PR TITLE
Fix FT.SEARCH/FT.AGGREGATE coordinator hotspot in Redis Cluster (#7165)

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonSearch.java
+++ b/redisson/src/main/java/org/redisson/RedissonSearch.java
@@ -445,7 +445,7 @@ public class RedissonSearch implements RSearch {
                                             new ObjectListReplayDecoder()));
         }
 
-        return commandExecutor.readAsync(indexName, StringCodec.INSTANCE, command, args.toArray());
+        return commandExecutor.readRoundRobinAsync(StringCodec.INSTANCE, command, args.toArray());
     }
 
     @SuppressWarnings("MethodLength")
@@ -824,7 +824,7 @@ public class RedissonSearch implements RSearch {
             }
         }
 
-        return commandExecutor.writeAsync(indexName, StringCodec.INSTANCE, command, args.toArray());
+        return commandExecutor.writeRoundRobinAsync(StringCodec.INSTANCE, command, args.toArray());
     }
 
     @Override
@@ -840,7 +840,7 @@ public class RedissonSearch implements RSearch {
         RedisStrictCommand<SearchProfileResult> command = new RedisStrictCommand<>("FT.PROFILE",
                 new UnboundedListMultiDecoder(new SearchProfileResultDecoder()));
 
-        return commandExecutor.readAsync(indexName, StringCodec.INSTANCE, command, args.toArray());
+        return commandExecutor.readRoundRobinAsync(StringCodec.INSTANCE, command, args.toArray());
     }
 
     @Override
@@ -856,7 +856,7 @@ public class RedissonSearch implements RSearch {
         RedisStrictCommand<AggregateProfileResult> command = new RedisStrictCommand<>("FT.PROFILE",
                 new UnboundedListMultiDecoder(new AggregateProfileResultDecoder()));
 
-        return commandExecutor.readAsync(indexName, StringCodec.INSTANCE, command, args.toArray());
+        return commandExecutor.readRoundRobinAsync(StringCodec.INSTANCE, command, args.toArray());
     }
 
     private static List<Object> buildProfileArgs(String indexName, String queryType, boolean limited, List<Object> innerArgs) {
@@ -1144,7 +1144,7 @@ public class RedissonSearch implements RSearch {
                             new ObjectMapReplayDecoder(new CompositeCodec(StringCodec.INSTANCE, DoubleCodec.INSTANCE))));
         }
 
-        return commandExecutor.readAsync(indexName, StringCodec.INSTANCE, command, args.toArray());
+        return commandExecutor.readRoundRobinAsync(StringCodec.INSTANCE, command, args.toArray());
     }
 
     @Override

--- a/redisson/src/main/java/org/redisson/command/CommandAsyncExecutor.java
+++ b/redisson/src/main/java/org/redisson/command/CommandAsyncExecutor.java
@@ -137,6 +137,10 @@ public interface CommandAsyncExecutor {
 
     <T, R> RFuture<R> readRandomAsync(RedisClient client, Codec codec, RedisCommand<T> command, Object... params);
 
+    <T, R> RFuture<R> readRoundRobinAsync(Codec codec, RedisCommand<T> command, Object... params);
+
+    <T, R> RFuture<R> writeRoundRobinAsync(Codec codec, RedisCommand<T> command, Object... params);
+
     <V> RFuture<V> pollFromAnyAsync(String name, Codec codec, RedisCommand<?> command, long secondsTimeout, String... queueNames);
 
     ByteBuf encode(Codec codec, Object value);

--- a/redisson/src/main/java/org/redisson/command/CommandAsyncService.java
+++ b/redisson/src/main/java/org/redisson/command/CommandAsyncService.java
@@ -278,7 +278,19 @@ public class CommandAsyncService implements CommandAsyncExecutor {
         retryReadRandomAsync(codec, command, mainPromise, list, params);
         return new CompletableFutureWrapper<>(mainPromise);
     }
-    
+
+    @Override
+    public <T, R> RFuture<R> readRoundRobinAsync(Codec codec, RedisCommand<T> command, Object... params) {
+        MasterSlaveEntry entry = connectionManager.getNextEntry();
+        return async(true, new NodeSource(entry), codec, command, params, false, false);
+    }
+
+    @Override
+    public <T, R> RFuture<R> writeRoundRobinAsync(Codec codec, RedisCommand<T> command, Object... params) {
+        MasterSlaveEntry entry = connectionManager.getNextEntry();
+        return async(false, new NodeSource(entry), codec, command, params, false, false);
+    }
+
     private <R, T> void retryReadRandomAsync(Codec codec, RedisCommand<T> command, CompletableFuture<R> mainPromise,
             List<RedisClient> nodes, Object... params) {
         RedisClient client = nodes.remove(0);

--- a/redisson/src/main/java/org/redisson/connection/ConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/ConnectionManager.java
@@ -50,6 +50,13 @@ public interface ConnectionManager {
 
     Collection<MasterSlaveEntry> getEntrySet();
 
+    /**
+     * Returns the next master entry using round-robin strategy.
+     * In single-server mode returns the single master; in cluster mode
+     * distributes across all cluster masters.
+     */
+    MasterSlaveEntry getNextEntry();
+
     MasterSlaveEntry getEntry(String name);
 
     MasterSlaveEntry getEntry(int slot);

--- a/redisson/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
@@ -33,6 +33,7 @@ import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -65,6 +66,8 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
     protected final AtomicReference<CompletableFuture<Void>> lazyConnectLatch = new AtomicReference<>();
 
     private boolean lastAttempt;
+
+    protected final AtomicInteger rrCounter = new AtomicInteger(0);
 
     MasterSlaveConnectionManager(BaseMasterSlaveServersConfig<?> cfg, Config configCopy) {
         if (cfg instanceof MasterSlaveServersConfig) {
@@ -156,6 +159,28 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
             return Collections.singletonList(masterSlaveEntry);
         }
         return Collections.emptyList();
+    }
+
+    /**
+     * Selects the next master entry using round-robin strategy.
+     * In single-server mode returns the single master; in cluster mode
+     * distributes across all cluster masters.
+     */
+    public MasterSlaveEntry getNextEntry() {
+        lazyConnect();
+
+        if (masterSlaveEntry != null) {
+            return masterSlaveEntry;
+        }
+
+        Collection<MasterSlaveEntry> entries = getEntrySet();
+        if (entries.isEmpty()) {
+            return null;
+        }
+
+        List<MasterSlaveEntry> list = new ArrayList<>(entries);
+        int index = Math.floorMod(rrCounter.getAndIncrement(), list.size());
+        return list.get(index);
     }
 
     protected final void lazyConnect() {


### PR DESCRIPTION
## Fixes
- Fixes #7165

## Description

In Redis Cluster with RediSearch coordinator, `FT.SEARCH` and `FT.AGGREGATE` are cluster-wide commands where the receiving master acts as coordinator and queries all shards.

**Before**: Redisson used `indexName` as the cluster routing key (`calcSlot(indexName)`), pinning all search/aggregate requests to a single master (the one owning the slot of the index name). This creates a coordinator hotspot under high load.

**After**: Round-robin routing across cluster masters for:
- `FT.SEARCH` (`searchAsync`)
- `FT.AGGREGATE` (`aggregateAsync`)
- `FT.PROFILE` (`profileSearchAsync`, `profileAggregateAsync`)
- `FT.SPELLCHECK` (`spellcheckAsync`)

## Changes

| File | Description |
|------|-------------|
| `ConnectionManager.java` | Add `getNextEntry()` interface method |
| `MasterSlaveConnectionManager.java` | Add `rrCounter` and `getNextEntry()` with round-robin logic |
| `CommandAsyncExecutor.java` | Add `readRoundRobinAsync` / `writeRoundRobinAsync` methods |
| `CommandAsyncService.java` | Implement round-robin methods |
| `RedissonSearch.java` | Switch coordinator commands to round-robin routing |

## Notes

- Cursor-related commands (`FT.CURSOR READ`) keep index-based routing for consistency
- Cluster-wide commands (`FT.LIST`, `FT.CONFIG`, `FT.CURSOR DEL`) already use null routing
- Single-server/sentinel mode unaffected — `getNextEntry()` returns the single master
- 54 lines added, 6 removed across 5 files