### PR TITLE
Fixes the failed node detector copy behavior in `RedisClientConfig`.

### DIFF
--- a/redisson/src/main/java/org/redisson/client/FailedCommandsDetector.java
+++ b/redisson/src/main/java/org/redisson/client/FailedCommandsDetector.java
@@ -27,9 +27,9 @@ import java.util.concurrent.ConcurrentSkipListSet;
  */
 public class FailedCommandsDetector implements FailedNodeDetector {
 
-    private long checkInterval;
+    protected long checkInterval;
 
-    private long failedCommandsLimit;
+    protected long failedCommandsLimit;
 
     private final NavigableSet<Long> failedCommands = new ConcurrentSkipListSet<>();
 
@@ -108,6 +108,11 @@ public class FailedCommandsDetector implements FailedNodeDetector {
             return true;
         }
         return false;
+    }
+
+    @Override
+    public FailedNodeDetector copy() {
+        return new FailedCommandsDetector(checkInterval, (int) failedCommandsLimit);
     }
 
 }

--- a/redisson/src/main/java/org/redisson/client/FailedCommandsTimeoutDetector.java
+++ b/redisson/src/main/java/org/redisson/client/FailedCommandsTimeoutDetector.java
@@ -38,4 +38,9 @@ public class FailedCommandsTimeoutDetector extends FailedCommandsDetector {
         }
     }
 
+    @Override
+    public FailedNodeDetector copy() {
+        return new FailedCommandsTimeoutDetector(checkInterval, (int) failedCommandsLimit);
+    }
+
 }

--- a/redisson/src/main/java/org/redisson/client/FailedConnectionDetector.java
+++ b/redisson/src/main/java/org/redisson/client/FailedConnectionDetector.java
@@ -94,4 +94,9 @@ public class FailedConnectionDetector implements FailedNodeDetector {
         return false;
     }
 
+    @Override
+    public FailedNodeDetector copy() {
+        return new FailedConnectionDetector(checkInterval);
+    }
+
 }

--- a/redisson/src/main/java/org/redisson/client/FailedNodeDetector.java
+++ b/redisson/src/main/java/org/redisson/client/FailedNodeDetector.java
@@ -48,4 +48,13 @@ public interface FailedNodeDetector {
 
     boolean isNodeFailed();
 
+    /**
+     * Returns a detector with the same configuration and independent runtime state.
+     *
+     * @return detector copy
+     */
+    default FailedNodeDetector copy() {
+        return this;
+    }
+
 }

