### PR TITLE
Fixed - tryLock method throws a redis timeout exception, and the key redisson_lock_queue and redisson_lock_timeout in redis is not removed. #5019

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonFairLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonFairLock.java
@@ -73,7 +73,7 @@ public class RedissonFairLock extends RedissonLock implements RLock {
             wait = unit.toMillis(waitTime);
         }
 
-        RFuture<Void> f = evalWriteSyncedNoRetryAsync(getRawName(), LongCodec.INSTANCE, RedisCommands.EVAL_VOID,
+        RFuture<Void> f = commandExecutor.syncedEvalWithRetry(getRawName(), LongCodec.INSTANCE, RedisCommands.EVAL_VOID,
                 // get the existing timeout for the thread to remove
                 "local queue = redis.call('lrange', KEYS[1], 0, -1);" +
                         // find the location in the queue where the thread is

--- a/redisson/src/main/java/org/redisson/RedissonLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonLock.java
@@ -17,6 +17,7 @@ package org.redisson;
 
 import io.netty.util.Timeout;
 import org.redisson.api.RFuture;
+import org.redisson.client.RedisResponseTimeoutException;
 import org.redisson.client.RedisTimeoutException;
 import org.redisson.client.codec.LongCodec;
 import org.redisson.client.protocol.RedisCommands;
@@ -270,7 +271,14 @@ public class RedissonLock extends RedissonBaseLock {
         
             while (true) {
                 long currentTime = System.currentTimeMillis();
-                ttl = tryAcquire(waitTime, leaseTime, unit, threadId);
+                try {
+                    ttl = tryAcquire(waitTime, leaseTime, unit, threadId);
+                } catch (RedisResponseTimeoutException e) {
+                    LOGGER.error(e.getMessage(), e);
+                    acquireFailed(waitTime, unit, threadId);
+                    return false;
+                }
+
                 // lock acquired
                 if (ttl == null) {
                     return true;


### PR DESCRIPTION
[issues/5019](https://github.com/redisson/redisson/issues/5019)