### PR TITLE
Fix lock leak in transactional fastRemove for non-existent keys (#6496)

### DIFF
--- a/redisson/src/main/java/org/redisson/transaction/BaseTransactionalMap.java
+++ b/redisson/src/main/java/org/redisson/transaction/BaseTransactionalMap.java
@@ -495,6 +495,13 @@ public class BaseTransactionalMap<K, V> extends BaseTransactionalObject {
                     counter.incrementAndGet();
                     state.put(keyHash, MapEntry.NULL);
                 }
+                // Release locks for keys that do not exist in Redis.
+                // Locks were acquired for all keys, but operations are only added for keys that exist.
+                for (K key : keyList) {
+                    if (!res.containsKey(key)) {
+                        getLock(key).unlockAsync(threadId);
+                    }
+                }
                 return counter.get();
             });
         }, locks);

--- a/redisson/src/test/java/org/redisson/transaction/RedissonBaseTransactionalMapTest.java
+++ b/redisson/src/test/java/org/redisson/transaction/RedissonBaseTransactionalMapTest.java
@@ -310,5 +310,24 @@ public abstract class RedissonBaseTransactionalMapTest extends RedisDockerTest {
         assertThat(m.get("3")).isEqualTo("4");
     }
 
-    
+    @Test
+    public void testFastRemoveNonExistentKeyDoesNotLeakLock() {
+        RMap<String, String> m = getMap();
+
+        // Remove a non-existent key in a transaction and commit
+        RTransaction tx1 = redisson.createTransaction(TransactionOptions.defaults().timeout(5, TimeUnit.SECONDS));
+        RMap<String, String> map1 = getTransactionalMap(tx1);
+        map1.fastRemove("nonexistent-key");
+        tx1.commit();
+
+        // Second transaction removing the same non-existent key should NOT timeout
+        RTransaction tx2 = redisson.createTransaction(TransactionOptions.defaults().timeout(5, TimeUnit.SECONDS));
+        RMap<String, String> map2 = getTransactionalMap(tx2);
+        map2.fastRemove("nonexistent-key");
+        tx2.commit();
+
+        assertThat(m.size()).isZero();
+    }
+
+
 }


### PR DESCRIPTION
## Fixes
- Fixes #6496

## Description

In a transactional context, `RMap.fastRemove(key)` acquires locks for all target keys upfront via `RedissonMultiLock`, but only adds `MapFastRemoveOperation` for keys that exist in Redis.

**Bug**: For keys that do not exist in Redis, no operation is added to the transaction operation list. Since lock release happens during commit via `MapOperation.commit()` (which calls `unlockAsync`), keys without operations have their locks **never released**.

This causes subsequent transactions operating on the same non-existent key to hang until the lock expires, resulting in `TransactionTimeoutException`.

## Root Cause

`BaseTransactionalMap.fastRemoveOperationAsync()` (line 471):
```java
List<RLock> locks = Arrays.stream(keys).map(k -> getLock(k)).collect(Collectors.toList());
// ...
return map.getAllAsync(...).thenApply(res -> {
    for (K key : res.keySet()) {  // only keys that EXIST
        operations.add(new MapFastRemoveOperation(...));
    }
    // keys not in res.keySet() → locks acquired but never released
});
```

Compare with `removeOperationAsync()` which **always** adds `MapRemoveOperation` regardless of key existence.

## Fix

Release locks explicitly for keys that do not exist in Redis, after the `getAllAsync` check:
```java
for (K key : keyList) {
    if (!res.containsKey(key)) {
        getLock(key).unlockAsync(threadId);
    }
}
```

## Changes

| File | Description |
|------|-------------|
| `BaseTransactionalMap.java` | Add explicit lock release for non-existent keys (+7 lines) |
| `RedissonBaseTransactionalMapTest.java` | Add regression test (+20 lines) |

## Verification

- **Red → Green**: Test fails without fix (`TransactionTimeoutException`), passes with fix
- All 15 existing `RedissonTransactionalMapTest` tests pass
- Checkstyle: 0 violations