### PR TITLE
Fixed - cluster lazy init self-deadlocks when re-registering a stale master entry

### DIFF
--- a/redisson/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
@@ -65,6 +65,10 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
 
     protected final AtomicReference<CompletableFuture<Void>> lazyConnectLatch = new AtomicReference<>();
 
+    // Owns lazyConnectLatch: a synchronous entry teardown during doConnect re-enters lazyConnect on
+    // this same thread, which must not join() the latch it holds.
+    private volatile Thread connectingThread;
+
     private boolean lastAttempt;
 
     protected final AtomicInteger rrCounter = new AtomicInteger(0);
@@ -188,6 +192,12 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
             return;
         }
 
+        // Re-entry by the connecting thread itself: return rather than join() the latch it holds,
+        // which would self-deadlock.
+        if (Thread.currentThread() == connectingThread) {
+            return;
+        }
+
         CompletableFuture<Void> newFuture = new CompletableFuture<>();
         if (!lazyConnectLatch.compareAndSet(null, newFuture)) {
             CompletableFuture<Void> currentFuture = lazyConnectLatch.get();
@@ -202,12 +212,17 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
             }
         }
 
+        // This thread now owns the latch; mark it so a synchronous re-entry into lazyConnect
+        // returns instead of join()ing the latch only it can complete.
+        connectingThread = Thread.currentThread();
         try {
             connect();
             newFuture.complete(null);
         } catch (Exception e) {
             newFuture.completeExceptionally(e);
             throw e;
+        } finally {
+            connectingThread = null;
         }
     }
 

--- a/redisson/src/test/java/org/redisson/connection/MasterSlaveConnectionManagerTest.java
+++ b/redisson/src/test/java/org/redisson/connection/MasterSlaveConnectionManagerTest.java
@@ -18,6 +18,7 @@ import org.redisson.misc.RedisURI;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -170,6 +171,34 @@ public class MasterSlaveConnectionManagerTest {
             // exceptional latch must be replaceable so a subsequent call retries initialization
             Assertions.assertThatCode(manager::getEntrySet).doesNotThrowAnyException();
             Assertions.assertThat(doConnectInvocations.get()).isEqualTo(2);
+        } finally {
+            manager.shutdown(0, 0, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void testLazyConnectReentryFromConnectingThreadDoesNotDeadlock() {
+        Config config = new Config();
+        config.setLazyInitialization(true);
+        MasterSlaveServersConfig msConfig = config.useMasterSlaveServers();
+        msConfig.setMasterAddress("redis://127.0.0.1:6379");
+        msConfig.setReadMode(ReadMode.MASTER);
+        msConfig.setRetryAttempts(0);
+
+        AtomicBoolean reentrantReturned = new AtomicBoolean();
+        MasterSlaveConnectionManager manager = new MasterSlaveConnectionManager(msConfig, config) {
+            @Override
+            protected void doConnect(Function<RedisURI, String> hostnameMapper) {
+                // mimics a synchronous entry teardown during init re-entering lazyConnect on the
+                // connecting thread; without the guard this join()s the latch it holds and deadlocks
+                lazyConnect();
+                reentrantReturned.set(true);
+            }
+        };
+
+        try {
+            assertTimeoutPreemptively(Duration.ofSeconds(10), manager::getEntrySet);
+            Assertions.assertThat(reentrantReturned).isTrue();
         } finally {
             manager.shutdown(0, 0, TimeUnit.SECONDS);
         }


### PR DESCRIPTION
## What

In cluster mode with lazy init, the first command can permanently self-deadlock:
the thread running init parks forever on the `lazyConnectLatch` it is itself holding.

Introduced by e3e3c41, which moved master registration onto the connecting thread
(build the entries async, then `registerMasterEntry` them inline in `doConnect`).
Before that change registration completed on a Netty thread, so the connecting thread
never re-entered `lazyConnect` synchronously and the cycle below couldn't form.

## Root cause

`lazyConnect()` admits one thread into `connect()`; that thread holds an uncompleted
`lazyConnectLatch` for the whole of `doConnect()`, and every other caller blocks on
`lazyConnectLatch.join()`.

`doConnect()` now registers each master **synchronously, on that same thread**, via
`registerMasterEntry -> addEntry`. When `addEntry` replaces a stale entry left by a
prior partial init, it tears the old one down inline — and that teardown re-enters
`lazyConnect()` on the connecting thread:

```
connect -> doConnect -> registerMasterEntry -> addEntry -> shutdownEntry
  -> nodeDown -> reattachPubSub -> getEntry -> lazyConnect
     -> lazyConnectLatch.join()   // parks on the latch THIS thread holds
```

`isInitialized()` is still false mid-init, so the existing early-return doesn't fire
and the re-entrant call joins a future only this thread can complete. Permanent
deadlock. (The same synchronous re-entry also reaches `getEntry` via
`nodeDown -> reattachBlockingQueue`, so the fix must cover any `getEntry` re-entry,
not just pub/sub.)

## Fix

Detect the re-entry by thread identity:

- `connect()` records `connectingThread = Thread.currentThread()`, cleared in `finally`.
- `lazyConnect()` returns early when `Thread.currentThread() == connectingThread`.

The connecting thread then returns from the re-entrant `getEntry` immediately, reading
the maps as they stand mid-init (it finds the entry being torn down, so the reattach
falls through harmlessly) instead of parking. Other threads still block on the latch
unchanged. The field is per-manager and `volatile`. This works precisely because
registration runs inline on the connecting thread.

## Reproduce

3-master cluster, lazy init, `retryAttempts(0)`, `masterConnectionMinimumIdleSize > 1`.
After the seed topology read succeeds, make the non-seed masters unreachable
(`CLIENT PAUSE` / partition) so init registers some masters then aborts on coverage,
leaving a stale entry. The next command's `doConnect` re-registers and deadlocks
(thread dump: connecting thread parked in `CompletableFuture.join()` inside
`lazyConnect`, in the stack above). With the patch it fails fast and a later command
on the same client recovers once the pause clears.

Fixes #7222
