### PR TITLE
Add RVectorSet support to RBatch (#7164)

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonBatch.java
+++ b/redisson/src/main/java/org/redisson/RedissonBatch.java
@@ -368,5 +368,10 @@ public class RedissonBatch implements RBatch {
         return new RedissonCuckooFilter<V>(codec, executorService, name);
     }
 
+    @Override
+    public RVectorSetAsync getVectorSet(String name) {
+        return new RedissonVectorSet(executorService, name);
+    }
+
 
 }

--- a/redisson/src/main/java/org/redisson/api/RBatch.java
+++ b/redisson/src/main/java/org/redisson/api/RBatch.java
@@ -75,6 +75,14 @@ public interface RBatch {
     <V> RCuckooFilterAsync<V> getCuckooFilter(String name, Codec codec);
 
     /**
+     * Returns vector set instance by name.
+     * Stores vectors and associated elements in a set optimized for similarity search.
+     *
+     * @return RVectorSet object
+     */
+    RVectorSetAsync getVectorSet(String name);
+
+    /**
      * Returns stream instance by <code>name</code>
      * 
      * @param <K> type of key

--- a/redisson/src/main/java/org/redisson/api/RBatchReactive.java
+++ b/redisson/src/main/java/org/redisson/api/RBatchReactive.java
@@ -53,6 +53,14 @@ public interface RBatchReactive {
     <V> RCuckooFilterReactive<V> getCuckooFilter(String name, Codec codec);
 
     /**
+     * Returns vector set instance by name.
+     * Stores vectors and associated elements in a set optimized for similarity search.
+     *
+     * @return RVectorSet object
+     */
+    RVectorSetReactive getVectorSet(String name);
+
+    /**
      * Returns bloom filter native instance by <code>name</code>.
      * Covers BF.* commands.
      *

--- a/redisson/src/main/java/org/redisson/api/RBatchRx.java
+++ b/redisson/src/main/java/org/redisson/api/RBatchRx.java
@@ -54,6 +54,14 @@ public interface RBatchRx {
     <V> RCuckooFilterRx<V> getCuckooFilter(String name, Codec codec);
 
     /**
+     * Returns vector set instance by name.
+     * Stores vectors and associated elements in a set optimized for similarity search.
+     *
+     * @return RVectorSet object
+     */
+    RVectorSetRx getVectorSet(String name);
+
+    /**
      * Returns bloom filter native instance by <code>name</code>.
      * Covers BF.* commands.
      *

--- a/redisson/src/main/java/org/redisson/reactive/RedissonBatchReactive.java
+++ b/redisson/src/main/java/org/redisson/reactive/RedissonBatchReactive.java
@@ -423,4 +423,11 @@ public class RedissonBatchReactive implements RBatchReactive {
                 RCuckooFilterReactive.class);
     }
 
+    @Override
+    public RVectorSetReactive getVectorSet(String name) {
+        return ReactiveProxyBuilder.create(executorService,
+                new RedissonVectorSet(executorService, name),
+                RVectorSetReactive.class);
+    }
+
 }

--- a/redisson/src/main/java/org/redisson/rx/RedissonBatchRx.java
+++ b/redisson/src/main/java/org/redisson/rx/RedissonBatchRx.java
@@ -440,4 +440,11 @@ public class RedissonBatchRx implements RBatchRx {
                 RCuckooFilterRx.class);
     }
 
+    @Override
+    public RVectorSetRx getVectorSet(String name) {
+        return RxProxyBuilder.create(executorService,
+                new RedissonVectorSet(executorService, name),
+                RVectorSetRx.class);
+    }
+
 }


### PR DESCRIPTION
## Fixes
- Fixes #7164

## Description

Add `getVectorSet(String name)` method to `RBatch` interface and all implementations (`RedissonBatch`, `RedissonBatchReactive`, `RedissonBatchRx`), enabling vector set operations to be batched using Redis pipeline feature.

## Implementation

| File | Description |
|------|-------------|
| `RBatch.java` | Add `getVectorSet(String name)` interface method |
| `RedissonBatch.java` | Return `new RedissonVectorSet(executorService, name)` |
| `RBatchReactive.java` | Add `getVectorSet(String name)` interface method |
| `RedissonBatchReactive.java` | Wrap with `ReactiveProxyBuilder` |
| `RBatchRx.java` | Add `getVectorSet(String name)` interface method |
| `RedissonBatchRx.java` | Wrap with `RxProxyBuilder` |

## Testing

- Compilation: PASS
- Checkstyle: 0 violations
- All 24 `RedissonVectorSetTest` tests: PASS

**Diff**: 6 files, +43 lines