### PR TITLE
Fix duplicate node connection when hostnames resolve to the same address

### DIFF
--- a/redisson/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
@@ -138,7 +138,23 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
                     RedisURI address = new RedisURI(addr.getScheme()
                                  + "://" + connection.getRedisClient().getAddr().getAddress().getHostAddress()
                                  + ":" + connection.getRedisClient().getAddr().getPort());
-                    nodeConnections.put(address, connection);
+                    // Distinct hostnames can resolve to one address (proxied cluster), so install
+                    // atomically to avoid leaving two live sockets: reuse an active winner, replace
+                    // a stale entry.
+                    while (true) {
+                        RedisConnection existing = nodeConnections.putIfAbsent(address, connection);
+                        if (existing == null || existing == connection) {
+                            break;
+                        }
+                        if (existing.isActive()) {
+                            nodeConnections.put(addr, existing);
+                            connection.getRedisClient().shutdownAsync();
+                            return CompletableFuture.completedFuture(existing);
+                        }
+                        if (nodeConnections.replace(address, existing, connection)) {
+                            break;
+                        }
+                    }
                 }
                 nodeConnections.put(addr, connection);
                 return CompletableFuture.completedFuture(connection);

--- a/redisson/src/test/java/org/redisson/connection/MasterSlaveConnectionManagerTest.java
+++ b/redisson/src/test/java/org/redisson/connection/MasterSlaveConnectionManagerTest.java
@@ -1,20 +1,25 @@
 package org.redisson.connection;
 
 import mockit.Expectations;
+import mockit.Injectable;
 import mockit.Invocation;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
+import mockit.Verifications;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.redisson.api.NodeType;
 import org.redisson.client.RedisClient;
 import org.redisson.client.RedisClientConfig;
+import org.redisson.client.RedisConnection;
 import org.redisson.client.RedisConnectionException;
 import org.redisson.config.*;
 
+import org.redisson.misc.CompletableFutureWrapper;
 import org.redisson.misc.RedisURI;
 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.concurrent.*;
