### PR TITLE
Fix RedissonSetMultimap.fastRemoveValueAsync always returning 0

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonSetMultimap.java
+++ b/redisson/src/main/java/org/redisson/RedissonSetMultimap.java
@@ -91,7 +91,7 @@ public class RedissonSetMultimap<K, V> extends RedissonMultimap<K, V> implements
                         "end; " +
                     "end;" +
                 "end; " +
-                "return 0; ",
+                "return size; ",
                 Arrays.asList(getRawName()),
                 args.toArray());
     }


### PR DESCRIPTION
## Description

`RedissonSetMultimap.fastRemoveValueAsync(V...)` always returns `0`, regardless of how many values are actually removed. Its Lua script accumulates the removed count into `size`:

```lua
size = size + redis.call(srem, name, ARGV[j]);
```

but then ends with `return 0;` instead of `return size;`.

The sibling `removeAllAsync` script in the same class uses the identical accumulation pattern and correctly ends with `return size;`, which confirms the intended behaviour. This looks like a copy/paste slip.

## Fix

Return the accumulated `size` instead of the hardcoded `0`:

```diff
-                "return 0; ",
+                "return size; ",
```

I verified this against a unit test that captures the evaluated Lua script and asserts the returned count matches the number removed. I left it out of this PR because it would pull in a mocking dependency the project does not currently use; I am happy to contribute a regression test using the existing testcontainers setup if you would like one in the suite.

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.
