### PR TITLE
Fixed - AsyncSemaphore.tryRun double-counts cancelled waiters

### DIFF
--- a/redisson/src/main/java/org/redisson/misc/AsyncSemaphore.java
+++ b/redisson/src/main/java/org/redisson/misc/AsyncSemaphore.java
@@ -102,6 +102,9 @@ public final class AsyncSemaphore {
                     return;
                 } else {
                     counter.incrementAndGet();
+                    // dead waiter already gave the permit back above; continue instead of
+                    // falling through to the trailing increment, which would double-count it
+                    continue;
                 }
             }
 


### PR DESCRIPTION
## Problem

When `AsyncSemaphore.tryRun` polls an acquire future that was already completed out of band (a cancelled / timed-out acquire), `future.complete(null)` returns `false`. The dead-waiter branch gives the permit back with `counter.incrementAndGet()` and then falls through to the trailing `counter.incrementAndGet()`, counting the permit a second time (net +1 per dead waiter). Under command timeouts at high QPS these cancelled acquires pile up and the counter ratchets above the pool max, deflating the same `IdleConnectionWatcher` idle-eviction gate.

## Fix

`continue` the loop after giving the permit back, instead of falling through to the trailing increment.

## Test

Covered by the existing `AsyncSemaphoreTest.testCancelledWaiter`, which lands the counter at the configured permits only when the dead waiter is not double-counted.

Split out from #7133 per review request.

Signed-off-by: yipeng-ma <yipeng.ma@airbnb.com>