@@ -294,6 +299,120 @@ public class MasterSlaveConnectionManagerTest {
             redisConfig.getConnectedListener().accept(addr);
 
             Assertions.assertThat(emittedNodeType.get()).isEqualTo(NodeType.MASTER);
+        } finally {
+            manager.shutdown(0, 0, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void connectToNodeReusesConnectionWhenHostnamesResolveToSameAddress(
+            @Injectable RedisClient seedClient, @Injectable RedisConnection seedConnection,
+            @Injectable RedisClient nodeClient, @Injectable RedisConnection nodeConnection)
+            throws Exception {
+        Config config = new Config();
+        MasterSlaveServersConfig msConfig = config.useMasterSlaveServers();
+        msConfig.setMasterAddress("redis://127.0.0.1:6379");
+        msConfig.setReadMode(ReadMode.MASTER);
+
+        // Two distinct hostnames (config endpoint + CLUSTER NODES address) that resolve to one
+        // address — the serverless proxy case. The first call connects via seedClient; the second
+        // must detect seedConnection already holds that resolved address and reuse it.
+        RedisURI seedUri = new RedisURI("redis://config-endpoint.example:6379");
+        RedisURI nodeUri = new RedisURI("redis://cluster-node.example:6379");
+        InetSocketAddress resolved =
+                new InetSocketAddress(InetAddress.getByName("10.0.0.1"), 6379);
+
+        MasterSlaveConnectionManager manager = new MasterSlaveConnectionManager(msConfig, config) {
+            @Override
+            protected RedisClient createClient(NodeType type, RedisURI address, int timeout,
+                    int commandTimeout, String sslHostname) {
+                return address.equals(seedUri) ? seedClient : nodeClient;
+            }
+        };
+
+        try {
+            new Expectations() {{
+                seedClient.connectAsync(); result = new CompletableFutureWrapper<>(seedConnection);
+                seedConnection.isActive(); result = true;
+                seedConnection.getRedisClient(); result = seedClient; minTimes = 0;
+                seedClient.getAddr(); result = resolved;
+
+                nodeClient.connectAsync(); result = new CompletableFutureWrapper<>(nodeConnection);
+                nodeConnection.isActive(); result = true;
+                nodeConnection.getRedisClient(); result = nodeClient;
+                nodeClient.getAddr(); result = resolved;
+            }};
+
+            RedisConnection first = manager
+                    .connectToNode(NodeType.MASTER, msConfig, seedUri, seedUri.getHost())
+                    .toCompletableFuture().get(5, TimeUnit.SECONDS);
+            RedisConnection second = manager
+                    .connectToNode(NodeType.MASTER, msConfig, nodeUri, nodeUri.getHost())
+                    .toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+            // the second call reuses the seed connection rather than holding a second socket
+            Assertions.assertThat(first).isSameAs(seedConnection);
+            Assertions.assertThat(second).isSameAs(seedConnection);
+
+            // and the redundant client opened by the second call is shut down
+            new Verifications() {{
+                nodeClient.shutdownAsync(); times = 1;
+            }};
+        } finally {
+            manager.shutdown(0, 0, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void connectToNodeReplacesStaleEntryWhenExistingResolvedConnectionIsInactive(
+            @Injectable RedisClient seedClient, @Injectable RedisConnection seedConnection,
+            @Injectable RedisClient nodeClient, @Injectable RedisConnection nodeConnection)
+            throws Exception {
+        Config config = new Config();
+        MasterSlaveServersConfig msConfig = config.useMasterSlaveServers();
+        msConfig.setMasterAddress("redis://127.0.0.1:6379");
+        msConfig.setReadMode(ReadMode.MASTER);
+
+        RedisURI seedUri = new RedisURI("redis://config-endpoint.example:6379");
+        RedisURI nodeUri = new RedisURI("redis://cluster-node.example:6379");
+        InetSocketAddress resolved =
+                new InetSocketAddress(InetAddress.getByName("10.0.0.1"), 6379);
+
+        MasterSlaveConnectionManager manager = new MasterSlaveConnectionManager(msConfig, config) {
+            @Override
+            protected RedisClient createClient(NodeType type, RedisURI address, int timeout,
+                    int commandTimeout, String sslHostname) {
+                return address.equals(seedUri) ? seedClient : nodeClient;
+            }
+        };
+
+        try {
+            new Expectations() {{
+                seedClient.connectAsync(); result = new CompletableFutureWrapper<>(seedConnection);
+                // active at install time, but dead by the time the second call inspects it
+                seedConnection.isActive(); returns(true, false);
+                seedConnection.getRedisClient(); result = seedClient; minTimes = 0;
+                seedClient.getAddr(); result = resolved;
+
+                nodeClient.connectAsync(); result = new CompletableFutureWrapper<>(nodeConnection);
+                nodeConnection.isActive(); result = true;
+                nodeConnection.getRedisClient(); result = nodeClient;
+                nodeClient.getAddr(); result = resolved;
+            }};
+
+            manager.connectToNode(NodeType.MASTER, msConfig, seedUri, seedUri.getHost())
+                    .toCompletableFuture().get(5, TimeUnit.SECONDS);
+            RedisConnection second = manager
+                    .connectToNode(NodeType.MASTER, msConfig, nodeUri, nodeUri.getHost())
+                    .toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+            // a dead resolved-IP entry must be replaced by the new connection, not reused
+            Assertions.assertThat(second).isSameAs(nodeConnection);
+
+            // and the new connection's client must not be shut down
+            new Verifications() {{
+                nodeClient.shutdownAsync(); times = 0;
+            }};
         } finally {
             manager.shutdown(0, 0, TimeUnit.SECONDS);
         }


### PR DESCRIPTION
Fixes #7219

### Problem

`MasterSlaveConnectionManager.connectToNode` keys its `nodeConnections` map by `RedisURI` (host + port + ssl). When two different hostnames resolve to the same socket address, the lookup at the top of the method misses on the raw hostname key, a second client is created, and the post-connect block then overwrites the resolved-IP entry — orphaning the first socket (still open) under its hostname key.

This surfaces on a proxied / single-endpoint cluster topology, where one endpoint fronts the whole cluster: the config endpoint used to bootstrap and the address reported by `CLUSTER NODES` are distinct hostnames that resolve to the same proxy address. The result is two live monitoring sockets to one address instead of one. On a real multi-node cluster the config endpoint is usually itself one of the discovered nodes, so the duplicate collapses and the bug is masked.

### Fix

Install the connection under the resolved-IP key atomically so a concurrent connect to the same address cannot leave two live sockets:

```java
while (true) {
    RedisConnection existing = nodeConnections.putIfAbsent(address, connection);
    if (existing == null || existing == connection) {
        break;
    }
    if (existing.isActive()) {
        nodeConnections.put(addr, existing);
        connection.getRedisClient().shutdownAsync();
        return CompletableFuture.completedFuture(existing);
    }
    // Stale entry: swap it out for ours, matching the prior unconditional overwrite.
    if (nodeConnections.replace(address, existing, connection)) {
        break;
    }
}
```

- If no active connection is held for that address, `putIfAbsent` installs this one (the common path).
- If another connect already installed an active connection for the address, reuse it and shut down the redundant client just opened.
- If the held entry is stale (inactive), swap it out via CAS `replace`, preserving the prior unconditional-overwrite behavior, and retry on contention.

The check-then-act is done through the map's atomic primitives (`putIfAbsent` / `replace`) rather than `get` + `put`, so two concurrent connects to the same address agree on a single winner instead of racing to overwrite each other.

In steady state on a multi-node cluster, distinct hostnames map to distinct addresses, so `putIfAbsent` always wins and behavior is unchanged. The dedup engages only when two hostnames transiently share one address.

### Tests

`MasterSlaveConnectionManagerTest`:

- `connectToNodeReusesConnectionWhenHostnamesResolveToSameAddress`: two `connectToNode` calls with different hostnames resolving to one `InetSocketAddress` return the same connection, and the redundant client is shut down exactly once.
- `connectToNodeReplacesStaleEntryWhenExistingResolvedConnectionIsInactive`: when the held resolved-IP entry is inactive, the new connection replaces it and its client is not shut down.

The first is verified as a regression test: it fails on master (the second call returns a distinct connection) and passes with this change. The full `MasterSlaveConnectionManagerTest` class passes.