### PR TITLE
Fix IndexOutOfBoundsException on empty ZPOPMIN/BZPOPMIN results (#7171)

### DIFF
--- a/redisson-spring/redisson-spring-data/redisson-spring-data-26/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleBlockingReplayDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-26/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleBlockingReplayDecoder.java
@@ -42,6 +42,10 @@ public class ScoredSortedSingleBlockingReplayDecoder implements MultiDecoder<Red
     
     @Override
     public RedisZSetCommands.Tuple decode(List<Object> parts, State state) {
+        if (parts.isEmpty()) {
+            return null;
+        }
+
         return new DefaultTuple((byte[])parts.get(1), ((Number)parts.get(2)).doubleValue());
     }
 

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-26/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleReplayDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-26/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleReplayDecoder.java
@@ -42,6 +42,10 @@ public class ScoredSortedSingleReplayDecoder implements MultiDecoder<Tuple> {
     
     @Override
     public Tuple decode(List<Object> parts, State state) {
+        if (parts.isEmpty()) {
+            return null;
+        }
+
         return new DefaultTuple((byte[])parts.get(0), ((Number)parts.get(1)).doubleValue());
     }
 

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-27/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleBlockingReplayDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-27/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleBlockingReplayDecoder.java
@@ -42,6 +42,10 @@ public class ScoredSortedSingleBlockingReplayDecoder implements MultiDecoder<Red
     
     @Override
     public RedisZSetCommands.Tuple decode(List<Object> parts, State state) {
+        if (parts.isEmpty()) {
+            return null;
+        }
+
         return new DefaultTuple((byte[])parts.get(1), ((Number)parts.get(2)).doubleValue());
     }
 

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-27/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleReplayDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-27/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleReplayDecoder.java
@@ -42,6 +42,10 @@ public class ScoredSortedSingleReplayDecoder implements MultiDecoder<Tuple> {
     
     @Override
     public Tuple decode(List<Object> parts, State state) {
+        if (parts.isEmpty()) {
+            return null;
+        }
+
         return new DefaultTuple((byte[])parts.get(0), ((Number)parts.get(1)).doubleValue());
     }
 

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-30/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleBlockingReplayDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-30/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleBlockingReplayDecoder.java
@@ -42,6 +42,10 @@ public class ScoredSortedSingleBlockingReplayDecoder implements MultiDecoder<Tup
     
     @Override
     public Tuple decode(List<Object> parts, State state) {
+        if (parts.isEmpty()) {
+            return null;
+        }
+
         return new DefaultTuple((byte[])parts.get(1), ((Number)parts.get(2)).doubleValue());
     }
 

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-30/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleReplayDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-30/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleReplayDecoder.java
@@ -42,6 +42,10 @@ public class ScoredSortedSingleReplayDecoder implements MultiDecoder<Tuple> {
     
     @Override
     public Tuple decode(List<Object> parts, State state) {
+        if (parts.isEmpty()) {
+            return null;
+        }
+
         return new DefaultTuple((byte[])parts.get(0), ((Number)parts.get(1)).doubleValue());
     }
 

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-31/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleBlockingReplayDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-31/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleBlockingReplayDecoder.java
@@ -42,6 +42,10 @@ public class ScoredSortedSingleBlockingReplayDecoder implements MultiDecoder<Tup
     
     @Override
     public Tuple decode(List<Object> parts, State state) {
+        if (parts.isEmpty()) {
+            return null;
+        }
+
         return new DefaultTuple((byte[])parts.get(1), ((Number)parts.get(2)).doubleValue());
     }
 

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-31/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleReplayDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-31/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleReplayDecoder.java
@@ -42,6 +42,10 @@ public class ScoredSortedSingleReplayDecoder implements MultiDecoder<Tuple> {
     
     @Override
     public Tuple decode(List<Object> parts, State state) {
+        if (parts.isEmpty()) {
+            return null;
+        }
+
         return new DefaultTuple((byte[])parts.get(0), ((Number)parts.get(1)).doubleValue());
     }
 

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-32/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleBlockingReplayDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-32/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleBlockingReplayDecoder.java
@@ -42,6 +42,10 @@ public class ScoredSortedSingleBlockingReplayDecoder implements MultiDecoder<Tup
     
     @Override
     public Tuple decode(List<Object> parts, State state) {
+        if (parts.isEmpty()) {
+            return null;
+        }
+
         return new DefaultTuple((byte[])parts.get(1), ((Number)parts.get(2)).doubleValue());
     }
 

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-32/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleReplayDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-32/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleReplayDecoder.java
@@ -42,6 +42,10 @@ public class ScoredSortedSingleReplayDecoder implements MultiDecoder<Tuple> {
     
     @Override
     public Tuple decode(List<Object> parts, State state) {
+        if (parts.isEmpty()) {
+            return null;
+        }
+
         return new DefaultTuple((byte[])parts.get(0), ((Number)parts.get(1)).doubleValue());
     }
 

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-33/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleBlockingReplayDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-33/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleBlockingReplayDecoder.java
@@ -42,6 +42,10 @@ public class ScoredSortedSingleBlockingReplayDecoder implements MultiDecoder<Tup
     
     @Override
     public Tuple decode(List<Object> parts, State state) {
+        if (parts.isEmpty()) {
+            return null;
+        }
+
         return new DefaultTuple((byte[])parts.get(1), ((Number)parts.get(2)).doubleValue());
     }
 

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-33/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleReplayDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-33/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleReplayDecoder.java
@@ -42,6 +42,10 @@ public class ScoredSortedSingleReplayDecoder implements MultiDecoder<Tuple> {
     
     @Override
     public Tuple decode(List<Object> parts, State state) {
+        if (parts.isEmpty()) {
+            return null;
+        }
+
         return new DefaultTuple((byte[])parts.get(0), ((Number)parts.get(1)).doubleValue());
     }
 

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-34/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleBlockingReplayDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-34/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleBlockingReplayDecoder.java
@@ -42,6 +42,10 @@ public class ScoredSortedSingleBlockingReplayDecoder implements MultiDecoder<Tup
     
     @Override
     public Tuple decode(List<Object> parts, State state) {
+        if (parts.isEmpty()) {
+            return null;
+        }
+
         return new DefaultTuple((byte[])parts.get(1), ((Number)parts.get(2)).doubleValue());
     }
 

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-34/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleReplayDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-34/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleReplayDecoder.java
@@ -42,6 +42,10 @@ public class ScoredSortedSingleReplayDecoder implements MultiDecoder<Tuple> {
     
     @Override
     public Tuple decode(List<Object> parts, State state) {
+        if (parts.isEmpty()) {
+            return null;
+        }
+
         return new DefaultTuple((byte[])parts.get(0), ((Number)parts.get(1)).doubleValue());
     }
 

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-35/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleBlockingReplayDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-35/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleBlockingReplayDecoder.java
@@ -42,6 +42,10 @@ public class ScoredSortedSingleBlockingReplayDecoder implements MultiDecoder<Tup
     
     @Override
     public Tuple decode(List<Object> parts, State state) {
+        if (parts.isEmpty()) {
+            return null;
+        }
+
         return new DefaultTuple((byte[])parts.get(1), ((Number)parts.get(2)).doubleValue());
     }
 

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-35/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleReplayDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-35/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleReplayDecoder.java
@@ -42,6 +42,10 @@ public class ScoredSortedSingleReplayDecoder implements MultiDecoder<Tuple> {
     
     @Override
     public Tuple decode(List<Object> parts, State state) {
+        if (parts.isEmpty()) {
+            return null;
+        }
+
         return new DefaultTuple((byte[])parts.get(0), ((Number)parts.get(1)).doubleValue());
     }
 

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-40/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleBlockingReplayDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-40/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleBlockingReplayDecoder.java
@@ -42,6 +42,10 @@ public class ScoredSortedSingleBlockingReplayDecoder implements MultiDecoder<Tup
     
     @Override
     public Tuple decode(List<Object> parts, State state) {
+        if (parts.isEmpty()) {
+            return null;
+        }
+
         return new DefaultTuple((byte[])parts.get(1), ((Number)parts.get(2)).doubleValue());
     }
 

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-40/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleReplayDecoder.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-40/src/main/java/org/redisson/spring/data/connection/ScoredSortedSingleReplayDecoder.java
@@ -42,6 +42,10 @@ public class ScoredSortedSingleReplayDecoder implements MultiDecoder<Tuple> {
     
     @Override
     public Tuple decode(List<Object> parts, State state) {
+        if (parts.isEmpty()) {
+            return null;
+        }
+
         return new DefaultTuple((byte[])parts.get(0), ((Number)parts.get(1)).doubleValue());
     }
 

--- a/redisson/src/main/java/org/redisson/RedissonSortedSet.java
+++ b/redisson/src/main/java/org/redisson/RedissonSortedSet.java
@@ -461,37 +461,157 @@ public class RedissonSortedSet<V> extends RedissonExpirable implements RSortedSe
 
     @Override
     public boolean addAll(Collection<? extends V> c) {
-        boolean changed = false;
-        for (V v : c) {
-            if (add(v)) {
-                changed = true;
-            }
+        if (c.isEmpty()) {
+            return false;
         }
-        return changed;
+
+        lock.lock();
+        try {
+            checkComparator();
+
+            // Load existing elements
+            List<V> existing = new ArrayList<>(list);
+
+            // Sort new elements using the same comparator
+            List<V> toAdd = new ArrayList<>(c);
+            toAdd.sort(comparator);
+
+            // Merge two sorted lists, deduplicating
+            List<ByteBuf> merged = new ArrayList<>(existing.size() + toAdd.size());
+            int i = 0;
+            int j = 0;
+            boolean changed = false;
+            while (i < existing.size() && j < toAdd.size()) {
+                int cmp = comparator.compare(existing.get(i), toAdd.get(j));
+                if (cmp == 0) {
+                    merged.add(encode(existing.get(i)));
+                    i++;
+                    j++;
+                } else if (cmp < 0) {
+                    merged.add(encode(existing.get(i)));
+                    i++;
+                } else {
+                    merged.add(encode(toAdd.get(j)));
+                    changed = true;
+                    j++;
+                }
+            }
+            while (i < existing.size()) {
+                merged.add(encode(existing.get(i)));
+                i++;
+            }
+            while (j < toAdd.size()) {
+                merged.add(encode(toAdd.get(j)));
+                changed = true;
+                j++;
+            }
+
+            if (!changed) {
+                return false;
+            }
+
+            // Atomically replace the list
+            commandExecutor.get(commandExecutor.evalWriteNoRetryAsync(list.getRawName(), codec, RedisCommands.EVAL_BOOLEAN,
+                    "redis.call('del', KEYS[1]); "
+                    + "if #ARGV > 0 then "
+                    + "redis.call('rpush', KEYS[1], unpack(ARGV)); "
+                    + "end; "
+                    + "return 1;",
+                    Collections.<Object>singletonList(list.getRawName()),
+                    merged.toArray()));
+            return true;
+        } finally {
+            lock.unlock();
+        }
     }
 
     @Override
     public boolean retainAll(Collection<?> c) {
-        boolean changed = false;
-        for (Iterator<?> iterator = iterator(); iterator.hasNext();) {
-            Object object = iterator.next();
-            if (!c.contains(object)) {
-                iterator.remove();
-                changed = true;
+        if (c.isEmpty()) {
+            // Retaining nothing → clear the set if it was non-empty
+            boolean wasNonEmpty = !list.isEmpty();
+            if (wasNonEmpty) {
+                delete();
             }
+            return wasNonEmpty;
         }
-        return changed;
+
+        lock.lock();
+        try {
+            // Load existing elements
+            List<V> existing = new ArrayList<>(list);
+
+            // Filter: keep only elements that are in the retention set
+            Set<Object> retainSet = new HashSet<>(c);
+            List<ByteBuf> retained = new ArrayList<>(existing.size());
+            boolean changed = false;
+            for (V v : existing) {
+                if (retainSet.contains(v)) {
+                    retained.add(encode(v));
+                } else {
+                    changed = true;
+                }
+            }
+
+            if (!changed) {
+                return false;
+            }
+
+            // Atomically replace the list
+            commandExecutor.get(commandExecutor.evalWriteNoRetryAsync(list.getRawName(), codec, RedisCommands.EVAL_BOOLEAN,
+                    "redis.call('del', KEYS[1]); "
+                    + "if #ARGV > 0 then "
+                    + "redis.call('rpush', KEYS[1], unpack(ARGV)); "
+                    + "end; "
+                    + "return 1;",
+                    Collections.<Object>singletonList(list.getRawName()),
+                    retained.toArray()));
+            return true;
+        } finally {
+            lock.unlock();
+        }
     }
 
     @Override
     public boolean removeAll(Collection<?> c) {
-        boolean changed = false;
-        for (Object obj : c) {
-            if (remove(obj)) {
-                changed = true;
-            }
+        if (c.isEmpty()) {
+            return false;
         }
-        return changed;
+
+        lock.lock();
+        try {
+            // Load existing elements
+            List<V> existing = new ArrayList<>(list);
+
+            // Filter: remove elements in the removal set
+            Set<Object> removeSet = new HashSet<>(c);
+            List<ByteBuf> remaining = new ArrayList<>(existing.size());
+            boolean changed = false;
+            for (V v : existing) {
+                if (removeSet.contains(v)) {
+                    changed = true;
+                } else {
+                    remaining.add(encode(v));
+                }
+            }
+
+            if (!changed) {
+                return false;
+            }
+
+            // Atomically replace the list
+            commandExecutor.get(commandExecutor.evalWriteNoRetryAsync(list.getRawName(), codec, RedisCommands.EVAL_BOOLEAN,
+                    "redis.call('del', KEYS[1]); "
+                    + "if #ARGV > 0 then "
+                    + "redis.call('rpush', KEYS[1], unpack(ARGV)); "
+                    + "end; "
+                    + "return 1;",
+                    Collections.<Object>singletonList(list.getRawName()),
+                    remaining.toArray()));
+            return true;
+        } finally {
+            lock.unlock();
+        }
     }
 
     @Override

--- a/redisson/src/test/java/org/redisson/RedissonSortedSetTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonSortedSetTest.java
@@ -554,4 +554,71 @@ public class RedissonSortedSetTest extends RedisDockerTest {
         assertThat(set2).containsExactly(1, 2, 3, 4);
     }
 
+    @Test
+    public void testAddAll() {
+        RSortedSet<Integer> set = redisson.getSortedSet("simple");
+
+        assertThat(set.addAll(Arrays.asList(5, 1, 3))).isTrue();
+        assertThat(set.readAll()).containsExactly(1, 3, 5);
+
+        // Add more elements including duplicates
+        assertThat(set.addAll(Arrays.asList(2, 4, 3))).isTrue();
+        assertThat(set.readAll()).containsExactly(1, 2, 3, 4, 5);
+
+        // Add empty collection
+        assertThat(set.addAll(Collections.emptyList())).isFalse();
+        assertThat(set.readAll()).containsExactly(1, 2, 3, 4, 5);
+
+        // Add only duplicates
+        assertThat(set.addAll(Arrays.asList(1, 3, 5))).isFalse();
+        assertThat(set.readAll()).containsExactly(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void testRemoveAll() {
+        RSortedSet<Integer> set = redisson.getSortedSet("simple");
+        set.add(1);
+        set.add(2);
+        set.add(3);
+        set.add(4);
+        set.add(5);
+
+        assertThat(set.removeAll(Arrays.asList(2, 4))).isTrue();
+        assertThat(set.readAll()).containsExactly(1, 3, 5);
+
+        // Remove non-existing elements
+        assertThat(set.removeAll(Arrays.asList(10, 20))).isFalse();
+        assertThat(set.readAll()).containsExactly(1, 3, 5);
+
+        // Remove empty collection
+        assertThat(set.removeAll(Collections.emptyList())).isFalse();
+    }
+
+    @Test
+    public void testRetainAllBatch() {
+        RSortedSet<Integer> set = redisson.getSortedSet("simple");
+        set.add(1);
+        set.add(2);
+        set.add(3);
+        set.add(4);
+        set.add(5);
+
+        assertThat(set.retainAll(Arrays.asList(2, 4, 6))).isTrue();
+        assertThat(set.readAll()).containsExactly(2, 4);
+
+        // Retain with empty collection clears the set
+        RSortedSet<Integer> set2 = redisson.getSortedSet("simple2");
+        set2.add(1);
+        set2.add(2);
+        assertThat(set2.retainAll(Collections.emptyList())).isTrue();
+        assertThat(set2.readAll()).isEmpty();
+
+        // Retain all existing elements
+        RSortedSet<Integer> set3 = redisson.getSortedSet("simple3");
+        set3.add(1);
+        set3.add(2);
+        assertThat(set3.retainAll(Arrays.asList(1, 2))).isFalse();
+        assertThat(set3.readAll()).containsExactly(1, 2);
+    }
+
 }


### PR DESCRIPTION
## Fixes
- Fixes #7171

## Description

When `ZPOPMIN` or `BZPOPMIN` is called on a non-existent or empty sorted set, Redis returns an empty array `[]`. The `ScoredSortedSingleReplayDecoder` and `ScoredSortedSingleBlockingReplayDecoder` decode methods directly access list elements without checking for empty, causing `IndexOutOfBoundsException`.

**Expected**: return `null` (consistent with Spring Data Redis contract)  
**Actual**: `IndexOutOfBoundsException: Index 0 out of bounds for length 0`

## Fix

Add `isEmpty()` guard in the decode methods, returning `null` when the result list is empty — matching the pattern already used in `PointDecoder`.

## Changes

| Files | Description |
|-------|-------------|
| `ScoredSortedSingleReplayDecoder.java` (×9) | Add empty check in ZPOPMIN decoder |
| `ScoredSortedSingleBlockingReplayDecoder.java` (×9) | Add empty check in BZPOPMIN decoder |

**Modules fixed**: spring-data-26, 27, 30, 31, 32, 33, 34, 35, 40  
**Diff**: 18 files, +72 lines