### PR TITLE
Add runtime connection pool warm up

### DIFF
--- a/redisson/src/main/java/org/redisson/api/redisnode/RedisClusterNode.java
+++ b/redisson/src/main/java/org/redisson/api/redisnode/RedisClusterNode.java
@@ -30,10 +30,11 @@ import java.util.Set;
 public interface RedisClusterNode extends RedisNode, RedisClusterNodeAsync {
 
     /**
-     * Warms up connection pool for this Redis node to the specified connection amount.
-     * If current connections amount is greater than or equal to specified value, then no new connections are created.
+     * Warms up connection pool for this Redis node until the specified amount of free connections is available.
+     * If current free connections amount is greater than or equal to specified value, then no new connections are
+     * created.
      *
-     * @param connectionAmount - connections amount
+     * @param connectionAmount - free connections amount
      */
     void warmUpConnectionPool(int connectionAmount);
 

--- a/redisson/src/main/java/org/redisson/api/redisnode/RedisClusterNode.java
+++ b/redisson/src/main/java/org/redisson/api/redisnode/RedisClusterNode.java
@@ -30,6 +30,14 @@ import java.util.Set;
 public interface RedisClusterNode extends RedisNode, RedisClusterNodeAsync {
 
     /**
+     * Warms up connection pool for this Redis node to the specified connection amount.
+     * If current connections amount is greater than or equal to specified value, then no new connections are created.
+     *
+     * @param connectionAmount - connections amount
+     */
+    void warmUpConnectionPool(int connectionAmount);
+
+    /**
      * Returns cluster information reported by this Redis node
      *
      * @return cluster information

--- a/redisson/src/main/java/org/redisson/api/redisnode/RedisClusterNode.java
+++ b/redisson/src/main/java/org/redisson/api/redisnode/RedisClusterNode.java
@@ -30,11 +30,11 @@ import java.util.Set;
 public interface RedisClusterNode extends RedisNode, RedisClusterNodeAsync {
 
     /**
-     * Warms up connection pool for this Redis node until the specified amount of free connections is available.
-     * If current free connections amount is greater than or equal to specified value, then no new connections are
-     * created.
+     * Warms up the connection pool for this Redis node until it contains the specified number of connections.
+     * Connections currently in use are included in this number. If the pool already contains at least the specified
+     * number, then no new connections are created.
      *
-     * @param connectionAmount - free connections amount
+     * @param connectionAmount target connection amount
      */
     void warmUpConnectionPool(int connectionAmount);
 

--- a/redisson/src/main/java/org/redisson/api/redisnode/RedisClusterNodeAsync.java
+++ b/redisson/src/main/java/org/redisson/api/redisnode/RedisClusterNodeAsync.java
@@ -31,6 +31,15 @@ import java.util.Set;
 public interface RedisClusterNodeAsync extends RedisNodeAsync {
 
     /**
+     * Warms up connection pool for this Redis node to the specified connection amount.
+     * If current connections amount is greater than or equal to specified value, then no new connections are created.
+     *
+     * @param connectionAmount - connections amount
+     * @return void
+     */
+    RFuture<Void> warmUpConnectionPoolAsync(int connectionAmount);
+
+    /**
      * Returns cluster information reported by this Redis node
      *
      * @return cluster information

--- a/redisson/src/main/java/org/redisson/api/redisnode/RedisClusterNodeAsync.java
+++ b/redisson/src/main/java/org/redisson/api/redisnode/RedisClusterNodeAsync.java
@@ -31,11 +31,12 @@ import java.util.Set;
 public interface RedisClusterNodeAsync extends RedisNodeAsync {
 
     /**
-     * Warms up connection pool for this Redis node to the specified connection amount.
-     * If current connections amount is greater than or equal to specified value, then no new connections are created.
+     * Warms up connection pool for this Redis node until the specified amount of free connections is available.
+     * If current free connections amount is greater than or equal to specified value, then no new connections are
+     * created.
      *
-     * @param connectionAmount - connections amount
-     * @return void
+     * @param connectionAmount - free connections amount
+     * @return future completed once the requested free connections amount is reached
      */
     RFuture<Void> warmUpConnectionPoolAsync(int connectionAmount);
 

--- a/redisson/src/main/java/org/redisson/api/redisnode/RedisClusterNodeAsync.java
+++ b/redisson/src/main/java/org/redisson/api/redisnode/RedisClusterNodeAsync.java
@@ -31,12 +31,12 @@ import java.util.Set;
 public interface RedisClusterNodeAsync extends RedisNodeAsync {
 
     /**
-     * Warms up connection pool for this Redis node until the specified amount of free connections is available.
-     * If current free connections amount is greater than or equal to specified value, then no new connections are
-     * created.
+     * Warms up the connection pool for this Redis node until it contains the specified number of connections.
+     * Connections currently in use are included in this number. If the pool already contains at least the specified
+     * number, then no new connections are created.
      *
-     * @param connectionAmount - free connections amount
-     * @return future completed once the requested free connections amount is reached
+     * @param connectionAmount target connection amount
+     * @return future completed once the target connection amount is reached
      */
     RFuture<Void> warmUpConnectionPoolAsync(int connectionAmount);
 

--- a/redisson/src/main/java/org/redisson/api/redisnode/RedisMaster.java
+++ b/redisson/src/main/java/org/redisson/api/redisnode/RedisMaster.java
@@ -24,10 +24,11 @@ package org.redisson.api.redisnode;
 public interface RedisMaster extends RedisNode, RedisMasterAsync {
 
     /**
-     * Warms up connection pool for this Redis node to the specified connection amount.
-     * If current connections amount is greater than or equal to specified value, then no new connections are created.
+     * Warms up connection pool for this Redis node until the specified amount of free connections is available.
+     * If current free connections amount is greater than or equal to specified value, then no new connections are
+     * created.
      *
-     * @param connectionAmount - connections amount
+     * @param connectionAmount - free connections amount
      */
     void warmUpConnectionPool(int connectionAmount);
 

--- a/redisson/src/main/java/org/redisson/api/redisnode/RedisMaster.java
+++ b/redisson/src/main/java/org/redisson/api/redisnode/RedisMaster.java
@@ -23,4 +23,12 @@ package org.redisson.api.redisnode;
  */
 public interface RedisMaster extends RedisNode, RedisMasterAsync {
 
+    /**
+     * Warms up connection pool for this Redis node to the specified connection amount.
+     * If current connections amount is greater than or equal to specified value, then no new connections are created.
+     *
+     * @param connectionAmount - connections amount
+     */
+    void warmUpConnectionPool(int connectionAmount);
+
 }

--- a/redisson/src/main/java/org/redisson/api/redisnode/RedisMaster.java
+++ b/redisson/src/main/java/org/redisson/api/redisnode/RedisMaster.java
@@ -24,11 +24,11 @@ package org.redisson.api.redisnode;
 public interface RedisMaster extends RedisNode, RedisMasterAsync {
 
     /**
-     * Warms up connection pool for this Redis node until the specified amount of free connections is available.
-     * If current free connections amount is greater than or equal to specified value, then no new connections are
-     * created.
+     * Warms up the connection pool for this Redis node until it contains the specified number of connections.
+     * Connections currently in use are included in this number. If the pool already contains at least the specified
+     * number, then no new connections are created.
      *
-     * @param connectionAmount - free connections amount
+     * @param connectionAmount target connection amount
      */
     void warmUpConnectionPool(int connectionAmount);
 

--- a/redisson/src/main/java/org/redisson/api/redisnode/RedisMasterAsync.java
+++ b/redisson/src/main/java/org/redisson/api/redisnode/RedisMasterAsync.java
@@ -26,11 +26,12 @@ import org.redisson.api.RFuture;
 public interface RedisMasterAsync extends RedisNodeAsync {
 
     /**
-     * Warms up connection pool for this Redis node to the specified connection amount.
-     * If current connections amount is greater than or equal to specified value, then no new connections are created.
+     * Warms up connection pool for this Redis node until the specified amount of free connections is available.
+     * If current free connections amount is greater than or equal to specified value, then no new connections are
+     * created.
      *
-     * @param connectionAmount - connections amount
-     * @return void
+     * @param connectionAmount - free connections amount
+     * @return future completed once the requested free connections amount is reached
      */
     RFuture<Void> warmUpConnectionPoolAsync(int connectionAmount);
 

--- a/redisson/src/main/java/org/redisson/api/redisnode/RedisMasterAsync.java
+++ b/redisson/src/main/java/org/redisson/api/redisnode/RedisMasterAsync.java
@@ -15,6 +15,8 @@
  */
 package org.redisson.api.redisnode;
 
+import org.redisson.api.RFuture;
+
 /**
  * Redis Master node API interface
  *
@@ -22,4 +24,14 @@ package org.redisson.api.redisnode;
  *
  */
 public interface RedisMasterAsync extends RedisNodeAsync {
+
+    /**
+     * Warms up connection pool for this Redis node to the specified connection amount.
+     * If current connections amount is greater than or equal to specified value, then no new connections are created.
+     *
+     * @param connectionAmount - connections amount
+     * @return void
+     */
+    RFuture<Void> warmUpConnectionPoolAsync(int connectionAmount);
+
 }

--- a/redisson/src/main/java/org/redisson/api/redisnode/RedisMasterAsync.java
+++ b/redisson/src/main/java/org/redisson/api/redisnode/RedisMasterAsync.java
@@ -26,12 +26,12 @@ import org.redisson.api.RFuture;
 public interface RedisMasterAsync extends RedisNodeAsync {
 
     /**
-     * Warms up connection pool for this Redis node until the specified amount of free connections is available.
-     * If current free connections amount is greater than or equal to specified value, then no new connections are
-     * created.
+     * Warms up the connection pool for this Redis node until it contains the specified number of connections.
+     * Connections currently in use are included in this number. If the pool already contains at least the specified
+     * number, then no new connections are created.
      *
-     * @param connectionAmount - free connections amount
-     * @return future completed once the requested free connections amount is reached
+     * @param connectionAmount target connection amount
+     * @return future completed once the target connection amount is reached
      */
     RFuture<Void> warmUpConnectionPoolAsync(int connectionAmount);
 

--- a/redisson/src/main/java/org/redisson/api/redisnode/RedisSlave.java
+++ b/redisson/src/main/java/org/redisson/api/redisnode/RedisSlave.java
@@ -24,10 +24,11 @@ package org.redisson.api.redisnode;
 public interface RedisSlave extends RedisNode, RedisSlaveAsync {
 
     /**
-     * Warms up connection pool for this Redis node to the specified connection amount.
-     * If current connections amount is greater than or equal to specified value, then no new connections are created.
+     * Warms up connection pool for this Redis node until the specified amount of free connections is available.
+     * If current free connections amount is greater than or equal to specified value, then no new connections are
+     * created.
      *
-     * @param connectionAmount - connections amount
+     * @param connectionAmount - free connections amount
      */
     void warmUpConnectionPool(int connectionAmount);
 

--- a/redisson/src/main/java/org/redisson/api/redisnode/RedisSlave.java
+++ b/redisson/src/main/java/org/redisson/api/redisnode/RedisSlave.java
@@ -22,4 +22,13 @@ package org.redisson.api.redisnode;
  *
  */
 public interface RedisSlave extends RedisNode, RedisSlaveAsync {
+
+    /**
+     * Warms up connection pool for this Redis node to the specified connection amount.
+     * If current connections amount is greater than or equal to specified value, then no new connections are created.
+     *
+     * @param connectionAmount - connections amount
+     */
+    void warmUpConnectionPool(int connectionAmount);
+
 }

--- a/redisson/src/main/java/org/redisson/api/redisnode/RedisSlave.java
+++ b/redisson/src/main/java/org/redisson/api/redisnode/RedisSlave.java
@@ -24,11 +24,11 @@ package org.redisson.api.redisnode;
 public interface RedisSlave extends RedisNode, RedisSlaveAsync {
 
     /**
-     * Warms up connection pool for this Redis node until the specified amount of free connections is available.
-     * If current free connections amount is greater than or equal to specified value, then no new connections are
-     * created.
+     * Warms up the connection pool for this Redis node until it contains the specified number of connections.
+     * Connections currently in use are included in this number. If the pool already contains at least the specified
+     * number, then no new connections are created.
      *
-     * @param connectionAmount - free connections amount
+     * @param connectionAmount target connection amount
      */
     void warmUpConnectionPool(int connectionAmount);
 

--- a/redisson/src/main/java/org/redisson/api/redisnode/RedisSlaveAsync.java
+++ b/redisson/src/main/java/org/redisson/api/redisnode/RedisSlaveAsync.java
@@ -15,6 +15,8 @@
  */
 package org.redisson.api.redisnode;
 
+import org.redisson.api.RFuture;
+
 /**
  * Redis Slave node API interface
  *
@@ -22,4 +24,14 @@ package org.redisson.api.redisnode;
  *
  */
 public interface RedisSlaveAsync extends RedisNodeAsync {
+
+    /**
+     * Warms up connection pool for this Redis node to the specified connection amount.
+     * If current connections amount is greater than or equal to specified value, then no new connections are created.
+     *
+     * @param connectionAmount - connections amount
+     * @return void
+     */
+    RFuture<Void> warmUpConnectionPoolAsync(int connectionAmount);
+
 }

--- a/redisson/src/main/java/org/redisson/api/redisnode/RedisSlaveAsync.java
+++ b/redisson/src/main/java/org/redisson/api/redisnode/RedisSlaveAsync.java
@@ -26,11 +26,12 @@ import org.redisson.api.RFuture;
 public interface RedisSlaveAsync extends RedisNodeAsync {
 
     /**
-     * Warms up connection pool for this Redis node to the specified connection amount.
-     * If current connections amount is greater than or equal to specified value, then no new connections are created.
+     * Warms up connection pool for this Redis node until the specified amount of free connections is available.
+     * If current free connections amount is greater than or equal to specified value, then no new connections are
+     * created.
      *
-     * @param connectionAmount - connections amount
-     * @return void
+     * @param connectionAmount - free connections amount
+     * @return future completed once the requested free connections amount is reached
      */
     RFuture<Void> warmUpConnectionPoolAsync(int connectionAmount);
 

--- a/redisson/src/main/java/org/redisson/api/redisnode/RedisSlaveAsync.java
+++ b/redisson/src/main/java/org/redisson/api/redisnode/RedisSlaveAsync.java
@@ -26,12 +26,12 @@ import org.redisson.api.RFuture;
 public interface RedisSlaveAsync extends RedisNodeAsync {
 
     /**
-     * Warms up connection pool for this Redis node until the specified amount of free connections is available.
-     * If current free connections amount is greater than or equal to specified value, then no new connections are
-     * created.
+     * Warms up the connection pool for this Redis node until it contains the specified number of connections.
+     * Connections currently in use are included in this number. If the pool already contains at least the specified
+     * number, then no new connections are created.
      *
-     * @param connectionAmount - free connections amount
-     * @return future completed once the requested free connections amount is reached
+     * @param connectionAmount target connection amount
+     * @return future completed once the target connection amount is reached
      */
     RFuture<Void> warmUpConnectionPoolAsync(int connectionAmount);
 

--- a/redisson/src/main/java/org/redisson/connection/ClientConnectionsEntry.java
+++ b/redisson/src/main/java/org/redisson/connection/ClientConnectionsEntry.java
@@ -86,6 +86,10 @@ public class ClientConnectionsEntry {
         return connectionsHolder.initConnections(minimumIdleSize);
     }
 
+    public CompletableFuture<Void> warmUpConnections(int connectionAmount) {
+        return connectionsHolder.warmUp(connectionAmount);
+    }
+
     public CompletableFuture<Void> initPubSubConnections(int minimumIdleSize) {
         return pubSubConnectionsHolder.initConnections(minimumIdleSize);
     }
@@ -271,4 +275,3 @@ public class ClientConnectionsEntry {
                 '}';
     }
 }
-

--- a/redisson/src/main/java/org/redisson/connection/ClientConnectionsEntry.java
+++ b/redisson/src/main/java/org/redisson/connection/ClientConnectionsEntry.java
@@ -19,6 +19,7 @@ import io.netty.channel.ChannelFuture;
 import org.redisson.api.NodeType;
 import org.redisson.client.RedisClient;
 import org.redisson.client.RedisConnection;
+import org.redisson.client.RedisConnectionException;
 import org.redisson.client.RedisPubSubConnection;
 import org.redisson.client.protocol.CommandData;
 import org.redisson.config.MasterSlaveServersConfig;
@@ -108,6 +109,7 @@ public class ClientConnectionsEntry {
 
     public CompletableFuture<Void> shutdownAsync() {
         idleConnectionWatcher.remove(this);
+        connectionsHolder.failWarmUp(new RedisConnectionException("Redis node has been shut down: " + client));
         return client.shutdownAsync().toCompletableFuture();
     }
 
@@ -123,6 +125,9 @@ public class ClientConnectionsEntry {
         this.freezeReason = freezeReason;
         if (freezeReason != null) {
             this.initialized = false;
+            connectionsHolder.failWarmUp(new RedisConnectionException("Redis node is frozen: " + client));
+        } else {
+            connectionsHolder.enableWarmUp();
         }
     }
 
@@ -154,6 +159,7 @@ public class ClientConnectionsEntry {
     }
 
     protected final void nodeDown(ConnectionsHolder<RedisConnection> connectionsHolder) {
+        connectionsHolder.failWarmUp(new RedisConnectionException("Redis node is down: " + client));
         connectionsHolder.getFreeConnectionsCounter().removeListeners();
 
         for (RedisConnection connection : connectionsHolder.getAllConnections()) {

--- a/redisson/src/main/java/org/redisson/connection/ConnectionsHolder.java
+++ b/redisson/src/main/java/org/redisson/connection/ConnectionsHolder.java
@@ -44,6 +44,7 @@ public class ConnectionsHolder<T extends RedisConnection> {
     private final Queue<T> allConnections = new ConcurrentLinkedQueue<>();
     private final Deque<T> freeConnections = new ConcurrentLinkedDeque<>();
     private final AsyncSemaphore freeConnectionsCounter;
+    private final int poolMaxSize;
 
     private final RedisClient client;
 
@@ -57,6 +58,7 @@ public class ConnectionsHolder<T extends RedisConnection> {
                              Function<RedisClient, CompletionStage<T>> connectionCallback,
                              ServiceManager serviceManager, boolean changeUsage) {
         this.freeConnectionsCounter = new AsyncSemaphore(poolMaxSize, serviceManager.getGroup());
+        this.poolMaxSize = poolMaxSize;
         this.client = client;
         this.connectionCallback = connectionCallback;
         this.serviceManager = serviceManager;
@@ -150,6 +152,51 @@ public class ConnectionsHolder<T extends RedisConnection> {
         }
         return f.thenAccept(r -> {
             log.info("{} connections initialized for {}", minimumIdleSize, client.getAddr());
+        });
+    }
+
+    public CompletableFuture<Void> warmUp(int connectionAmount) {
+        if (connectionAmount < 0) {
+            return failedFuture(new IllegalArgumentException("connectionAmount can't be negative"));
+        }
+        if (connectionAmount > poolMaxSize) {
+            return failedFuture(new IllegalArgumentException(
+                    "connectionAmount can't be greater than connection pool size"));
+        }
+        return warmUpConnection(connectionAmount);
+    }
+
+    private CompletableFuture<Void> failedFuture(Exception e) {
+        CompletableFuture<Void> f = new CompletableFuture<>();
+        f.completeExceptionally(e);
+        return f;
+    }
+
+    private CompletableFuture<Void> warmUpConnection(int connectionAmount) {
+        if (allConnections.size() >= connectionAmount) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        CompletableFuture<Void> f = acquireConnection();
+        return f.thenCompose(r -> {
+            if (allConnections.size() >= connectionAmount) {
+                releaseConnection();
+                return CompletableFuture.completedFuture(null);
+            }
+
+            CompletableFuture<T> promise = new CompletableFuture<>();
+            createConnection(promise);
+            return promise.handle((conn, e) -> {
+                if (e == null) {
+                    if (changeUsage) {
+                        conn.decUsage();
+                    }
+                    addConnection(conn);
+                    releaseConnection();
+                    return null;
+                }
+                throw new CompletionException(e);
+            }).thenCompose(ignored -> warmUpConnection(connectionAmount));
         });
     }
 
@@ -274,4 +321,3 @@ public class ConnectionsHolder<T extends RedisConnection> {
         return serviceManager;
     }
 }
-

--- a/redisson/src/main/java/org/redisson/connection/ConnectionsHolder.java
+++ b/redisson/src/main/java/org/redisson/connection/ConnectionsHolder.java
@@ -43,6 +43,7 @@ public class ConnectionsHolder<T extends RedisConnection> {
 
     private final Queue<T> allConnections = new ConcurrentLinkedQueue<>();
     private final Deque<T> freeConnections = new ConcurrentLinkedDeque<>();
+    private final Queue<WarmUpRequest> warmUpListeners = new ConcurrentLinkedQueue<>();
     private final AsyncSemaphore freeConnectionsCounter;
     private final int poolMaxSize;
 
@@ -53,6 +54,16 @@ public class ConnectionsHolder<T extends RedisConnection> {
     private final ServiceManager serviceManager;
 
     private final boolean changeUsage;
+
+    private static final class WarmUpRequest {
+        private final int connectionAmount;
+        private final CompletableFuture<Void> promise;
+
+        private WarmUpRequest(int connectionAmount, CompletableFuture<Void> promise) {
+            this.connectionAmount = connectionAmount;
+            this.promise = promise;
+        }
+    }
 
     public ConnectionsHolder(RedisClient client, int poolMaxSize,
                              Function<RedisClient, CompletionStage<T>> connectionCallback,
@@ -173,31 +184,85 @@ public class ConnectionsHolder<T extends RedisConnection> {
     }
 
     private CompletableFuture<Void> warmUpConnection(int connectionAmount) {
-        if (allConnections.size() >= connectionAmount) {
+        if (hasFreeConnections(connectionAmount)) {
             return CompletableFuture.completedFuture(null);
         }
 
+        CompletableFuture<Void> result = new CompletableFuture<>();
+        warmUpConnection(connectionAmount, result);
+        return result;
+    }
+
+    private void warmUpConnection(int connectionAmount, CompletableFuture<Void> result) {
+        if (result.isDone()) {
+            return;
+        }
+        if (hasFreeConnections(connectionAmount)) {
+            result.complete(null);
+            return;
+        }
+        if (allConnections.size() >= poolMaxSize) {
+            waitForFreeConnections(connectionAmount, result);
+            return;
+        }
+
         CompletableFuture<Void> f = acquireConnection();
-        return f.thenCompose(r -> {
-            if (allConnections.size() >= connectionAmount) {
+        f.thenAccept(r -> {
+            if (result.isDone()) {
                 releaseConnection();
-                return CompletableFuture.completedFuture(null);
+                return;
+            }
+            if (hasFreeConnections(connectionAmount)) {
+                releaseConnection();
+                result.complete(null);
+                return;
+            }
+            if (allConnections.size() >= poolMaxSize) {
+                releaseConnection();
+                waitForFreeConnections(connectionAmount, result);
+                return;
             }
 
             CompletableFuture<T> promise = new CompletableFuture<>();
             createConnection(promise);
-            return promise.handle((conn, e) -> {
+            promise.whenComplete((conn, e) -> {
                 if (e == null) {
                     if (changeUsage) {
                         conn.decUsage();
                     }
                     addConnection(conn);
                     releaseConnection();
-                    return null;
+                    completeWarmUpListeners();
+                    warmUpConnection(connectionAmount, result);
+                    return;
                 }
-                throw new CompletionException(e);
-            }).thenCompose(ignored -> warmUpConnection(connectionAmount));
+                result.completeExceptionally(e);
+            });
         });
+    }
+
+    private boolean hasFreeConnections(int connectionAmount) {
+        return freeConnections.size() >= connectionAmount;
+    }
+
+    private void waitForFreeConnections(int connectionAmount, CompletableFuture<Void> result) {
+        WarmUpRequest request = new WarmUpRequest(connectionAmount, result);
+        warmUpListeners.add(request);
+        result.whenComplete((r, e) -> warmUpListeners.remove(request));
+        completeWarmUpListeners();
+    }
+
+    private void completeWarmUpListeners() {
+        for (WarmUpRequest request : warmUpListeners) {
+            if (request.promise.isDone()) {
+                warmUpListeners.remove(request);
+                continue;
+            }
+            if (hasFreeConnections(request.connectionAmount)
+                    && warmUpListeners.remove(request)) {
+                request.promise.complete(null);
+            }
+        }
     }
 
     private CompletableFuture<Void> createConnection(int minimumIdleSize, int index) {
@@ -214,6 +279,7 @@ public class ConnectionsHolder<T extends RedisConnection> {
                     // release only on success; the failure path already releases in createConnection(promise),
                     // so an unconditional release here double-releases per failed init and lifts the counter above pool max
                     releaseConnection();
+                    completeWarmUpListeners();
                 }
 
                 if (e != null) {
@@ -265,6 +331,7 @@ public class ConnectionsHolder<T extends RedisConnection> {
         if (!promise.complete(conn)) {
             releaseConnection(conn);
             releaseConnection();
+            completeWarmUpListeners();
         }
     }
 
@@ -315,6 +382,7 @@ public class ConnectionsHolder<T extends RedisConnection> {
             releaseConnection(connection);
         }
         releaseConnection();
+        completeWarmUpListeners();
     }
 
     public ServiceManager getServiceManager() {

--- a/redisson/src/main/java/org/redisson/connection/ConnectionsHolder.java
+++ b/redisson/src/main/java/org/redisson/connection/ConnectionsHolder.java
@@ -43,7 +43,8 @@ public class ConnectionsHolder<T extends RedisConnection> {
 
     private final Queue<T> allConnections = new ConcurrentLinkedQueue<>();
     private final Deque<T> freeConnections = new ConcurrentLinkedDeque<>();
-    private final Queue<WarmUpRequest> warmUpListeners = new ConcurrentLinkedQueue<>();
+    private final Object warmUpLock = new Object();
+    private CompletableFuture<Void> lastWarmUp = CompletableFuture.completedFuture(null);
     private final AsyncSemaphore freeConnectionsCounter;
     private final int poolMaxSize;
 
@@ -54,16 +55,6 @@ public class ConnectionsHolder<T extends RedisConnection> {
     private final ServiceManager serviceManager;
 
     private final boolean changeUsage;
-
-    private static final class WarmUpRequest {
-        private final int connectionAmount;
-        private final CompletableFuture<Void> promise;
-
-        private WarmUpRequest(int connectionAmount, CompletableFuture<Void> promise) {
-            this.connectionAmount = connectionAmount;
-            this.promise = promise;
-        }
-    }
 
     public ConnectionsHolder(RedisClient client, int poolMaxSize,
                              Function<RedisClient, CompletionStage<T>> connectionCallback,
@@ -174,7 +165,13 @@ public class ConnectionsHolder<T extends RedisConnection> {
             return failedFuture(new IllegalArgumentException(
                     "connectionAmount can't be greater than connection pool size"));
         }
-        return warmUpConnection(connectionAmount);
+        CompletableFuture<Void> warmUpFuture;
+        synchronized (warmUpLock) {
+            lastWarmUp = lastWarmUp.handle((r, e) -> null)
+                                  .thenCompose(r -> warmUpConnection(connectionAmount));
+            warmUpFuture = lastWarmUp;
+        }
+        return warmUpFuture.thenApply(r -> null);
     }
 
     private CompletableFuture<Void> failedFuture(Exception e) {
@@ -184,85 +181,27 @@ public class ConnectionsHolder<T extends RedisConnection> {
     }
 
     private CompletableFuture<Void> warmUpConnection(int connectionAmount) {
-        if (hasFreeConnections(connectionAmount)) {
+        if (allConnections.size() >= connectionAmount) {
             return CompletableFuture.completedFuture(null);
         }
 
-        CompletableFuture<Void> result = new CompletableFuture<>();
-        warmUpConnection(connectionAmount, result);
-        return result;
+        return createWarmUpConnection()
+                .thenCompose(r -> warmUpConnection(connectionAmount));
     }
 
-    private void warmUpConnection(int connectionAmount, CompletableFuture<Void> result) {
-        if (result.isDone()) {
-            return;
-        }
-        if (hasFreeConnections(connectionAmount)) {
-            result.complete(null);
-            return;
-        }
-        if (allConnections.size() >= poolMaxSize) {
-            waitForFreeConnections(connectionAmount, result);
-            return;
-        }
-
+    private CompletableFuture<Void> createWarmUpConnection() {
         CompletableFuture<Void> f = acquireConnection();
-        f.thenAccept(r -> {
-            if (result.isDone()) {
-                releaseConnection();
-                return;
-            }
-            if (hasFreeConnections(connectionAmount)) {
-                releaseConnection();
-                result.complete(null);
-                return;
-            }
-            if (allConnections.size() >= poolMaxSize) {
-                releaseConnection();
-                waitForFreeConnections(connectionAmount, result);
-                return;
-            }
-
+        return f.thenCompose(r -> {
             CompletableFuture<T> promise = new CompletableFuture<>();
             createConnection(promise);
-            promise.whenComplete((conn, e) -> {
-                if (e == null) {
-                    if (changeUsage) {
-                        conn.decUsage();
-                    }
-                    addConnection(conn);
-                    releaseConnection();
-                    completeWarmUpListeners();
-                    warmUpConnection(connectionAmount, result);
-                    return;
+            return promise.thenAccept(conn -> {
+                if (changeUsage) {
+                    conn.decUsage();
                 }
-                result.completeExceptionally(e);
+                addConnection(conn);
+                releaseConnection();
             });
         });
-    }
-
-    private boolean hasFreeConnections(int connectionAmount) {
-        return freeConnections.size() >= connectionAmount;
-    }
-
-    private void waitForFreeConnections(int connectionAmount, CompletableFuture<Void> result) {
-        WarmUpRequest request = new WarmUpRequest(connectionAmount, result);
-        warmUpListeners.add(request);
-        result.whenComplete((r, e) -> warmUpListeners.remove(request));
-        completeWarmUpListeners();
-    }
-
-    private void completeWarmUpListeners() {
-        for (WarmUpRequest request : warmUpListeners) {
-            if (request.promise.isDone()) {
-                warmUpListeners.remove(request);
-                continue;
-            }
-            if (hasFreeConnections(request.connectionAmount)
-                    && warmUpListeners.remove(request)) {
-                request.promise.complete(null);
-            }
-        }
     }
 
     private CompletableFuture<Void> createConnection(int minimumIdleSize, int index) {
@@ -279,7 +218,6 @@ public class ConnectionsHolder<T extends RedisConnection> {
                     // release only on success; the failure path already releases in createConnection(promise),
                     // so an unconditional release here double-releases per failed init and lifts the counter above pool max
                     releaseConnection();
-                    completeWarmUpListeners();
                 }
 
                 if (e != null) {
@@ -331,7 +269,6 @@ public class ConnectionsHolder<T extends RedisConnection> {
         if (!promise.complete(conn)) {
             releaseConnection(conn);
             releaseConnection();
-            completeWarmUpListeners();
         }
     }
 
@@ -382,7 +319,6 @@ public class ConnectionsHolder<T extends RedisConnection> {
             releaseConnection(connection);
         }
         releaseConnection();
-        completeWarmUpListeners();
     }
 
     public ServiceManager getServiceManager() {

--- a/redisson/src/main/java/org/redisson/connection/ConnectionsHolder.java
+++ b/redisson/src/main/java/org/redisson/connection/ConnectionsHolder.java
@@ -24,7 +24,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Deque;
+import java.util.HashSet;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
@@ -44,7 +46,11 @@ public class ConnectionsHolder<T extends RedisConnection> {
     private final Queue<T> allConnections = new ConcurrentLinkedQueue<>();
     private final Deque<T> freeConnections = new ConcurrentLinkedDeque<>();
     private final Object warmUpLock = new Object();
+    private final Set<CompletableFuture<Void>> warmUpFutures = new HashSet<>();
+    private final Set<CompletableFuture<Void>> warmUpPermits = new HashSet<>();
     private CompletableFuture<Void> lastWarmUp = CompletableFuture.completedFuture(null);
+    private long warmUpGeneration;
+    private boolean warmUpEnabled = true;
     private final AsyncSemaphore freeConnectionsCounter;
     private final int poolMaxSize;
 
@@ -167,10 +173,16 @@ public class ConnectionsHolder<T extends RedisConnection> {
         }
         CompletableFuture<Void> warmUpFuture;
         synchronized (warmUpLock) {
+            if (!warmUpEnabled) {
+                return failedWarmUpFuture();
+            }
+            long generation = warmUpGeneration;
             lastWarmUp = lastWarmUp.handle((r, e) -> null)
-                                  .thenCompose(r -> warmUpConnection(connectionAmount));
+                                  .thenCompose(r -> warmUpConnection(connectionAmount, generation));
             warmUpFuture = lastWarmUp;
+            warmUpFutures.add(warmUpFuture);
         }
+        warmUpFuture.whenComplete((r, e) -> removeWarmUpFuture(warmUpFuture));
         return warmUpFuture.thenApply(r -> null);
     }
 
@@ -180,28 +192,109 @@ public class ConnectionsHolder<T extends RedisConnection> {
         return f;
     }
 
-    private CompletableFuture<Void> warmUpConnection(int connectionAmount) {
-        if (allConnections.size() >= connectionAmount) {
-            return CompletableFuture.completedFuture(null);
-        }
-
-        return createWarmUpConnection()
-                .thenCompose(r -> warmUpConnection(connectionAmount));
+    private CompletableFuture<Void> failedWarmUpFuture() {
+        return failedFuture(new RedisConnectionException("Redis node isn't available: " + client));
     }
 
-    private CompletableFuture<Void> createWarmUpConnection() {
-        CompletableFuture<Void> f = acquireConnection();
+    private void removeWarmUpFuture(CompletableFuture<Void> future) {
+        synchronized (warmUpLock) {
+            warmUpFutures.remove(future);
+        }
+    }
+
+    private CompletableFuture<Void> warmUpConnection(int connectionAmount, long generation) {
+        synchronized (warmUpLock) {
+            if (!isWarmUpValid(generation)) {
+                return failedWarmUpFuture();
+            }
+            if (allConnections.size() >= connectionAmount) {
+                return CompletableFuture.completedFuture(null);
+            }
+        }
+
+        return createWarmUpConnection(connectionAmount, generation)
+                .thenCompose(r -> warmUpConnection(connectionAmount, generation));
+    }
+
+    private CompletableFuture<Void> createWarmUpConnection(int connectionAmount, long generation) {
+        CompletableFuture<Void> f;
+        synchronized (warmUpLock) {
+            if (!isWarmUpValid(generation)) {
+                return failedWarmUpFuture();
+            }
+            f = acquireConnection();
+            warmUpPermits.add(f);
+        }
+        f.whenComplete((r, e) -> removeWarmUpPermit(f));
         return f.thenCompose(r -> {
+            synchronized (warmUpLock) {
+                if (!isWarmUpValid(generation)) {
+                    releaseConnection();
+                    return failedWarmUpFuture();
+                }
+                if (allConnections.size() >= connectionAmount) {
+                    releaseConnection();
+                    return CompletableFuture.completedFuture(null);
+                }
+            }
+
             CompletableFuture<T> promise = new CompletableFuture<>();
             createConnection(promise);
-            return promise.thenAccept(conn -> {
-                if (changeUsage) {
-                    conn.decUsage();
+            return promise.handle((conn, e) -> {
+                if (e != null) {
+                    throw new CompletionException(e);
                 }
-                addConnection(conn);
-                releaseConnection();
+
+                synchronized (warmUpLock) {
+                    if (!isWarmUpValid(generation)) {
+                        allConnections.remove(conn);
+                        conn.closeAsync();
+                        releaseConnection();
+                        throw new CompletionException(new RedisConnectionException(
+                                "Redis node isn't available: " + client));
+                    }
+                    if (changeUsage) {
+                        conn.decUsage();
+                    }
+                    addConnection(conn);
+                    releaseConnection();
+                }
+                return null;
             });
         });
+    }
+
+    private void removeWarmUpPermit(CompletableFuture<Void> future) {
+        synchronized (warmUpLock) {
+            warmUpPermits.remove(future);
+        }
+    }
+
+    private boolean isWarmUpValid(long generation) {
+        return warmUpEnabled && warmUpGeneration == generation;
+    }
+
+    void failWarmUp(Throwable cause) {
+        Set<CompletableFuture<Void>> futures;
+        Set<CompletableFuture<Void>> permits;
+        synchronized (warmUpLock) {
+            warmUpEnabled = false;
+            warmUpGeneration++;
+            futures = new HashSet<>(warmUpFutures);
+            permits = new HashSet<>(warmUpPermits);
+            warmUpFutures.clear();
+            warmUpPermits.clear();
+            lastWarmUp = CompletableFuture.completedFuture(null);
+        }
+
+        futures.forEach(f -> f.completeExceptionally(cause));
+        permits.forEach(f -> f.cancel(false));
+    }
+
+    void enableWarmUp() {
+        synchronized (warmUpLock) {
+            warmUpEnabled = true;
+        }
     }
 
     private CompletableFuture<Void> createConnection(int minimumIdleSize, int index) {

--- a/redisson/src/main/java/org/redisson/redisnode/RedisNode.java
+++ b/redisson/src/main/java/org/redisson/redisnode/RedisNode.java
@@ -19,6 +19,7 @@ import org.redisson.api.NodeType;
 import org.redisson.api.RFuture;
 import org.redisson.api.redisnode.*;
 import org.redisson.client.RedisClient;
+import org.redisson.client.RedisConnectionException;
 import org.redisson.client.RedisTimeoutException;
 import org.redisson.client.codec.LongCodec;
 import org.redisson.client.codec.StringCodec;
@@ -26,6 +27,8 @@ import org.redisson.client.protocol.RedisCommands;
 import org.redisson.client.protocol.Time;
 import org.redisson.cluster.ClusterSlotRange;
 import org.redisson.command.CommandAsyncExecutor;
+import org.redisson.connection.ClientConnectionsEntry;
+import org.redisson.connection.MasterSlaveEntry;
 import org.redisson.misc.CompletableFutureWrapper;
 import org.redisson.misc.RedisURI;
 
@@ -91,6 +94,31 @@ public class RedisNode implements RedisClusterMaster, RedisClusterSlave, RedisMa
     @Override
     public boolean ping(long timeout, TimeUnit timeUnit) {
         return commandExecutor.get(pingAsync(timeout, timeUnit));
+    }
+
+    @Override
+    public RFuture<Void> warmUpConnectionPoolAsync(int connectionAmount) {
+        ClientConnectionsEntry entry = getEntry();
+        if (entry == null) {
+            RedisConnectionException e = new RedisConnectionException("Redis node entry hasn't been found: " + client);
+            return new CompletableFutureWrapper<>(e);
+        }
+        return new CompletableFutureWrapper<>(entry.warmUpConnections(connectionAmount));
+    }
+
+    @Override
+    public void warmUpConnectionPool(int connectionAmount) {
+        commandExecutor.get(warmUpConnectionPoolAsync(connectionAmount));
+    }
+
+    private ClientConnectionsEntry getEntry() {
+        for (MasterSlaveEntry entry : commandExecutor.getConnectionManager().getEntrySet()) {
+            ClientConnectionsEntry clientEntry = entry.getEntry(client);
+            if (clientEntry != null) {
+                return clientEntry;
+            }
+        }
+        return null;
     }
 
     @Override

--- a/redisson/src/test/java/org/redisson/connection/ConnectionsHolderTest.java
+++ b/redisson/src/test/java/org/redisson/connection/ConnectionsHolderTest.java
@@ -1,5 +1,6 @@
 package org.redisson.connection;
 
+import mockit.Expectations;
 import mockit.Mocked;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -26,6 +27,14 @@ public class ConnectionsHolderTest {
         msConfig.setMasterAddress("redis://127.0.0.1:6379");
         msConfig.setReadMode(ReadMode.MASTER);
         return new MasterSlaveConnectionManager(msConfig, config);
+    }
+
+    private Function<RedisClient, CompletionStage<RedisConnection>> succeedingCallback(
+            AtomicInteger createdConnections, RedisConnection... connections) {
+        return r -> {
+            int index = createdConnections.getAndIncrement();
+            return CompletableFuture.completedFuture(connections[index]);
+        };
     }
 
     @Test
@@ -55,12 +64,15 @@ public class ConnectionsHolderTest {
     }
 
     @Test
-    void testSuccessfulInitReleasesEachPermitExactlyOnce(@Mocked RedisClient client, @Mocked RedisConnection conn) {
+    void testSuccessfulInitReleasesEachPermitExactlyOnce(@Mocked RedisClient client,
+                                                         @Mocked RedisConnection conn1,
+                                                         @Mocked RedisConnection conn2) {
         MasterSlaveConnectionManager manager = buildManager();
         try {
             int poolMaxSize = 2;
+            AtomicInteger createdConnections = new AtomicInteger();
             Function<RedisClient, CompletionStage<RedisConnection>> succeedingCallback =
-                    r -> CompletableFuture.completedFuture(conn);
+                    succeedingCallback(createdConnections, conn1, conn2);
             ConnectionsHolder<RedisConnection> holder =
                     new ConnectionsHolder<>(client, poolMaxSize, succeedingCallback, manager.getServiceManager(), false);
             AsyncSemaphore counter = holder.getFreeConnectionsCounter();
@@ -79,16 +91,16 @@ public class ConnectionsHolderTest {
     }
 
     @Test
-    void testWarmUpCreatesConnectionsUpToDefinedAmount(@Mocked RedisClient client, @Mocked RedisConnection conn) {
+    void testWarmUpCreatesFreeConnectionsUpToDefinedAmount(@Mocked RedisConnection conn1,
+                                                           @Mocked RedisConnection conn2,
+                                                           @Mocked RedisConnection conn3) {
         MasterSlaveConnectionManager manager = buildManager();
         try {
             AtomicInteger createdConnections = new AtomicInteger();
-            Function<RedisClient, CompletionStage<RedisConnection>> succeedingCallback = r -> {
-                createdConnections.incrementAndGet();
-                return CompletableFuture.completedFuture(conn);
-            };
+            Function<RedisClient, CompletionStage<RedisConnection>> succeedingCallback =
+                    succeedingCallback(createdConnections, conn1, conn2, conn3);
             ConnectionsHolder<RedisConnection> holder =
-                    new ConnectionsHolder<>(client, 4, succeedingCallback, manager.getServiceManager(), false);
+                    new ConnectionsHolder<>(null, 4, succeedingCallback, manager.getServiceManager(), false);
 
             CompletableFuture<Void> result = holder.warmUp(3);
             Assertions.assertThat(result).isCompleted();
@@ -104,14 +116,14 @@ public class ConnectionsHolderTest {
 
     @Test
     void testWarmUpDoesNotCreateConnectionsIfAmountAlreadyReached(@Mocked RedisClient client,
-                                                                  @Mocked RedisConnection conn) {
+                                                                  @Mocked RedisConnection conn1,
+                                                                  @Mocked RedisConnection conn2,
+                                                                  @Mocked RedisConnection conn3) {
         MasterSlaveConnectionManager manager = buildManager();
         try {
             AtomicInteger createdConnections = new AtomicInteger();
-            Function<RedisClient, CompletionStage<RedisConnection>> succeedingCallback = r -> {
-                createdConnections.incrementAndGet();
-                return CompletableFuture.completedFuture(conn);
-            };
+            Function<RedisClient, CompletionStage<RedisConnection>> succeedingCallback =
+                    succeedingCallback(createdConnections, conn1, conn2, conn3);
             ConnectionsHolder<RedisConnection> holder =
                     new ConnectionsHolder<>(client, 4, succeedingCallback, manager.getServiceManager(), false);
 
@@ -122,6 +134,106 @@ public class ConnectionsHolderTest {
             Assertions.assertThat(holder.getAllConnections()).hasSize(3);
             Assertions.assertThat(holder.getFreeConnections()).hasSize(3);
             Assertions.assertThat(holder.getFreeConnectionsCounter().getCounter()).isEqualTo(4);
+        } finally {
+            manager.shutdown(0, 0, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void testWarmUpCreatesConnectionsUntilFreeAmountIsReached(@Mocked RedisConnection conn1,
+                                                              @Mocked RedisConnection conn2,
+                                                              @Mocked RedisConnection conn3,
+                                                              @Mocked RedisConnection conn4) {
+        MasterSlaveConnectionManager manager = buildManager();
+        try {
+            new Expectations() {{
+                conn1.isActive(); result = true; minTimes = 0;
+                conn2.isActive(); result = true; minTimes = 0;
+                conn3.isActive(); result = true; minTimes = 0;
+                conn4.isActive(); result = true; minTimes = 0;
+            }};
+
+            AtomicInteger createdConnections = new AtomicInteger();
+            Function<RedisClient, CompletionStage<RedisConnection>> succeedingCallback =
+                    succeedingCallback(createdConnections, conn1, conn2, conn3, conn4);
+            ConnectionsHolder<RedisConnection> holder =
+                    new ConnectionsHolder<>(null, 4, succeedingCallback, manager.getServiceManager(), false);
+
+            Assertions.assertThat(holder.warmUp(3)).isCompleted();
+            RedisConnection connection = holder.acquireConnection(null).join();
+
+            CompletableFuture<Void> result = holder.warmUp(3);
+
+            Assertions.assertThat(result).isCompleted();
+            Assertions.assertThat(connection).isSameAs(conn1);
+            Assertions.assertThat(createdConnections).hasValue(4);
+            Assertions.assertThat(holder.getAllConnections()).hasSize(4);
+            Assertions.assertThat(holder.getFreeConnections()).hasSize(3);
+            Assertions.assertThat(holder.getFreeConnectionsCounter().getCounter()).isEqualTo(3);
+        } finally {
+            manager.shutdown(0, 0, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void testWarmUpCompletesAfterBorrowedConnectionReturnsWhenPoolIsFull(@Mocked RedisConnection conn1,
+                                                                         @Mocked RedisConnection conn2,
+                                                                         @Mocked RedisConnection conn3,
+                                                                         @Mocked ClientConnectionsEntry entry) {
+        MasterSlaveConnectionManager manager = buildManager();
+        try {
+            new Expectations() {{
+                conn1.isActive(); result = true; minTimes = 0;
+                conn2.isActive(); result = true; minTimes = 0;
+                conn3.isActive(); result = true; minTimes = 0;
+                entry.isFreezed(); result = false; minTimes = 0;
+            }};
+
+            AtomicInteger createdConnections = new AtomicInteger();
+            Function<RedisClient, CompletionStage<RedisConnection>> succeedingCallback =
+                    succeedingCallback(createdConnections, conn1, conn2, conn3);
+            ConnectionsHolder<RedisConnection> holder =
+                    new ConnectionsHolder<>(null, 3, succeedingCallback, manager.getServiceManager(), false);
+
+            Assertions.assertThat(holder.warmUp(3)).isCompleted();
+            RedisConnection connection = holder.acquireConnection(null).join();
+
+            CompletableFuture<Void> result = holder.warmUp(3);
+            Assertions.assertThat(result).isNotDone();
+
+            holder.releaseConnection(entry, connection);
+
+            Assertions.assertThat(result).isCompleted();
+            Assertions.assertThat(createdConnections).hasValue(3);
+            Assertions.assertThat(holder.getAllConnections()).hasSize(3);
+            Assertions.assertThat(holder.getFreeConnections()).hasSize(3);
+            Assertions.assertThat(holder.getFreeConnectionsCounter().getCounter()).isEqualTo(3);
+        } finally {
+            manager.shutdown(0, 0, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void testWarmUpFailedConnectionReleasesPermitExactlyOnce() {
+        MasterSlaveConnectionManager manager = buildManager();
+        try {
+            int poolMaxSize = 2;
+            Function<RedisClient, CompletionStage<RedisConnection>> failingCallback = r -> {
+                CompletableFuture<RedisConnection> f = new CompletableFuture<>();
+                f.completeExceptionally(new RuntimeException("connect failed"));
+                return f;
+            };
+            ConnectionsHolder<RedisConnection> holder =
+                    new ConnectionsHolder<>(null, poolMaxSize, failingCallback, manager.getServiceManager(), false);
+            AsyncSemaphore counter = holder.getFreeConnectionsCounter();
+            Assertions.assertThat(counter.getCounter()).isEqualTo(poolMaxSize);
+
+            CompletableFuture<Void> result = holder.warmUp(poolMaxSize);
+            Assertions.assertThat(result).isCompletedExceptionally();
+
+            Assertions.assertThat(counter.getCounter()).isEqualTo(poolMaxSize);
+            Assertions.assertThat(holder.getAllConnections()).isEmpty();
+            Assertions.assertThat(holder.getFreeConnections()).isEmpty();
         } finally {
             manager.shutdown(0, 0, TimeUnit.SECONDS);
         }

--- a/redisson/src/test/java/org/redisson/connection/ConnectionsHolderTest.java
+++ b/redisson/src/test/java/org/redisson/connection/ConnectionsHolderTest.java
@@ -13,6 +13,7 @@ import org.redisson.misc.AsyncSemaphore;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 
@@ -72,6 +73,78 @@ public class ConnectionsHolderTest {
             // returns to the pool max — never inflated above it, which would jam idle eviction
             Assertions.assertThat(counter.getCounter()).isEqualTo(poolMaxSize);
             Assertions.assertThat(holder.getFreeConnections()).hasSize(poolMaxSize);
+        } finally {
+            manager.shutdown(0, 0, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void testWarmUpCreatesConnectionsUpToDefinedAmount(@Mocked RedisClient client, @Mocked RedisConnection conn) {
+        MasterSlaveConnectionManager manager = buildManager();
+        try {
+            AtomicInteger createdConnections = new AtomicInteger();
+            Function<RedisClient, CompletionStage<RedisConnection>> succeedingCallback = r -> {
+                createdConnections.incrementAndGet();
+                return CompletableFuture.completedFuture(conn);
+            };
+            ConnectionsHolder<RedisConnection> holder =
+                    new ConnectionsHolder<>(client, 4, succeedingCallback, manager.getServiceManager(), false);
+
+            CompletableFuture<Void> result = holder.warmUp(3);
+            Assertions.assertThat(result).isCompleted();
+
+            Assertions.assertThat(createdConnections).hasValue(3);
+            Assertions.assertThat(holder.getAllConnections()).hasSize(3);
+            Assertions.assertThat(holder.getFreeConnections()).hasSize(3);
+            Assertions.assertThat(holder.getFreeConnectionsCounter().getCounter()).isEqualTo(4);
+        } finally {
+            manager.shutdown(0, 0, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void testWarmUpDoesNotCreateConnectionsIfAmountAlreadyReached(@Mocked RedisClient client,
+                                                                  @Mocked RedisConnection conn) {
+        MasterSlaveConnectionManager manager = buildManager();
+        try {
+            AtomicInteger createdConnections = new AtomicInteger();
+            Function<RedisClient, CompletionStage<RedisConnection>> succeedingCallback = r -> {
+                createdConnections.incrementAndGet();
+                return CompletableFuture.completedFuture(conn);
+            };
+            ConnectionsHolder<RedisConnection> holder =
+                    new ConnectionsHolder<>(client, 4, succeedingCallback, manager.getServiceManager(), false);
+
+            Assertions.assertThat(holder.warmUp(3)).isCompleted();
+            Assertions.assertThat(holder.warmUp(2)).isCompleted();
+
+            Assertions.assertThat(createdConnections).hasValue(3);
+            Assertions.assertThat(holder.getAllConnections()).hasSize(3);
+            Assertions.assertThat(holder.getFreeConnections()).hasSize(3);
+            Assertions.assertThat(holder.getFreeConnectionsCounter().getCounter()).isEqualTo(4);
+        } finally {
+            manager.shutdown(0, 0, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void testWarmUpRejectsAmountGreaterThanPoolSize(@Mocked RedisClient client, @Mocked RedisConnection conn) {
+        MasterSlaveConnectionManager manager = buildManager();
+        try {
+            AtomicInteger createdConnections = new AtomicInteger();
+            Function<RedisClient, CompletionStage<RedisConnection>> succeedingCallback = r -> {
+                createdConnections.incrementAndGet();
+                return CompletableFuture.completedFuture(conn);
+            };
+            ConnectionsHolder<RedisConnection> holder =
+                    new ConnectionsHolder<>(client, 2, succeedingCallback, manager.getServiceManager(), false);
+
+            CompletableFuture<Void> result = holder.warmUp(3);
+
+            Assertions.assertThat(result).isCompletedExceptionally();
+            Assertions.assertThat(createdConnections).hasValue(0);
+            Assertions.assertThat(holder.getAllConnections()).isEmpty();
+            Assertions.assertThat(holder.getFreeConnections()).isEmpty();
         } finally {
             manager.shutdown(0, 0, TimeUnit.SECONDS);
         }

--- a/redisson/src/test/java/org/redisson/connection/ConnectionsHolderTest.java
+++ b/redisson/src/test/java/org/redisson/connection/ConnectionsHolderTest.java
@@ -6,6 +6,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.redisson.client.RedisClient;
 import org.redisson.client.RedisConnection;
+import org.redisson.client.RedisConnectionException;
 import org.redisson.config.Config;
 import org.redisson.config.MasterSlaveServersConfig;
 import org.redisson.config.ReadMode;
@@ -334,6 +335,109 @@ public class ConnectionsHolderTest {
             Assertions.assertThat(result4).isCompleted();
             Assertions.assertThat(holder.getAllConnections()).hasSize(3);
             Assertions.assertThat(holder.getFreeConnections()).hasSize(3);
+        } finally {
+            manager.shutdown(0, 0, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void testWarmUpRechecksTargetAfterPermitIsAcquired(@Mocked RedisConnection conn1,
+                                                       @Mocked RedisConnection conn2,
+                                                       @Mocked ClientConnectionsEntry entry) {
+        MasterSlaveConnectionManager manager = buildManager();
+        try {
+            new Expectations() {{
+                conn1.isActive(); result = true; minTimes = 0;
+                conn2.isActive(); result = true; minTimes = 0;
+                entry.isFreezed(); result = false; minTimes = 0;
+            }};
+
+            List<CompletableFuture<RedisConnection>> connectionFutures = new ArrayList<>();
+            Function<RedisClient, CompletionStage<RedisConnection>> callback = r -> {
+                CompletableFuture<RedisConnection> f = new CompletableFuture<>();
+                connectionFutures.add(f);
+                return f;
+            };
+            ConnectionsHolder<RedisConnection> holder =
+                    new ConnectionsHolder<>(null, 2, callback, manager.getServiceManager(), false);
+
+            CompletableFuture<Void> initialWarmUp = holder.warmUp(1);
+            connectionFutures.get(0).complete(conn1);
+            Assertions.assertThat(initialWarmUp).isCompleted();
+
+            RedisConnection borrowedConnection = holder.acquireConnection(null).join();
+            CompletableFuture<RedisConnection> commandConnection = holder.acquireConnection(null);
+            Assertions.assertThat(connectionFutures).hasSize(2);
+
+            CompletableFuture<Void> warmUp = holder.warmUp(2);
+            Assertions.assertThat(warmUp).isNotDone();
+
+            connectionFutures.get(1).complete(conn2);
+            Assertions.assertThat(commandConnection).isCompleted();
+            Assertions.assertThat(holder.getAllConnections()).hasSize(2);
+
+            holder.releaseConnection(entry, borrowedConnection);
+
+            Assertions.assertThat(warmUp).isCompleted();
+            Assertions.assertThat(connectionFutures).hasSize(2);
+            Assertions.assertThat(holder.getAllConnections()).hasSize(2);
+
+            holder.releaseConnection(entry, commandConnection.join());
+            Assertions.assertThat(holder.getFreeConnectionsCounter().getCounter()).isEqualTo(2);
+        } finally {
+            manager.shutdown(0, 0, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void testFailWarmUpCancelsPendingPermit(@Mocked RedisConnection conn,
+                                            @Mocked ClientConnectionsEntry entry) {
+        MasterSlaveConnectionManager manager = buildManager();
+        try {
+            new Expectations() {{
+                conn.isActive(); result = true; minTimes = 0;
+                entry.isFreezed(); result = false; minTimes = 0;
+            }};
+
+            CompletableFuture<RedisConnection> connectionFuture = new CompletableFuture<>();
+            ConnectionsHolder<RedisConnection> holder = new ConnectionsHolder<>(null, 1,
+                    r -> connectionFuture, manager.getServiceManager(), false);
+
+            CompletableFuture<RedisConnection> commandConnection = holder.acquireConnection(null);
+            CompletableFuture<Void> warmUp = holder.warmUp(1);
+            Assertions.assertThat(holder.getFreeConnectionsCounter().queueSize()).isEqualTo(1);
+
+            holder.failWarmUp(new RedisConnectionException("node down"));
+
+            Assertions.assertThat(warmUp).isCompletedExceptionally();
+            Assertions.assertThat(holder.getFreeConnectionsCounter().queueSize()).isZero();
+
+            connectionFuture.complete(conn);
+            holder.releaseConnection(entry, commandConnection.join());
+            Assertions.assertThat(holder.getFreeConnectionsCounter().getCounter()).isEqualTo(1);
+        } finally {
+            manager.shutdown(0, 0, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void testFailWarmUpDiscardsConnectionCreatedAfterNodeDown(@Mocked RedisConnection conn) {
+        MasterSlaveConnectionManager manager = buildManager();
+        try {
+            CompletableFuture<RedisConnection> connectionFuture = new CompletableFuture<>();
+            ConnectionsHolder<RedisConnection> holder = new ConnectionsHolder<>(null, 1,
+                    r -> connectionFuture, manager.getServiceManager(), false);
+
+            CompletableFuture<Void> warmUp = holder.warmUp(1);
+            holder.failWarmUp(new RedisConnectionException("node down"));
+
+            Assertions.assertThat(warmUp).isCompletedExceptionally();
+
+            connectionFuture.complete(conn);
+
+            Assertions.assertThat(holder.getAllConnections()).isEmpty();
+            Assertions.assertThat(holder.getFreeConnections()).isEmpty();
+            Assertions.assertThat(holder.getFreeConnectionsCounter().getCounter()).isEqualTo(1);
         } finally {
             manager.shutdown(0, 0, TimeUnit.SECONDS);
         }

--- a/redisson/src/test/java/org/redisson/connection/ConnectionsHolderTest.java
+++ b/redisson/src/test/java/org/redisson/connection/ConnectionsHolderTest.java
@@ -11,6 +11,8 @@ import org.redisson.config.MasterSlaveServersConfig;
 import org.redisson.config.ReadMode;
 import org.redisson.misc.AsyncSemaphore;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
@@ -91,9 +93,9 @@ public class ConnectionsHolderTest {
     }
 
     @Test
-    void testWarmUpCreatesFreeConnectionsUpToDefinedAmount(@Mocked RedisConnection conn1,
-                                                           @Mocked RedisConnection conn2,
-                                                           @Mocked RedisConnection conn3) {
+    void testWarmUpCreatesConnectionsUpToDefinedAmount(@Mocked RedisConnection conn1,
+                                                       @Mocked RedisConnection conn2,
+                                                       @Mocked RedisConnection conn3) {
         MasterSlaveConnectionManager manager = buildManager();
         try {
             AtomicInteger createdConnections = new AtomicInteger();
@@ -140,22 +142,20 @@ public class ConnectionsHolderTest {
     }
 
     @Test
-    void testWarmUpCreatesConnectionsUntilFreeAmountIsReached(@Mocked RedisConnection conn1,
-                                                              @Mocked RedisConnection conn2,
-                                                              @Mocked RedisConnection conn3,
-                                                              @Mocked RedisConnection conn4) {
+    void testWarmUpCreatesConnectionsUntilTotalAmountIsReached(@Mocked RedisConnection conn1,
+                                                               @Mocked RedisConnection conn2,
+                                                               @Mocked RedisConnection conn3) {
         MasterSlaveConnectionManager manager = buildManager();
         try {
             new Expectations() {{
                 conn1.isActive(); result = true; minTimes = 0;
                 conn2.isActive(); result = true; minTimes = 0;
                 conn3.isActive(); result = true; minTimes = 0;
-                conn4.isActive(); result = true; minTimes = 0;
             }};
 
             AtomicInteger createdConnections = new AtomicInteger();
             Function<RedisClient, CompletionStage<RedisConnection>> succeedingCallback =
-                    succeedingCallback(createdConnections, conn1, conn2, conn3, conn4);
+                    succeedingCallback(createdConnections, conn1, conn2, conn3);
             ConnectionsHolder<RedisConnection> holder =
                     new ConnectionsHolder<>(null, 4, succeedingCallback, manager.getServiceManager(), false);
 
@@ -166,9 +166,9 @@ public class ConnectionsHolderTest {
 
             Assertions.assertThat(result).isCompleted();
             Assertions.assertThat(connection).isSameAs(conn1);
-            Assertions.assertThat(createdConnections).hasValue(4);
-            Assertions.assertThat(holder.getAllConnections()).hasSize(4);
-            Assertions.assertThat(holder.getFreeConnections()).hasSize(3);
+            Assertions.assertThat(createdConnections).hasValue(3);
+            Assertions.assertThat(holder.getAllConnections()).hasSize(3);
+            Assertions.assertThat(holder.getFreeConnections()).hasSize(2);
             Assertions.assertThat(holder.getFreeConnectionsCounter().getCounter()).isEqualTo(3);
         } finally {
             manager.shutdown(0, 0, TimeUnit.SECONDS);
@@ -176,10 +176,10 @@ public class ConnectionsHolderTest {
     }
 
     @Test
-    void testWarmUpCompletesAfterBorrowedConnectionReturnsWhenPoolIsFull(@Mocked RedisConnection conn1,
-                                                                         @Mocked RedisConnection conn2,
-                                                                         @Mocked RedisConnection conn3,
-                                                                         @Mocked ClientConnectionsEntry entry) {
+    void testWarmUpCompletesWhenTotalAmountAlreadyReachedEvenIfConnectionIsBorrowed(@Mocked RedisConnection conn1,
+                                                                                    @Mocked RedisConnection conn2,
+                                                                                    @Mocked RedisConnection conn3,
+                                                                                    @Mocked ClientConnectionsEntry entry) {
         MasterSlaveConnectionManager manager = buildManager();
         try {
             new Expectations() {{
@@ -199,7 +199,7 @@ public class ConnectionsHolderTest {
             RedisConnection connection = holder.acquireConnection(null).join();
 
             CompletableFuture<Void> result = holder.warmUp(3);
-            Assertions.assertThat(result).isNotDone();
+            Assertions.assertThat(result).isCompleted();
 
             holder.releaseConnection(entry, connection);
 
@@ -234,6 +234,106 @@ public class ConnectionsHolderTest {
             Assertions.assertThat(counter.getCounter()).isEqualTo(poolMaxSize);
             Assertions.assertThat(holder.getAllConnections()).isEmpty();
             Assertions.assertThat(holder.getFreeConnections()).isEmpty();
+        } finally {
+            manager.shutdown(0, 0, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void testWarmUpFailurePreservesExistingConnectionsAndAllowsRetry(@Mocked RedisConnection conn1,
+                                                                      @Mocked RedisConnection conn2) {
+        MasterSlaveConnectionManager manager = buildManager();
+        try {
+            AtomicInteger attempts = new AtomicInteger();
+            Function<RedisClient, CompletionStage<RedisConnection>> callback = r -> {
+                int attempt = attempts.getAndIncrement();
+                if (attempt == 1) {
+                    CompletableFuture<RedisConnection> f = new CompletableFuture<>();
+                    f.completeExceptionally(new RuntimeException("connect failed"));
+                    return f;
+                }
+                return CompletableFuture.completedFuture(attempt == 0 ? conn1 : conn2);
+            };
+            ConnectionsHolder<RedisConnection> holder =
+                    new ConnectionsHolder<>(null, 2, callback, manager.getServiceManager(), false);
+
+            Assertions.assertThat(holder.warmUp(1)).isCompleted();
+            Assertions.assertThat(holder.warmUp(2)).isCompletedExceptionally();
+
+            Assertions.assertThat(holder.getAllConnections()).containsExactly(conn1);
+            Assertions.assertThat(holder.getFreeConnections()).containsExactly(conn1);
+            Assertions.assertThat(holder.getFreeConnectionsCounter().getCounter()).isEqualTo(2);
+
+            Assertions.assertThat(holder.warmUp(2)).isCompleted();
+            Assertions.assertThat(holder.getAllConnections()).containsExactly(conn1, conn2);
+            Assertions.assertThat(holder.getFreeConnections()).containsExactly(conn1, conn2);
+            Assertions.assertThat(holder.getFreeConnectionsCounter().getCounter()).isEqualTo(2);
+        } finally {
+            manager.shutdown(0, 0, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void testWarmUpCountsAllCreatedConnections(@Mocked RedisConnection conn1,
+                                               @Mocked RedisConnection conn2) {
+        MasterSlaveConnectionManager manager = buildManager();
+        try {
+            new Expectations() {{
+                conn1.isActive(); result = false; minTimes = 0;
+            }};
+
+            AtomicInteger createdConnections = new AtomicInteger();
+            Function<RedisClient, CompletionStage<RedisConnection>> succeedingCallback =
+                    succeedingCallback(createdConnections, conn1, conn2);
+            ConnectionsHolder<RedisConnection> holder =
+                    new ConnectionsHolder<>(null, 3, succeedingCallback, manager.getServiceManager(), false);
+
+            CompletableFuture<Void> result = holder.warmUp(2);
+
+            Assertions.assertThat(result).isCompleted();
+            Assertions.assertThat(createdConnections).hasValue(2);
+            Assertions.assertThat(holder.getAllConnections()).hasSize(2);
+            Assertions.assertThat(holder.getFreeConnections()).hasSize(2);
+        } finally {
+            manager.shutdown(0, 0, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void testConcurrentWarmUpsDoNotReserveMoreThanPoolSize(@Mocked RedisConnection conn1,
+                                                           @Mocked RedisConnection conn2,
+                                                           @Mocked RedisConnection conn3) {
+        MasterSlaveConnectionManager manager = buildManager();
+        try {
+            List<CompletableFuture<RedisConnection>> connectionFutures = new ArrayList<>();
+            Function<RedisClient, CompletionStage<RedisConnection>> callback = r -> {
+                CompletableFuture<RedisConnection> f = new CompletableFuture<>();
+                connectionFutures.add(f);
+                return f;
+            };
+            ConnectionsHolder<RedisConnection> holder =
+                    new ConnectionsHolder<>(null, 3, callback, manager.getServiceManager(), false);
+
+            CompletableFuture<Void> result1 = holder.warmUp(3);
+            CompletableFuture<Void> result2 = holder.warmUp(3);
+            CompletableFuture<Void> result3 = holder.warmUp(3);
+            CompletableFuture<Void> result4 = holder.warmUp(3);
+            Assertions.assertThat(connectionFutures).hasSize(1);
+
+            connectionFutures.get(0).complete(conn1);
+            Assertions.assertThat(connectionFutures).hasSize(2);
+
+            connectionFutures.get(1).complete(conn2);
+            Assertions.assertThat(connectionFutures).hasSize(3);
+
+            connectionFutures.get(2).complete(conn3);
+
+            Assertions.assertThat(result1).isCompleted();
+            Assertions.assertThat(result2).isCompleted();
+            Assertions.assertThat(result3).isCompleted();
+            Assertions.assertThat(result4).isCompleted();
+            Assertions.assertThat(holder.getAllConnections()).hasSize(3);
+            Assertions.assertThat(holder.getFreeConnections()).hasSize(3);
         } finally {
             manager.shutdown(0, 0, TimeUnit.SECONDS);
         }


### PR DESCRIPTION
## Summary

- add Redis master/slave/cluster node APIs to warm up the regular command connection pool at runtime
- create missing connections until the pool contains the requested total connection amount
- include currently borrowed connections in the requested amount
- serialize concurrent warm-up requests so the configured pool max size isn't exceeded
- recheck the target after acquiring a pool permit to account for concurrent command connection creation
- preserve existing healthy pool connections if a warm-up connection attempt fails
- fail pending warm-up requests when the node is frozen, goes down, or shuts down
- keep Sentinel nodes out of the new API since they do not expose this connection pool target

## Behavior

- If the pool already contains at least the requested number of connections, no new connections are created.
- Borrowed connections count toward the requested amount, so warm-up doesn't wait for them to return.
- Missing connections are created asynchronously and sequentially.
- The requested amount must be between zero and the configured max connection pool size.
- A failed warm-up completes exceptionally without clearing existing pool connections.
- Pending warm-ups complete exceptionally on node lifecycle transitions, and late connection results are discarded.

## Motivation

The minimum idle settings cover the configured baseline pool size during client initialization. This API supports runtime, on-demand preparation after the client has already been initialized.

A primary use case is an application-level circuit breaker that temporarily bypasses Redis cache traffic. While the circuit is open, the pool may remain at its configured minimum idle size. Before moving the circuit to half-open or closed and restoring cache traffic, the application can await this warm-up operation to prepare the desired connection capacity. Setting a larger minimum idle size would keep that extra capacity allocated permanently, whereas runtime warm-up creates it only when traffic is about to resume after an incident or failover.

Closes #7242

## Validation

- `JAVA_HOME=/opt/homebrew/opt/openjdk@25/libexec/openjdk.jdk/Contents/Home mvn -B -pl redisson -Dtest=org.redisson.connection.ConnectionsHolderTest -DskipTests=false -Dmaven.test.skip=false test`
  - 14 tests passed, 0 failures, 0 errors
- `JAVA_HOME=/opt/homebrew/opt/openjdk@25/libexec/openjdk.jdk/Contents/Home mvn -B -pl redisson -DskipTests -Dmaven.test.skip=false verify`
  - build, Javadocs, PMD, CPD, Checkstyle, and license checks passed
- `git diff --check`
