### PR TITLE
Integrate Kryo5 KeySetViewSerializer into Kryo5Codec

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -285,6 +285,8 @@
                     </includes>
                     <excludes>
                         <exclude>target/**</exclude>
+                        <!-- vendored in from Kryo5, BSD-3-clause -->
+                        <exclude>src/main/java/org/redisson/codec/Kryo5KeySetViewSerializer.java</exclude>
                     </excludes>
                     <useDefaultExcludes>true</useDefaultExcludes>
                     <mapping>

--- a/redisson/src/main/java/org/redisson/codec/Kryo5Codec.java
+++ b/redisson/src/main/java/org/redisson/codec/Kryo5Codec.java
@@ -41,6 +41,7 @@ import java.net.InetAddress;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -185,6 +186,8 @@ public class Kryo5Codec extends BaseCodec {
         kryo.addDefaultSerializer(AtomicInteger.class, new DefaultSerializers.AtomicIntegerSerializer());
         kryo.addDefaultSerializer(AtomicLong.class, new DefaultSerializers.AtomicLongSerializer());
         kryo.addDefaultSerializer(AtomicReference.class, new DefaultSerializers.AtomicReferenceSerializer());
+        // once kryo5 releases a new version, this serializer will be included in kryo5s DefaultSerializers
+        kryo.addDefaultSerializer(ConcurrentHashMap.KeySetView.class, new Kryo5KeySetViewSerializer());
         return kryo;
     }
 

--- a/redisson/src/main/java/org/redisson/codec/Kryo5KeySetViewSerializer.java
+++ b/redisson/src/main/java/org/redisson/codec/Kryo5KeySetViewSerializer.java
@@ -1,0 +1,59 @@
+/*
+ * This file is licensed under BSD-3-Clause, not Apache-2.0; see notice below.
+ * Vendored in from https://github.com/EsotericSoftware/kryo/blob/90a1c0b0e6519098a33316cc48b3895759739261/src/com/esotericsoftware/kryo/serializers/DefaultSerializers.java#L859
+ * as it is not yet part of a released version of Kryo5.
+ *
+ * Released under BSD-3-Clause license. Original license:
+ *
+ * Copyright (c) 2008-2025, Nathan Sweet
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the distribution.
+ * - Neither the name of Esoteric Software nor the names of its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+// SPDX-License-Identifier: BSD-3-Clause
+
+package org.redisson.codec;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Serializer for {@link ConcurrentHashMap.KeySetView}.
+ *
+ * @author Andreas Bergander
+ */
+class Kryo5KeySetViewSerializer extends Serializer<ConcurrentHashMap.KeySetView> {
+    public void write(Kryo kryo, Output output, ConcurrentHashMap.KeySetView set) {
+        kryo.writeClassAndObject(output, set.getMap());
+        kryo.writeClassAndObject(output, set.getMappedValue());
+    }
+
+    public ConcurrentHashMap.KeySetView read(Kryo kryo, Input input, Class<? extends ConcurrentHashMap.KeySetView> type) {
+        return createKeySetView((ConcurrentHashMap) kryo.readClassAndObject(input), kryo.readClassAndObject(input));
+    }
+
+    public ConcurrentHashMap.KeySetView copy(Kryo kryo, ConcurrentHashMap.KeySetView original) {
+        return createKeySetView(kryo.copy(original.getMap()), kryo.copy(original.getMappedValue()));
+    }
+
+    private ConcurrentHashMap.KeySetView createKeySetView(ConcurrentHashMap map, Object mappedValue) {
+        return map.keySet(mappedValue);
+    }
+}

--- a/redisson/src/test/java/org/redisson/codec/Kryo5CodecTest.java
+++ b/redisson/src/test/java/org/redisson/codec/Kryo5CodecTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -97,6 +98,20 @@ public class Kryo5CodecTest {
         ByteBuf b4 = cc.getValueEncoder().encode(v4);
         AtomicReference<String> v4_1 = (AtomicReference<String>)cc.getValueDecoder().decode(b4, null);
         assertThat(v4_1.get()).isEqualTo("123");
+    }
+    
+    @Test
+    public void testKeySetView() throws IOException {
+        Kryo5Codec cc = new Kryo5Codec();
+
+        ConcurrentHashMap.KeySetView<String, Boolean> set = ConcurrentHashMap.newKeySet();
+        set.add("123");
+        ByteBuf b1 = cc.getValueEncoder().encode(set);
+        Set<String> set_1 = (Set<String>) cc.getValueDecoder().decode(b1, null);
+        assertThat(set_1).containsOnly("123");
+        // ensure this has the value part of the KeySetView set correctly so we can add things
+        set_1.add("456");
+        assertThat(set_1).containsOnly("123", "456");
     }
 
 }


### PR DESCRIPTION
Based upon discussion in https://github.com/redisson/redisson/issues/7207

Adds the `KeySetViewSerializer` that Kryo5 already has on its `master` branch but not yet in any release to the `Kryo5Codec`, allowing the successful serialization of `ConcurrentHashMap.KeySetView` (commonly used via `ConcurrentHashMap.newKeySet()`)

Potential discussion points:

- I put `Kryo5KeySetViewSerializer` into its own class to make it easier to highlight the BSD-3-clause license this code has from the Kryo5 project. Could however also be an inner class of `Kryo5Codec`
- I made the `Kryo5KeySetViewSerializer` package-private to not pollute the `codec` package.