### PR TITLE
Expose node address to failed node detectors

### DIFF
--- a/redisson/src/main/java/org/redisson/client/FailedNodeDetector.java
+++ b/redisson/src/main/java/org/redisson/client/FailedNodeDetector.java
@@ -15,6 +15,8 @@
  */
 package org.redisson.client;
 
+import java.net.InetSocketAddress;
+
 /**
  * Detects failed Redis node depending
  * on {@link #isNodeFailed()} method implementation.
@@ -47,6 +49,14 @@ public interface FailedNodeDetector {
     void onCommandFailed(Throwable cause);
 
     boolean isNodeFailed();
+
+    /**
+     * Assigns Redis node address this detector instance observes.
+     *
+     * @param address Redis node address
+     */
+    default void setNodeAddress(InetSocketAddress address) {
+    }
 
     /**
      * Returns a detector with the same configuration and independent runtime state.

--- a/redisson/src/main/java/org/redisson/client/FailedNodeDetector.java
+++ b/redisson/src/main/java/org/redisson/client/FailedNodeDetector.java
@@ -28,6 +28,10 @@ public interface FailedNodeDetector {
 
     void onConnectSuccessful();
 
+    default void onConnectSuccessful(InetSocketAddress address) {
+        onConnectSuccessful();
+    }
+
     @Deprecated
     void onConnectFailed();
 
@@ -35,7 +39,15 @@ public interface FailedNodeDetector {
         onConnectFailed();
     }
 
+    default void onConnectFailed(Throwable cause, InetSocketAddress address) {
+        onConnectFailed(cause);
+    }
+
     void onPingSuccessful();
+
+    default void onPingSuccessful(InetSocketAddress address) {
+        onPingSuccessful();
+    }
 
     @Deprecated
     void onPingFailed();
@@ -44,18 +56,26 @@ public interface FailedNodeDetector {
         onPingFailed();
     }
 
+    default void onPingFailed(Throwable cause, InetSocketAddress address) {
+        onPingFailed(cause);
+    }
+
     void onCommandSuccessful();
+
+    default void onCommandSuccessful(InetSocketAddress address) {
+        onCommandSuccessful();
+    }
 
     void onCommandFailed(Throwable cause);
 
+    default void onCommandFailed(Throwable cause, InetSocketAddress address) {
+        onCommandFailed(cause);
+    }
+
     boolean isNodeFailed();
 
-    /**
-     * Assigns Redis node address this detector instance observes.
-     *
-     * @param address Redis node address
-     */
-    default void setNodeAddress(InetSocketAddress address) {
+    default boolean isNodeFailed(InetSocketAddress address) {
+        return isNodeFailed();
     }
 
     /**

--- a/redisson/src/main/java/org/redisson/client/FailedNodeDetector.java
+++ b/redisson/src/main/java/org/redisson/client/FailedNodeDetector.java
@@ -26,6 +26,7 @@ import java.net.InetSocketAddress;
  */
 public interface FailedNodeDetector {
 
+    @Deprecated
     void onConnectSuccessful();
 
     default void onConnectSuccessful(InetSocketAddress address) {
@@ -35,6 +36,7 @@ public interface FailedNodeDetector {
     @Deprecated
     void onConnectFailed();
 
+    @Deprecated
     default void onConnectFailed(Throwable cause) {
         onConnectFailed();
     }
@@ -43,6 +45,7 @@ public interface FailedNodeDetector {
         onConnectFailed(cause);
     }
 
+    @Deprecated
     void onPingSuccessful();
 
     default void onPingSuccessful(InetSocketAddress address) {
@@ -52,6 +55,7 @@ public interface FailedNodeDetector {
     @Deprecated
     void onPingFailed();
 
+    @Deprecated
     default void onPingFailed(Throwable cause) {
         onPingFailed();
     }
@@ -60,18 +64,21 @@ public interface FailedNodeDetector {
         onPingFailed(cause);
     }
 
+    @Deprecated
     void onCommandSuccessful();
 
     default void onCommandSuccessful(InetSocketAddress address) {
         onCommandSuccessful();
     }
 
+    @Deprecated
     void onCommandFailed(Throwable cause);
 
     default void onCommandFailed(Throwable cause, InetSocketAddress address) {
         onCommandFailed(cause);
     }
 
+    @Deprecated
     boolean isNodeFailed();
 
     default boolean isNodeFailed(InetSocketAddress address) {

--- a/redisson/src/main/java/org/redisson/client/RedisClientConfig.java
+++ b/redisson/src/main/java/org/redisson/client/RedisClientConfig.java
@@ -132,6 +132,7 @@ public class RedisClientConfig {
         this.commandMapper = config.commandMapper;
         if (config.failedNodeDetector != null) {
             this.failedNodeDetector = config.failedNodeDetector.copy();
+            this.failedNodeDetector.setNodeAddress(getNodeAddress());
         }
         this.tcpKeepAliveCount = config.tcpKeepAliveCount;
         this.tcpKeepAliveIdle = config.tcpKeepAliveIdle;
@@ -182,6 +183,17 @@ public class RedisClientConfig {
     }
     public InetSocketAddress getAddr() {
         return addr;
+    }
+
+    private InetSocketAddress getNodeAddress() {
+        if (addr != null) {
+            return addr;
+        }
+        if (address == null) {
+            return null;
+        }
+
+        return InetSocketAddress.createUnresolved(address.getHost(), address.getPort());
     }
     
     public Timer getTimer() {

--- a/redisson/src/main/java/org/redisson/client/RedisClientConfig.java
+++ b/redisson/src/main/java/org/redisson/client/RedisClientConfig.java
@@ -132,7 +132,6 @@ public class RedisClientConfig {
         this.commandMapper = config.commandMapper;
         if (config.failedNodeDetector != null) {
             this.failedNodeDetector = config.failedNodeDetector.copy();
-            this.failedNodeDetector.setNodeAddress(getNodeAddress());
         }
         this.tcpKeepAliveCount = config.tcpKeepAliveCount;
         this.tcpKeepAliveIdle = config.tcpKeepAliveIdle;
@@ -183,17 +182,6 @@ public class RedisClientConfig {
     }
     public InetSocketAddress getAddr() {
         return addr;
-    }
-
-    private InetSocketAddress getNodeAddress() {
-        if (addr != null) {
-            return addr;
-        }
-        if (address == null) {
-            return null;
-        }
-
-        return InetSocketAddress.createUnresolved(address.getHost(), address.getPort());
     }
     
     public Timer getTimer() {

--- a/redisson/src/main/java/org/redisson/client/handler/PingConnectionHandler.java
+++ b/redisson/src/main/java/org/redisson/client/handler/PingConnectionHandler.java
@@ -19,6 +19,7 @@ import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import org.redisson.api.RFuture;
+import org.redisson.client.RedisClient;
 import org.redisson.client.RedisClientConfig;
 import org.redisson.client.RedisConnection;
 import org.redisson.client.RedisRetryException;
@@ -99,9 +100,11 @@ public class PingConnectionHandler extends ChannelInboundHandlerAdapter {
                 } else {
                     sendPing(ctx);
                 }
-                connection.getRedisClient().getConfig().getFailedNodeDetector().onPingFailed(cause);
+                RedisClient client = connection.getRedisClient();
+                client.getConfig().getFailedNodeDetector().onPingFailed(cause, client.getAddr());
             } else if (future != null) {
-                connection.getRedisClient().getConfig().getFailedNodeDetector().onPingSuccessful();
+                RedisClient client = connection.getRedisClient();
+                client.getConfig().getFailedNodeDetector().onPingSuccessful(client.getAddr());
                 sendPing(ctx);
             } else {
                 sendPing(ctx);

--- a/redisson/src/main/java/org/redisson/command/RedisExecutor.java
+++ b/redisson/src/main/java/org/redisson/command/RedisExecutor.java
@@ -700,8 +700,8 @@ public class RedisExecutor<V, R> {
 
         RedisClient client = connectionFuture.join().getRedisClient();
         FailedNodeDetector detector = client.getConfig().getFailedNodeDetector();
-        detector.onCommandFailed(cause);
-        if (detector.isNodeFailed()) {
+        detector.onCommandFailed(cause, client.getAddr());
+        if (detector.isNodeFailed(client.getAddr())) {
             log.error("Redis node {} has been marked as failed according to the detection logic defined in {}",
                             client.getAddr(), detector);
             entry.shutdownAndReconnectAsync(client, cause);
@@ -714,7 +714,8 @@ public class RedisExecutor<V, R> {
         } else {
             promise.complete(res);
         }
-        connectionFuture.join().getRedisClient().getConfig().getFailedNodeDetector().onCommandSuccessful();
+        RedisClient client = connectionFuture.join().getRedisClient();
+        client.getConfig().getFailedNodeDetector().onCommandSuccessful(client.getAddr());
     }
 
     protected void sendCommand(CompletableFuture<R> attemptPromise, RedisConnection connection) {

--- a/redisson/src/main/java/org/redisson/connection/MasterSlaveEntry.java
+++ b/redisson/src/main/java/org/redisson/connection/MasterSlaveEntry.java
@@ -712,7 +712,8 @@ public class MasterSlaveEntry {
 
     @SuppressWarnings("BooleanExpressionComplexity")
     private ClientConnectionsEntry freeze(ClientConnectionsEntry connectionEntry, FreezeReason freezeReason) {
-        if (connectionEntry == null || (connectionEntry.getClient().getConfig().getFailedNodeDetector().isNodeFailed()
+        if (connectionEntry == null || (connectionEntry.getClient().getConfig().getFailedNodeDetector()
+                                                    .isNodeFailed(connectionEntry.getClient().getAddr())
                                             && connectionEntry.getFreezeReason() == FreezeReason.RECONNECT
                                             && freezeReason == FreezeReason.RECONNECT)) {
             return null;
@@ -800,7 +801,8 @@ public class MasterSlaveEntry {
                             return;
                         }
 
-                        entry.getClient().getConfig().getFailedNodeDetector().onConnectSuccessful();
+                        entry.getClient().getConfig().getFailedNodeDetector()
+                                .onConnectSuccessful(entry.getClient().getAddr());
                         entry.setFreezeReason(null);
                         log.debug("Unfreezed entry: {} after {} attempts", entry, retry);
                         f.complete(true);

--- a/redisson/src/main/java/org/redisson/connection/pool/ConnectionPool.java
+++ b/redisson/src/main/java/org/redisson/connection/pool/ConnectionPool.java
@@ -88,7 +88,7 @@ abstract class ConnectionPool<T extends RedisConnection> {
         List<InetSocketAddress> failed = new ArrayList<>();
         List<InetSocketAddress> freezed = new ArrayList<>();
         for (ClientConnectionsEntry entry : entries) {
-            if (entry.getClient().getConfig().getFailedNodeDetector().isNodeFailed()) {
+            if (entry.getClient().getConfig().getFailedNodeDetector().isNodeFailed(entry.getClient().getAddr())) {
                 failed.add(entry.getClient().getAddr());
             } else if (entry.isFreezed()) {
                 freezed.add(entry.getClient().getAddr());
@@ -135,8 +135,8 @@ abstract class ConnectionPool<T extends RedisConnection> {
             if (e != null) {
                 if (entry.getNodeType() == NodeType.SLAVE) {
                     FailedNodeDetector detector = entry.getClient().getConfig().getFailedNodeDetector();
-                    detector.onConnectFailed(e);
-                    if (detector.isNodeFailed()) {
+                    detector.onConnectFailed(e, entry.getClient().getAddr());
+                    if (detector.isNodeFailed(entry.getClient().getAddr())) {
                         shutdownAndReconnect(entry, detector, e);
                     }
                 }
@@ -147,7 +147,8 @@ abstract class ConnectionPool<T extends RedisConnection> {
             entry.addHandler(r, handler);
 
             if (entry.getNodeType() == NodeType.SLAVE) {
-                entry.getClient().getConfig().getFailedNodeDetector().onConnectSuccessful();
+                entry.getClient().getConfig().getFailedNodeDetector()
+                        .onConnectSuccessful(entry.getClient().getAddr());
             }
 
             if (!cancelableFuture.complete(r)) {
@@ -163,7 +164,7 @@ abstract class ConnectionPool<T extends RedisConnection> {
         }
 
         FailedNodeDetector detector = entry.getClient().getConfig().getFailedNodeDetector();
-        return !detector.isNodeFailed();
+        return !detector.isNodeFailed(entry.getClient().getAddr());
     }
 
     private void shutdownAndReconnect(ClientConnectionsEntry entry, FailedNodeDetector detector, Throwable cause) {

--- a/redisson/src/test/java/org/redisson/client/FailedCommandsDetectorTest.java
+++ b/redisson/src/test/java/org/redisson/client/FailedCommandsDetectorTest.java
@@ -137,7 +137,7 @@ class FailedCommandsDetectorTest {
         detector.blockNextTimeRead();
         ExecutorService executor = Executors.newFixedThreadPool(2);
         try {
-            Future<Boolean> transition = executor.submit(detector::isNodeFailed);
+            Future<Boolean> transition = executor.submit(() -> detector.isNodeFailed());
             detector.awaitBlockedTimeRead();
 
             CountDownLatch writerStarted = new CountDownLatch(1);

--- a/redisson/src/test/java/org/redisson/client/FailedNodeDetectorCopyTest.java
+++ b/redisson/src/test/java/org/redisson/client/FailedNodeDetectorCopyTest.java
@@ -16,6 +16,9 @@
 package org.redisson.client;
 
 import org.junit.jupiter.api.Test;
+import org.redisson.misc.RedisURI;
+
+import java.net.InetSocketAddress;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -73,12 +76,42 @@ class FailedNodeDetectorCopyTest {
         assertThat(copy.getFailedNodeDetector()).isNotSameAs(detector);
     }
 
+    @Test
+    void redisClientConfigCopyAssignsResolvedAddress() {
+        TrackingDetector detector = new TrackingDetector();
+        InetSocketAddress address = new InetSocketAddress("127.0.0.1", 6379);
+        RedisURI uri = new RedisURI("redis://localhost:6379");
+        RedisClientConfig config = new RedisClientConfig()
+                .setAddress(address, uri)
+                .setFailedNodeDetector(detector);
+
+        RedisClientConfig copy = new RedisClientConfig(config);
+
+        assertThat(((TrackingDetector) copy.getFailedNodeDetector()).address).isEqualTo(address);
+    }
+
+    @Test
+    void redisClientConfigCopyAssignsUnresolvedUriAddress() {
+        TrackingDetector detector = new TrackingDetector();
+        RedisClientConfig config = new RedisClientConfig()
+                .setAddress("redis://redis.example.com:6379")
+                .setFailedNodeDetector(detector);
+
+        RedisClientConfig copy = new RedisClientConfig(config);
+        InetSocketAddress address = ((TrackingDetector) copy.getFailedNodeDetector()).address;
+
+        assertThat(address.getHostString()).isEqualTo("redis.example.com");
+        assertThat(address.getPort()).isEqualTo(6379);
+        assertThat(address.isUnresolved()).isTrue();
+    }
+
     private void failCommand(FailedNodeDetector detector, Throwable cause) throws Exception {
         detector.onCommandFailed(cause);
         Thread.sleep(2);
     }
 
     private static final class TrackingDetector implements FailedNodeDetector {
+        private InetSocketAddress address;
 
         @Override
         public void onConnectSuccessful() {
@@ -107,6 +140,11 @@ class FailedNodeDetectorCopyTest {
         @Override
         public boolean isNodeFailed() {
             return false;
+        }
+
+        @Override
+        public void setNodeAddress(InetSocketAddress address) {
+            this.address = address;
         }
 
         @Override

--- a/redisson/src/test/java/org/redisson/client/FailedNodeDetectorCopyTest.java
+++ b/redisson/src/test/java/org/redisson/client/FailedNodeDetectorCopyTest.java
@@ -16,7 +16,6 @@
 package org.redisson.client;
 
 import org.junit.jupiter.api.Test;
-import org.redisson.misc.RedisURI;
 
 import java.net.InetSocketAddress;
 
@@ -77,32 +76,46 @@ class FailedNodeDetectorCopyTest {
     }
 
     @Test
-    void redisClientConfigCopyAssignsResolvedAddress() {
-        TrackingDetector detector = new TrackingDetector();
+    void addressAwareMethodsReceiveSuppliedAddress() {
+        AddressAwareDetector detector = new AddressAwareDetector();
         InetSocketAddress address = new InetSocketAddress("127.0.0.1", 6379);
-        RedisURI uri = new RedisURI("redis://localhost:6379");
-        RedisClientConfig config = new RedisClientConfig()
-                .setAddress(address, uri)
-                .setFailedNodeDetector(detector);
+        RedisConnectionException cause = new RedisConnectionException("test");
 
-        RedisClientConfig copy = new RedisClientConfig(config);
+        detector.onConnectSuccessful(address);
+        detector.onConnectFailed(cause, address);
+        detector.onPingSuccessful(address);
+        detector.onPingFailed(cause, address);
+        detector.onCommandSuccessful(address);
+        detector.onCommandFailed(cause, address);
 
-        assertThat(((TrackingDetector) copy.getFailedNodeDetector()).address).isEqualTo(address);
+        assertThat(detector.addresses).containsOnly(address);
+        assertThat(detector.causes).containsOnly(cause);
+        assertThat(detector.isNodeFailed(address)).isTrue();
+        assertThat(detector.failedCheckAddress).isEqualTo(address);
     }
 
     @Test
-    void redisClientConfigCopyAssignsUnresolvedUriAddress() {
+    void addressAwareMethodsDelegateToLegacyMethodsByDefault() {
         TrackingDetector detector = new TrackingDetector();
-        RedisClientConfig config = new RedisClientConfig()
-                .setAddress("redis://redis.example.com:6379")
-                .setFailedNodeDetector(detector);
+        InetSocketAddress address = new InetSocketAddress("127.0.0.1", 6379);
+        RedisConnectionException cause = new RedisConnectionException("test");
 
-        RedisClientConfig copy = new RedisClientConfig(config);
-        InetSocketAddress address = ((TrackingDetector) copy.getFailedNodeDetector()).address;
+        detector.onConnectSuccessful(address);
+        detector.onConnectFailed(cause, address);
+        detector.onPingSuccessful(address);
+        detector.onPingFailed(cause, address);
+        detector.onCommandSuccessful(address);
+        detector.onCommandFailed(cause, address);
 
-        assertThat(address.getHostString()).isEqualTo("redis.example.com");
-        assertThat(address.getPort()).isEqualTo(6379);
-        assertThat(address.isUnresolved()).isTrue();
+        assertThat(detector.connectSuccessfulCalls).isEqualTo(1);
+        assertThat(detector.connectFailedCalls).isEqualTo(1);
+        assertThat(detector.pingSuccessfulCalls).isEqualTo(1);
+        assertThat(detector.pingFailedCalls).isEqualTo(1);
+        assertThat(detector.commandSuccessfulCalls).isEqualTo(1);
+        assertThat(detector.commandFailedCalls).isEqualTo(1);
+        assertThat(detector.lastCause).isEqualTo(cause);
+        assertThat(detector.isNodeFailed(address)).isTrue();
+        assertThat(detector.nodeFailedCalls).isEqualTo(1);
     }
 
     private void failCommand(FailedNodeDetector detector, Throwable cause) throws Exception {
@@ -111,10 +124,70 @@ class FailedNodeDetectorCopyTest {
     }
 
     private static final class TrackingDetector implements FailedNodeDetector {
-        private InetSocketAddress address;
+        private int connectSuccessfulCalls;
+        private int connectFailedCalls;
+        private int pingSuccessfulCalls;
+        private int pingFailedCalls;
+        private int commandSuccessfulCalls;
+        private int commandFailedCalls;
+        private int nodeFailedCalls;
+        private Throwable lastCause;
 
         @Override
         public void onConnectSuccessful() {
+            connectSuccessfulCalls++;
+        }
+
+        @Override
+        public void onConnectFailed() {
+            connectFailedCalls++;
+        }
+
+        @Override
+        public void onPingSuccessful() {
+            pingSuccessfulCalls++;
+        }
+
+        @Override
+        public void onPingFailed() {
+            pingFailedCalls++;
+        }
+
+        @Override
+        public void onCommandSuccessful() {
+            commandSuccessfulCalls++;
+        }
+
+        @Override
+        public void onCommandFailed(Throwable cause) {
+            commandFailedCalls++;
+            lastCause = cause;
+        }
+
+        @Override
+        public boolean isNodeFailed() {
+            nodeFailedCalls++;
+            return true;
+        }
+
+        @Override
+        public FailedNodeDetector copy() {
+            return new TrackingDetector();
+        }
+    }
+
+    private static final class AddressAwareDetector implements FailedNodeDetector {
+        private final InetSocketAddress[] addresses = new InetSocketAddress[6];
+        private final Throwable[] causes = new Throwable[3];
+        private InetSocketAddress failedCheckAddress;
+
+        @Override
+        public void onConnectSuccessful() {
+        }
+
+        @Override
+        public void onConnectSuccessful(InetSocketAddress address) {
+            addresses[0] = address;
         }
 
         @Override
@@ -122,7 +195,18 @@ class FailedNodeDetectorCopyTest {
         }
 
         @Override
+        public void onConnectFailed(Throwable cause, InetSocketAddress address) {
+            causes[0] = cause;
+            addresses[1] = address;
+        }
+
+        @Override
         public void onPingSuccessful() {
+        }
+
+        @Override
+        public void onPingSuccessful(InetSocketAddress address) {
+            addresses[2] = address;
         }
 
         @Override
@@ -130,11 +214,28 @@ class FailedNodeDetectorCopyTest {
         }
 
         @Override
+        public void onPingFailed(Throwable cause, InetSocketAddress address) {
+            causes[1] = cause;
+            addresses[3] = address;
+        }
+
+        @Override
         public void onCommandSuccessful() {
         }
 
         @Override
+        public void onCommandSuccessful(InetSocketAddress address) {
+            addresses[4] = address;
+        }
+
+        @Override
         public void onCommandFailed(Throwable cause) {
+        }
+
+        @Override
+        public void onCommandFailed(Throwable cause, InetSocketAddress address) {
+            causes[2] = cause;
+            addresses[5] = address;
         }
 
         @Override
@@ -143,13 +244,9 @@ class FailedNodeDetectorCopyTest {
         }
 
         @Override
-        public void setNodeAddress(InetSocketAddress address) {
-            this.address = address;
-        }
-
-        @Override
-        public FailedNodeDetector copy() {
-            return new TrackingDetector();
+        public boolean isNodeFailed(InetSocketAddress address) {
+            failedCheckAddress = address;
+            return true;
         }
     }
 }


### PR DESCRIPTION
# Summary
Adds a follow-up observability hook for custom failed-node detectors. [[issue](https://github.com/redisson/redisson/issues/7232)]

  This builds on the per-node detector copy fix in #7226. Once every copied `RedisClientConfig` has an independent detector instance, Redisson can assign the Redis node
  address to that detector so custom wrappers can attribute/log the node they are observing.

  Changes:

  - Add default `FailedNodeDetector.setNodeAddress(InetSocketAddress)`.
  - Assign the resolved socket address when available.
  - Fall back to an unresolved socket address from `RedisURI` when the resolved address is not set.
  - Cover both resolved and unresolved address assignment in `FailedNodeDetectorCopyTest`.

  Depends on #7226.

 # Test:

  ```bash
  JAVA_HOME=/Library/Java/JavaVirtualMachines/amazon-corretto-21.jdk/Contents/Home mvn -pl redisson -Punit-test -Dmaven.compiler.testRelease=21
  -Dmaven.compiler.testSource=21 -Dmaven.compiler.testTarget=21 -Dtest=org.redisson.client.FailedNodeDetectorCopyTest test
