### PR TITLE
Fixed - non-cluster lazy initialization can park caller threads indefinitely

### DIFF
--- a/redisson/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
@@ -255,11 +255,8 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
             String hostname = hostnameMapper.apply(uri);
             CompletableFuture<RedisClient> masterFuture = masterSlaveEntry.setupMasterEntry(uri, hostname);
             try {
-                if (config.getMasterConnectionMinimumIdleSize() == 0) {
-                    masterFuture.join();
-                } else {
-                    masterFuture.get(config.getConnectTimeout()*config.getMasterConnectionMinimumIdleSize(), TimeUnit.MILLISECONDS);
-                }
+                // bound the wait even when minimumIdleSize == 0; an unbounded join() never completes the lazyConnect latch if master entry setup stalls, parking all callers
+                masterFuture.get((long) config.getConnectTimeout() * Math.max(1, config.getMasterConnectionMinimumIdleSize()), TimeUnit.MILLISECONDS);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 throw new RedisConnectionException(e);
@@ -270,11 +267,8 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
             if (!config.isSlaveNotUsed()) {
                 CompletableFuture<Void> fs = masterSlaveEntry.initSlaveBalancer(hostnameMapper);
                 try {
-                    if (config.getSlaveConnectionMinimumIdleSize() == 0) {
-                        fs.join();
-                    } else {
-                        fs.get(config.getConnectTimeout()*config.getSlaveConnectionMinimumIdleSize(), TimeUnit.MILLISECONDS);
-                    }
+                    // bound the wait even when minimumIdleSize == 0; an unbounded join() never completes the lazyConnect latch if the slave balancer stalls, parking all callers
+                    fs.get((long) config.getConnectTimeout() * Math.max(1, config.getSlaveConnectionMinimumIdleSize()), TimeUnit.MILLISECONDS);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     throw new RedisConnectionException(e);

--- a/redisson/src/main/java/org/redisson/connection/ReplicatedConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/ReplicatedConnectionManager.java
@@ -84,7 +84,15 @@ public class ReplicatedConnectionManager extends MasterSlaveConnectionManager {
             CompletionStage<RedisConnection> connectionFuture = connectToNode(cfg, addr, addr.getHost());
             RedisConnection connection = null;
             try {
-                connection = connectionFuture.toCompletableFuture().join();
+                // bound the wait; an unbounded join() on a half-open seed never completes the lazyConnect latch, parking all callers
+                connection = connectionFuture.toCompletableFuture().get(config.getConnectTimeout(), TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                if (ex != null) {
+                    ex.addSuppressed(e);
+                } else {
+                    ex = e;
+                }
             } catch (Exception e) {
                 if (ex != null) {
                     ex.addSuppressed(e);

--- a/redisson/src/test/java/org/redisson/connection/MasterSlaveConnectionManagerTest.java
+++ b/redisson/src/test/java/org/redisson/connection/MasterSlaveConnectionManagerTest.java
@@ -13,7 +13,10 @@ import org.redisson.config.*;
 import org.redisson.misc.RedisURI;
 
 import java.net.InetSocketAddress;
+import java.time.Duration;
 import java.util.concurrent.*;
+
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 
 public class MasterSlaveConnectionManagerTest {
@@ -62,6 +65,47 @@ public class MasterSlaveConnectionManagerTest {
             Assertions.assertThat(Thread.currentThread().isInterrupted()).isTrue();
         } finally {
             Thread.interrupted(); // restore clean interrupt state
+            manager.shutdown(0, 0, TimeUnit.SECONDS);
+        }
+    }
+
+    MasterSlaveConnectionManager buildStuckConnectionManager(BaseMasterSlaveServersConfig<?> msConfig, Config config) {
+        // resolveAddr returns a future that never completes, mimicking a node that accepts TCP
+        // but never finishes the handshake. setupMasterEntry then never completes either.
+        return new MasterSlaveConnectionManager(msConfig, config) {
+            @Override
+            protected RedisClient createClient(NodeType type, RedisURI address, int timeout, int commandTimeout, String sslHostname) {
+                RedisClient client = super.createClient(type, address, timeout, commandTimeout, sslHostname);
+                new MockUp<RedisClient>(client) {
+                    @Mock
+                    public CompletableFuture<InetSocketAddress> resolveAddr(Invocation inv) {
+                        return new CompletableFuture<>();
+                    }
+                };
+                return client;
+            }
+        };
+    }
+
+    @Test
+    void testDoConnectBoundsWaitWhenMinimumIdleSizeIsZero() {
+        Config config = new Config();
+        MasterSlaveServersConfig msConfig = config.useMasterSlaveServers();
+        msConfig.setMasterAddress("redis://127.0.0.1:6379");
+        msConfig.setReadMode(ReadMode.MASTER);
+        // the unbounded-join branch was taken only when minimumIdleSize == 0
+        msConfig.setMasterConnectionMinimumIdleSize(0);
+        msConfig.setConnectTimeout(100);
+
+        MasterSlaveConnectionManager manager = buildStuckConnectionManager(msConfig, config);
+
+        try {
+            // a stuck master entry setup must surface a bounded-wait timeout rather than parking the caller
+            assertTimeoutPreemptively(Duration.ofSeconds(10), () ->
+                    Assertions.assertThatThrownBy(() -> manager.doConnect(u -> null))
+                            .isInstanceOf(RedisConnectionException.class)
+                            .hasCauseInstanceOf(TimeoutException.class));
+        } finally {
             manager.shutdown(0, 0, TimeUnit.SECONDS);
         }
     }

--- a/redisson/src/test/java/org/redisson/connection/ReplicatedConnectionManagerTest.java
+++ b/redisson/src/test/java/org/redisson/connection/ReplicatedConnectionManagerTest.java
@@ -2,14 +2,19 @@ package org.redisson.connection;
 
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.embedded.EmbeddedChannel;
+import mockit.Invocation;
+import mockit.Mock;
+import mockit.MockUp;
 import org.assertj.core.api.Assertions;
 import org.joor.Reflect;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.redisson.api.NodeType;
 import org.redisson.api.RFuture;
 import org.redisson.client.RedisClient;
 import org.redisson.client.RedisClientConfig;
 import org.redisson.client.RedisConnection;
+import org.redisson.client.RedisConnectionException;
 import org.redisson.client.RedisTimeoutException;
 import org.redisson.client.codec.Codec;
 import org.redisson.client.protocol.RedisCommand;
@@ -20,6 +25,7 @@ import org.redisson.misc.CompletableFutureWrapper;
 import org.redisson.misc.RedisURI;
 
 import java.net.InetSocketAddress;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Map;
@@ -28,6 +34,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 public class ReplicatedConnectionManagerTest {
 
@@ -96,11 +105,45 @@ public class ReplicatedConnectionManagerTest {
         }
     }
 
+    @Test
+    public void testDoConnectBoundsWaitWhenSeedConnectionStalls() {
+        Config config = new Config();
+        ReplicatedServersConfig serversConfig = config.useReplicatedServers();
+        serversConfig.addNodeAddress("redis://127.0.0.1:6379");
+        // a stalled seed must surface a bounded-wait timeout rather than parking the caller forever
+        serversConfig.setConnectTimeout(100);
+
+        manager = buildStuckManager(serversConfig, config);
+
+        assertTimeoutPreemptively(Duration.ofSeconds(10), () ->
+                Assertions.assertThatThrownBy(() -> manager.doConnect(u -> null))
+                        .isInstanceOf(RedisConnectionException.class)
+                        .hasCauseInstanceOf(TimeoutException.class));
+    }
+
     private ReplicatedConnectionManager createManager() {
         Config config = new Config();
         ReplicatedServersConfig serversConfig = new ReplicatedServersConfig();
         serversConfig.addNodeAddress("redis://127.0.0.1:6379");
         return new ReplicatedConnectionManager(serversConfig, config);
+    }
+
+    private static ReplicatedConnectionManager buildStuckManager(ReplicatedServersConfig serversConfig, Config config) {
+        // resolveAddr returns a future that never completes, so connectToNode never finishes and
+        // the seed-node join in doConnect must time out instead of parking forever
+        return new ReplicatedConnectionManager(serversConfig, config) {
+            @Override
+            protected RedisClient createClient(NodeType type, RedisURI address, int timeout, int commandTimeout, String sslHostname) {
+                RedisClient client = super.createClient(type, address, timeout, commandTimeout, sslHostname);
+                new MockUp<RedisClient>(client) {
+                    @Mock
+                    public CompletableFuture<InetSocketAddress> resolveAddr(Invocation inv) {
+                        return new CompletableFuture<>();
+                    }
+                };
+                return client;
+            }
+        };
     }
 
     private static Map<RedisURI, RedisConnection> nodeConnections(ReplicatedConnectionManager manager) {


### PR DESCRIPTION
## Summary

Lazy connection init runs doConnect() under the lazyConnect() latch; if the connecting thread blocks forever, the latch is never completed and every subsequent caller parks on latch.join(). The cluster path (ClusterConnectionManager.doConnect) already bounds its waits. This fixes the same bug class in the two non-cluster paths that were not covered:

1. MasterSlaveConnectionManager.doConnect bounded the master-entry and slave-balancer waits only when minimumIdleSize > 0; on the == 0 branch it fell back to an unbounded join() that parks forever if setupMasterEntry / initSlaveBalancer never completes (e.g. a node that accepts TCP but never finishes the handshake). Both waits now always use a bounded get() with a floor of one connectTimeout, so minIdle == 0 still waits at least once.

2. ReplicatedConnectionManager.doConnect joined the seed-node connection future unbounded; a half-open seed parks doConnect there. It now bounds the wait with get(connectTimeout), mirroring ClusterConnectionManager, and re-sets the interrupt flag on InterruptedException before accumulating into the per-loop suppressed exception.

## Test plan

- Added MasterSlaveConnectionManagerTest.testDoConnectBoundsWaitWhenMinimumIdleSizeIsZero: with masterConnectionMinimumIdleSize == 0 and a stuck master-entry setup (resolveAddr returns a never-completing future), doConnect surfaces a RedisConnectionException caused by TimeoutException rather than parking. The assertion is wrapped in assertTimeoutPreemptively so a regression to the unbounded-join behavior fails the test instead of hanging it. No Thread.sleep is used.
- Added ReplicatedConnectionManagerTest.testDoConnectBoundsWaitWhenSeedConnectionStalls: with a seed whose resolveAddr never completes, doConnect surfaces a RedisConnectionException caused by TimeoutException rather than parking on the seed-node join. Same stuck-connection technique and assertTimeoutPreemptively wrapper as the minIdle==0 test; no Thread.sleep, no live seed required. Verified that reverting the fix to the unbounded join() makes this test fail with a preemptive-timeout instead of passing.
