### PR TITLE
Add RMap.keysAsync() method (#7166)

### DIFF
--- a/redisson/src/main/java/org/redisson/MapCacheNativeWrapper.java
+++ b/redisson/src/main/java/org/redisson/MapCacheNativeWrapper.java
@@ -1062,6 +1062,16 @@ public class MapCacheNativeWrapper<K, V> implements RMapCache<K, V>, Supplier<RM
     }
 
     @Override
+    public AsyncIterator<K> keysAsync() {
+        return cache.keysAsync();
+    }
+
+    @Override
+    public AsyncIterator<K> keysAsync(int count) {
+        return cache.keysAsync(count);
+    }
+
+    @Override
     public AsyncIterator<Entry<K, V>> entrySetAsync() {
         return cache.entrySetAsync();
     }

--- a/redisson/src/main/java/org/redisson/RedissonMap.java
+++ b/redisson/src/main/java/org/redisson/RedissonMap.java
@@ -785,6 +785,29 @@ public class RedissonMap<K, V> extends RedissonExpirable implements RMap<K, V> {
     }
 
     @Override
+    public AsyncIterator<K> keysAsync() {
+        return keysAsync(10);
+    }
+
+    @Override
+    public AsyncIterator<K> keysAsync(int count) {
+        AsyncIterator<K> asyncIterator = new BaseAsyncIterator<K, Map.Entry<Object, Object>>() {
+
+            @Override
+            protected RFuture<ScanResult<Map.Entry<Object, Object>>> iterator(RedisClient client, String nextItPos) {
+                return scanIteratorAsync(name, client, nextItPos, null, count);
+            }
+
+            @Override
+            protected K getValue(java.util.Map.Entry<Object, Object> entry) {
+                return (K) entry.getKey();
+            }
+
+        };
+        return new CompositeAsyncIterator<>(Arrays.asList(asyncIterator), 0);
+    }
+
+    @Override
     public Set<java.util.Map.Entry<K, V>> entrySet() {
         return entrySet(null);
     }

--- a/redisson/src/main/java/org/redisson/api/RMapAsync.java
+++ b/redisson/src/main/java/org/redisson/api/RMapAsync.java
@@ -285,6 +285,23 @@ public interface RMapAsync<K, V> extends RExpirableAsync {
     AsyncIterator<V> valuesAsync(int count);
 
     /**
+     * Returns keys of this map using iterable.
+     * Keys are loaded in batch. Batch size is <code>10</code>.
+     *
+     * @return Asynchronous Iterable object
+     */
+    AsyncIterator<K> keysAsync();
+
+    /**
+     * Returns keys of this map using iterable.
+     * Keys are loaded in batch. Batch size is defined by <code>count</code> param.
+     *
+     * @param count - size of keys batch
+     * @return Asynchronous Iterable object
+     */
+    AsyncIterator<K> keysAsync(int count);
+
+    /**
      * Returns map entries using iterable.
      * Map entries are loaded in batch. Batch size is <code>10</code>.
      *

--- a/redisson/src/test/java/org/redisson/RedissonMapTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonMapTest.java
@@ -274,6 +274,37 @@ public class RedissonMapTest extends BaseMapTest {
     }
 
     @Test
+    public void testKeysAsync() {
+        RMap<Integer, String> map = redisson.getMap("simple12");
+        map.put(1, "12");
+        map.put(2, "33");
+        map.put(3, "43");
+
+        List<Integer> list = new ArrayList<>();
+        AsyncIterator<Integer> iterator = map.keysAsync();
+        CompletionStage<Void> f = iterateAll(iterator, list);
+        f.toCompletableFuture().join();
+
+        assertThat(map.size()).isEqualTo(list.size());
+        assertThat(list).containsExactlyInAnyOrder(1, 2, 3);
+    }
+
+    @Test
+    public void testKeysByCountAsync() {
+        RMap<Integer, String> map = redisson.getMap("simple12");
+        map.put(1, "12");
+        map.put(2, "33");
+        map.put(3, "43");
+
+        List<Integer> list = new ArrayList<>();
+        AsyncIterator<Integer> iterator = map.keysAsync(2);
+        CompletionStage<Void> f = iterateAll(iterator, list);
+        f.toCompletableFuture().join();
+
+        assertThat(list).containsExactlyInAnyOrder(1, 2, 3);
+    }
+
+    @Test
     public void testValuesByPatternAsync() {
         RMap<String, String> map = getMap("simple", StringCodec.INSTANCE);
         map.put("10", "100");


### PR DESCRIPTION
## Fixes
- Fixes #7166

## Description

Add `AsyncIterator<K> keysAsync()` and `keysAsync(int count)` methods to `RMap`/`RMapAsync` interfaces, providing lazy key iteration via Redis SCAN command.

This fills the gap — `RMap` already has `valuesAsync()` and `entrySetAsync()`, but was missing a dedicated keys-only async iterator. Previously the only option was `readAllKeySetAsync()` which loads all keys at once into memory.

## Implementation

- `keysAsync()` — default batch size of 10
- `keysAsync(int count)` — configurable batch size
- Uses `BaseAsyncIterator` with `scanIteratorAsync`, extracting only keys from each HSCAN batch (same pattern as `valuesAsync`)
- Delegation added to `MapCacheNativeWrapper`

## Changes

| File | Description |
|------|-------------|
| `RMapAsync.java` | Add `keysAsync()` and `keysAsync(int count)` interface methods |
| `RedissonMap.java` | Implement `keysAsync()` methods |
| `MapCacheNativeWrapper.java` | Delegate `keysAsync()` to underlying cache |
| `RedissonMapTest.java` | Add `testKeysAsync` and `testKeysByCountAsync` tests |

**Diff**: 4 files, +81 lines