### PR TITLE
Fixed - failed node detection polluted by failures from other Redis nodes #7231

### DIFF
--- a/redisson/src/main/java/org/redisson/client/FailedCommandsDetector.java
+++ b/redisson/src/main/java/org/redisson/client/FailedCommandsDetector.java
@@ -36,6 +36,14 @@ public class FailedCommandsDetector implements FailedNodeDetector {
     public FailedCommandsDetector() {
     }
 
+    /**
+     * Creates an empty detector of the same type. Overridden by subclasses so
+     * that {@link #copy()} preserves the concrete detector type.
+     */
+    protected FailedCommandsDetector newInstance() {
+        return new FailedCommandsDetector();
+    }
+
     public FailedCommandsDetector(long checkInterval, int failedCommandsLimit) {
         if (checkInterval == 0) {
             throw new IllegalArgumentException("checkInterval value");
@@ -108,6 +116,14 @@ public class FailedCommandsDetector implements FailedNodeDetector {
             return true;
         }
         return false;
+    }
+
+    @Override
+    public FailedNodeDetector copy() {
+        FailedCommandsDetector detector = newInstance();
+        detector.checkInterval = checkInterval;
+        detector.failedCommandsLimit = failedCommandsLimit;
+        return detector;
     }
 
 }

--- a/redisson/src/main/java/org/redisson/client/FailedCommandsTimeoutDetector.java
+++ b/redisson/src/main/java/org/redisson/client/FailedCommandsTimeoutDetector.java
@@ -32,6 +32,11 @@ public class FailedCommandsTimeoutDetector extends FailedCommandsDetector {
     }
 
     @Override
+    protected FailedCommandsDetector newInstance() {
+        return new FailedCommandsTimeoutDetector();
+    }
+
+    @Override
     public void onCommandFailed(Throwable cause) {
         if (cause instanceof RedisTimeoutException) {
             super.onCommandFailed(cause);

--- a/redisson/src/main/java/org/redisson/client/FailedConnectionDetector.java
+++ b/redisson/src/main/java/org/redisson/client/FailedConnectionDetector.java
@@ -94,4 +94,9 @@ public class FailedConnectionDetector implements FailedNodeDetector {
         return false;
     }
 
+    @Override
+    public FailedNodeDetector copy() {
+        return new FailedConnectionDetector(checkInterval);
+    }
+
 }

--- a/redisson/src/main/java/org/redisson/client/FailedNodeDetector.java
+++ b/redisson/src/main/java/org/redisson/client/FailedNodeDetector.java
@@ -48,4 +48,20 @@ public interface FailedNodeDetector {
 
     boolean isNodeFailed();
 
+    /**
+     * Returns a copy of this detector that keeps the same configuration
+     * but starts with fresh runtime state. It is used to assign an independent
+     * detector to each Redis node, so that failures of one node don't pollute
+     * the failure state of another.
+     * <p>
+     * The default implementation returns the same instance, preserving the
+     * shared state. Custom detectors holding per-node runtime state should
+     * override this method.
+     *
+     * @return detector copy with fresh runtime state
+     */
+    default FailedNodeDetector copy() {
+        return this;
+    }
+
 }

--- a/redisson/src/main/java/org/redisson/client/RedisClientConfig.java
+++ b/redisson/src/main/java/org/redisson/client/RedisClientConfig.java
@@ -130,7 +130,8 @@ public class RedisClientConfig {
         this.sslKeyManagerFactory = config.sslKeyManagerFactory;
         this.sslTrustManagerFactory = config.sslTrustManagerFactory;
         this.commandMapper = config.commandMapper;
-        this.failedNodeDetector = config.failedNodeDetector;
+        this.failedNodeDetector = config.failedNodeDetector != null
+                ? config.failedNodeDetector.copy() : null;
         this.tcpKeepAliveCount = config.tcpKeepAliveCount;
         this.tcpKeepAliveIdle = config.tcpKeepAliveIdle;
         this.tcpKeepAliveInterval = config.tcpKeepAliveInterval;

--- a/redisson/src/test/java/org/redisson/client/FailedNodeDetectorCopyTest.java
+++ b/redisson/src/test/java/org/redisson/client/FailedNodeDetectorCopyTest.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2013-2026 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.client;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FailedNodeDetectorCopyTest {
+
+    @Test
+    public void testRedisClientConfigCopyIsolatesDetectorPerNode() throws InterruptedException {
+        // A single detector is configured once and reused for every node's RedisClient,
+        // each of which copies the base config. The copies must not share failure state,
+        // otherwise one failing node marks healthy nodes as failed (issue #7231).
+        FailedConnectionDetector detector = new FailedConnectionDetector(50);
+
+        RedisClientConfig config = new RedisClientConfig();
+        config.setFailedNodeDetector(detector);
+
+        RedisClientConfig nodeA = new RedisClientConfig(config);
+        RedisClientConfig nodeB = new RedisClientConfig(config);
+
+        assertThat(nodeA.getFailedNodeDetector()).isNotSameAs(detector);
+        assertThat(nodeA.getFailedNodeDetector()).isNotSameAs(nodeB.getFailedNodeDetector());
+
+        nodeA.getFailedNodeDetector().onConnectFailed(new RuntimeException());
+        Thread.sleep(60);
+
+        assertThat(nodeA.getFailedNodeDetector().isNodeFailed()).isTrue();
+        assertThat(nodeB.getFailedNodeDetector().isNodeFailed()).isFalse();
+    }
+
+    @Test
+    public void testFailedConnectionDetectorCopyResetsState() throws InterruptedException {
+        FailedConnectionDetector detector = new FailedConnectionDetector(50);
+        detector.onConnectFailed(new RuntimeException());
+
+        FailedNodeDetector copy = detector.copy();
+        assertThat(copy).isInstanceOf(FailedConnectionDetector.class);
+
+        Thread.sleep(60);
+        assertThat(detector.isNodeFailed()).isTrue();
+        assertThat(copy.isNodeFailed()).isFalse();
+    }
+
+    @Test
+    public void testFailedCommandsDetectorCopyKeepsConfigAndResetsState() throws InterruptedException {
+        // FailedCommandsDetector tracks failures by millisecond timestamp, so the
+        // failures are spaced out to make sure they count as distinct commands.
+        FailedCommandsDetector detector = new FailedCommandsDetector(60000, 2);
+        detector.onCommandFailed(new RuntimeException());
+        Thread.sleep(2);
+        detector.onCommandFailed(new RuntimeException());
+        assertThat(detector.isNodeFailed()).isTrue();
+
+        FailedNodeDetector copy = detector.copy();
+        assertThat(copy).isInstanceOf(FailedCommandsDetector.class);
+
+        // configured limit is preserved, but the accumulated failures are not
+        assertThat(copy.isNodeFailed()).isFalse();
+        copy.onCommandFailed(new RuntimeException());
+        Thread.sleep(2);
+        copy.onCommandFailed(new RuntimeException());
+        assertThat(copy.isNodeFailed()).isTrue();
+    }
+
+    @Test
+    public void testFailedCommandsTimeoutDetectorCopyPreservesType() {
+        FailedCommandsTimeoutDetector detector = new FailedCommandsTimeoutDetector(60000, 1);
+
+        FailedNodeDetector copy = detector.copy();
+        assertThat(copy).isInstanceOf(FailedCommandsTimeoutDetector.class);
+
+        // only timeout errors count towards failure for this detector
+        copy.onCommandFailed(new RuntimeException());
+        assertThat(copy.isNodeFailed()).isFalse();
+        copy.onCommandFailed(new RedisTimeoutException("timeout"));
+        assertThat(copy.isNodeFailed()).isTrue();
+    }
+
+    @Test
+    public void testDefaultDetectorCopyReturnsSameInstance() {
+        FailedNodeDetector custom = new FailedNodeDetector() {
+            @Override
+            public void onConnectSuccessful() {
+            }
+            @Override
+            public void onConnectFailed() {
+            }
+            @Override
+            public void onPingSuccessful() {
+            }
+            @Override
+            public void onPingFailed() {
+            }
+            @Override
+            public void onCommandSuccessful() {
+            }
+            @Override
+            public void onCommandFailed(Throwable cause) {
+            }
+            @Override
+            public boolean isNodeFailed() {
+                return false;
+            }
+        };
+
+        assertThat(custom.copy()).isSameAs(custom);
+    }
+}


### PR DESCRIPTION
Fixes #7231.

## Problem
A single `FailedNodeDetector` instance was shared across every Redis node. In `MasterSlaveConnectionManager#createRedisConfig`, each per-node `RedisClientConfig` is assigned the same `getFailedSlaveNodeDetector()` reference, and `RedisClientConfig`'s copy constructor passed that reference straight through. Since the built-in detectors hold mutable runtime state (`FailedConnectionDetector#firstFailTime`, `FailedCommandsDetector#failedCommands`), failures from one node accumulated in the shared instance — so a healthy node could be reported as failed because another node had failed, and `isNodeFailed()` was effectively evaluated against cross-node state.

## Fix
Give each node an independent detector with the same configuration but fresh runtime state:
- Added `FailedNodeDetector#copy()` as a default method returning `this`, so existing custom detectors remain fully backward-compatible (they can opt in by overriding).
- Implemented `copy()` in the three built-in detectors; `FailedCommandsTimeoutDetector` keeps its subclass type via a small factory so its timeout-only semantics are preserved.
- `RedisClientConfig`'s copy constructor now calls `copy()` (null-safe) so each `RedisClient` gets its own detector.

## Tests
Added `FailedNodeDetectorCopyTest` covering per-node isolation and each detector type. The isolation test fails on `master` and passes with this change.