### PR TITLE
Fixed - ConnectionsHolder init-connection double release inflates pool counter

### DIFF
--- a/redisson/src/main/java/org/redisson/connection/ConnectionsHolder.java
+++ b/redisson/src/main/java/org/redisson/connection/ConnectionsHolder.java
@@ -164,9 +164,10 @@ public class ConnectionsHolder<T extends RedisConnection> {
                         conn.decUsage();
                     }
                     addConnection(conn);
+                    // release only on success; the failure path already releases in createConnection(promise),
+                    // so an unconditional release here double-releases per failed init and lifts the counter above pool max
+                    releaseConnection();
                 }
-
-                releaseConnection();
 
                 if (e != null) {
                     for (RedisConnection connection : getAllConnections()) {

--- a/redisson/src/test/java/org/redisson/connection/ConnectionsHolderTest.java
+++ b/redisson/src/test/java/org/redisson/connection/ConnectionsHolderTest.java
@@ -1,0 +1,79 @@
+package org.redisson.connection;
+
+import mockit.Mocked;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.redisson.client.RedisClient;
+import org.redisson.client.RedisConnection;
+import org.redisson.config.Config;
+import org.redisson.config.MasterSlaveServersConfig;
+import org.redisson.config.ReadMode;
+import org.redisson.misc.AsyncSemaphore;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+
+public class ConnectionsHolderTest {
+
+    private MasterSlaveConnectionManager buildManager() {
+        Config config = new Config();
+        config.setLazyInitialization(true);
+        MasterSlaveServersConfig msConfig = config.useMasterSlaveServers();
+        msConfig.setMasterAddress("redis://127.0.0.1:6379");
+        msConfig.setReadMode(ReadMode.MASTER);
+        return new MasterSlaveConnectionManager(msConfig, config);
+    }
+
+    @Test
+    void testFailedInitConnectionReleasesPermitExactlyOnce() {
+        MasterSlaveConnectionManager manager = buildManager();
+        try {
+            int poolMaxSize = 2;
+            Function<RedisClient, CompletionStage<RedisConnection>> failingCallback = r -> {
+                CompletableFuture<RedisConnection> f = new CompletableFuture<>();
+                f.completeExceptionally(new RuntimeException("connect failed"));
+                return f;
+            };
+            ConnectionsHolder<RedisConnection> holder =
+                    new ConnectionsHolder<>(null, poolMaxSize, failingCallback, manager.getServiceManager(), false);
+            AsyncSemaphore counter = holder.getFreeConnectionsCounter();
+            Assertions.assertThat(counter.getCounter()).isEqualTo(poolMaxSize);
+
+            CompletableFuture<Void> result = holder.initConnections(poolMaxSize);
+            Assertions.assertThat(result).isCompletedExceptionally();
+
+            // a failed init acquires one permit and must release it exactly once; an extra release
+            // lifts the counter above the pool max and jams idle eviction so the pool never drains
+            Assertions.assertThat(counter.getCounter()).isEqualTo(poolMaxSize);
+        } finally {
+            manager.shutdown(0, 0, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void testSuccessfulInitReleasesEachPermitExactlyOnce(@Mocked RedisClient client, @Mocked RedisConnection conn) {
+        MasterSlaveConnectionManager manager = buildManager();
+        try {
+            int poolMaxSize = 2;
+            Function<RedisClient, CompletionStage<RedisConnection>> succeedingCallback =
+                    r -> CompletableFuture.completedFuture(conn);
+            ConnectionsHolder<RedisConnection> holder =
+                    new ConnectionsHolder<>(client, poolMaxSize, succeedingCallback, manager.getServiceManager(), false);
+            AsyncSemaphore counter = holder.getFreeConnectionsCounter();
+            Assertions.assertThat(counter.getCounter()).isEqualTo(poolMaxSize);
+
+            CompletableFuture<Void> result = holder.initConnections(poolMaxSize);
+            Assertions.assertThat(result).isCompleted();
+
+            // each successful init acquires one permit and releases it exactly once, so the counter
+            // returns to the pool max — never inflated above it, which would jam idle eviction
+            Assertions.assertThat(counter.getCounter()).isEqualTo(poolMaxSize);
+            Assertions.assertThat(holder.getFreeConnections()).hasSize(poolMaxSize);
+        } finally {
+            manager.shutdown(0, 0, TimeUnit.SECONDS);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

On a failed init connection, `ConnectionsHolder.createConnection(int, int)` releases the acquired permit twice: the inner `createConnection(promise)` already releases it on the failure path, and the outer `createConnection(int, int)` then released it again unconditionally. Each failed init therefore lifts the per-pool free-connection semaphore one above the pool max. That deflates `IdleConnectionWatcher`'s in-use estimate (`poolMax - counter`) and jams idle eviction, so the pool never shrinks back to `minIdle`. A heap dump under sustained load with node slowness showed the counter climbed above the pool max.

## Fix

Release only on the success branch. The failure path already releases inside `createConnection(promise)`, so the failed init now releases exactly once.

## Test

`ConnectionsHolderTest.testFailedInitConnectionReleasesPermitExactlyOnce` drives a failing connection callback through `initConnections(poolMaxSize)` and asserts the free-connection counter is left at the pool max, not above it.

Split out from #7133 per review request.

Signed-off-by: yipeng-ma <yipeng.ma@airbnb.com>