--- a/redisson/src/main/java/org/redisson/client/RedisClientConfig.java
+++ b/redisson/src/main/java/org/redisson/client/RedisClientConfig.java
@@ -130,7 +130,9 @@ public class RedisClientConfig {
         this.sslKeyManagerFactory = config.sslKeyManagerFactory;
         this.sslTrustManagerFactory = config.sslTrustManagerFactory;
         this.commandMapper = config.commandMapper;
-        this.failedNodeDetector = config.failedNodeDetector;
+        if (config.failedNodeDetector != null) {
+            this.failedNodeDetector = config.failedNodeDetector.copy();
+        }
         this.tcpKeepAliveCount = config.tcpKeepAliveCount;
         this.tcpKeepAliveIdle = config.tcpKeepAliveIdle;
         this.tcpKeepAliveInterval = config.tcpKeepAliveInterval;

--- a/redisson/src/test/java/org/redisson/client/FailedNodeDetectorCopyTest.java
+++ b/redisson/src/test/java/org/redisson/client/FailedNodeDetectorCopyTest.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2013-2026 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.client;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FailedNodeDetectorCopyTest {
+
+    @Test
+    void failedConnectionDetectorCopyHasIndependentState() throws Exception {
+        FailedConnectionDetector detector = new FailedConnectionDetector(1);
+        FailedNodeDetector copy = detector.copy();
+
+        detector.onConnectFailed(new RedisConnectionException("test"));
+        Thread.sleep(5);
+
+        assertThat(copy).isInstanceOf(FailedConnectionDetector.class).isNotSameAs(detector);
+        assertThat(detector.isNodeFailed()).isTrue();
+        assertThat(copy.isNodeFailed()).isFalse();
+    }
+
+    @Test
+    void failedCommandsDetectorCopyHasIndependentState() throws Exception {
+        FailedCommandsDetector detector = new FailedCommandsDetector(10000, 2);
+        FailedNodeDetector copy = detector.copy();
+
+        failCommand(detector, new RedisConnectionException("test"));
+        failCommand(detector, new RedisConnectionException("test"));
+
+        assertThat(copy).isInstanceOf(FailedCommandsDetector.class).isNotSameAs(detector);
+        assertThat(detector.isNodeFailed()).isTrue();
+        assertThat(copy.isNodeFailed()).isFalse();
+    }
+
+    @Test
+    void failedCommandsTimeoutDetectorCopyHasIndependentStateAndType() throws Exception {
+        FailedCommandsTimeoutDetector detector = new FailedCommandsTimeoutDetector(10000, 2);
+        FailedNodeDetector copy = detector.copy();
+
+        failCommand(detector, new RedisConnectionException("test"));
+        failCommand(detector, new RedisTimeoutException("test"));
+        failCommand(detector, new RedisTimeoutException("test"));
+
+        assertThat(copy).isInstanceOf(FailedCommandsTimeoutDetector.class).isNotSameAs(detector);
+        assertThat(detector.isNodeFailed()).isTrue();
+        assertThat(copy.isNodeFailed()).isFalse();
+    }
+
+    @Test
+    void redisClientConfigCopyCopiesDetectorState() {
+        TrackingDetector detector = new TrackingDetector();
+        RedisClientConfig config = new RedisClientConfig()
+                .setFailedNodeDetector(detector);
+
+        RedisClientConfig copy = new RedisClientConfig(config);
+
+        assertThat(copy.getFailedNodeDetector()).isInstanceOf(TrackingDetector.class);
+        assertThat(copy.getFailedNodeDetector()).isNotSameAs(detector);
+    }
+
+    private void failCommand(FailedNodeDetector detector, Throwable cause) throws Exception {
+        detector.onCommandFailed(cause);
+        Thread.sleep(2);
+    }
+
+    private static final class TrackingDetector implements FailedNodeDetector {
+
+        @Override
+        public void onConnectSuccessful() {
+        }
+
+        @Override
+        public void onConnectFailed() {
+        }
+
+        @Override
+        public void onPingSuccessful() {
+        }
+
+        @Override
+        public void onPingFailed() {
+        }
+
+        @Override
+        public void onCommandSuccessful() {
+        }
+
+        @Override
+        public void onCommandFailed(Throwable cause) {
+        }
+
+        @Override
+        public boolean isNodeFailed() {
+            return false;
+        }
+
+        @Override
+        public FailedNodeDetector copy() {
+            return new TrackingDetector();
+        }
+    }
+}


### PR DESCRIPTION
# Summary
Fixes the failed node detector copy behavior in `RedisClientConfig`. [[issue](https://github.com/redisson/redisson/issues/7231)]

  `RedisClientConfig` creates per-node client configs, but previously reused the same `FailedNodeDetector` instance across copied configs. Since the built-in detectors keep
  runtime failure state, failures from one node could contribute to another node's failure window.

  This PR adds `FailedNodeDetector.copy()` and makes the built-in detectors return new instances with the same configuration but independent runtime state.
  `RedisClientConfig` now uses the copy when cloning config.
  

# Test:

  ```bash
  JAVA_HOME=/Library/Java/JavaVirtualMachines/amazon-corretto-21.jdk/Contents/Home mvn -pl redisson -Punit-test -Dmaven.compiler.testRelease=21
  -Dmaven.compiler.testSource=21 -Dmaven.compiler.testTarget=21 -Dtest=org.redisson.client.FailedNodeDetectorCopyTest test