### PR TITLE
Implement configurable rate for RGcra (trySetRate/setRate/getConfig) #7181

### DIFF
--- a/docs/data-and-services/objects.md
+++ b/docs/data-and-services/objects.md
@@ -2415,9 +2415,15 @@ Applying a separate limit to each user, tenant, or API key means one limiter per
     ```
 
 ## GCRA Rate Limiter
-Java implementation of Redis based [RGcra](https://static.javadoc.io/org.redisson/redisson/latest/org/redisson/api/RGcra.html) object is a rate limiter based on the [Generic Cell Rate Algorithm](https://en.wikipedia.org/wiki/Generic_cell_rate_algorithm). It restricts the rate of operations using a burst capacity and a token replenishment rate. State is stored in a single Redis key, so the limit applies across all threads regardless of the Redisson instance. This object is thread-safe.
+Java implementation of Redis based [RGcra](https://static.javadoc.io/org.redisson/redisson/latest/org/redisson/api/RGcra.html) object is a rate limiter based on the [Generic Cell Rate Algorithm](https://en.wikipedia.org/wiki/Generic_cell_rate_algorithm). It restricts the rate of operations using a burst capacity and a token replenishment rate. State is stored in Redis, so the limit applies across all threads regardless of the Redisson instance. This object is thread-safe.
 
 Requires Redis 8.8.0 or higher.
+
+The rate is configured once through the `trySetRate()` or `setRate()` method:
+
+* `trySetRate(maxBurst, tokensPerPeriod, period)` - sets the rate only if it hasn't been set before, returns `false` otherwise
+* `setRate(maxBurst, tokensPerPeriod, period)` - overwrites the rate and resets the consumed tokens
+* `getConfig()` - returns the currently configured rate
 
 Each call to `tryAcquire()` requests one or more tokens and returns a `GcraResult` with the following information:
 
@@ -2434,21 +2440,24 @@ Code example:
     RGcra gcra = redisson.getGcra("myLimiter");
 
     // up to 4 tokens per second, with burst of 2 additional tokens
-    GcraResult result = gcra.tryAcquire(2, 4, Duration.ofSeconds(1));
+    gcra.trySetRate(2, 4, Duration.ofSeconds(1));
+
+    GcraResult result = gcra.tryAcquire();
     if (!result.isLimited()) {
         // request accepted
     }
 
     // acquire 3 tokens at once
-    GcraResult batch = gcra.tryAcquire(2, 4, Duration.ofSeconds(1), 3);
+    GcraResult batch = gcra.tryAcquire(3);
     ```
 
 === "Async"
     ```
     RGcraAsync gcra = redisson.getGcra("myLimiter");
 
-    RFuture<GcraResult> resultFuture = gcra.tryAcquireAsync(2, 4, Duration.ofSeconds(1));
-    RFuture<GcraResult> batchFuture = gcra.tryAcquireAsync(2, 4, Duration.ofSeconds(1), 3);
+    RFuture<Boolean> setFuture = gcra.trySetRateAsync(2, 4, Duration.ofSeconds(1));
+    RFuture<GcraResult> resultFuture = gcra.tryAcquireAsync();
+    RFuture<GcraResult> batchFuture = gcra.tryAcquireAsync(3);
     ```
 
 === "Reactive"
@@ -2456,8 +2465,9 @@ Code example:
     RedissonReactiveClient redisson = redissonClient.reactive();
     RGcraReactive gcra = redisson.getGcra("myLimiter");
 
-    Mono<GcraResult> resultMono = gcra.tryAcquire(2, 4, Duration.ofSeconds(1));
-    Mono<GcraResult> batchMono = gcra.tryAcquire(2, 4, Duration.ofSeconds(1), 3);
+    Mono<Boolean> setMono = gcra.trySetRate(2, 4, Duration.ofSeconds(1));
+    Mono<GcraResult> resultMono = gcra.tryAcquire();
+    Mono<GcraResult> batchMono = gcra.tryAcquire(3);
     ```
 
 === "RxJava3"
@@ -2465,25 +2475,28 @@ Code example:
     RedissonRxClient redisson = redissonClient.rxJava();
     RGcraRx gcra = redisson.getGcra("myLimiter");
 
-    Single<GcraResult> resultRx = gcra.tryAcquire(2, 4, Duration.ofSeconds(1));
-    Single<GcraResult> batchRx = gcra.tryAcquire(2, 4, Duration.ofSeconds(1), 3);
+    Single<Boolean> setRx = gcra.trySetRate(2, 4, Duration.ofSeconds(1));
+    Single<GcraResult> resultRx = gcra.tryAcquire();
+    Single<GcraResult> batchRx = gcra.tryAcquire(3);
     ```
 
 ### Use Cases
 
-The GCRA rate limiter enforces a smooth request rate with a configurable burst allowance, keeping all state in a single Redis key so one limit applies across every thread and Redisson instance. Each `tryAcquire` call is non-blocking and returns a `GcraResult` that reports whether the call was limited and, when it was, how long to wait. That makes it a fit for guarding APIs, pacing calls to downstream services, and enforcing per-client quotas.
+The GCRA rate limiter enforces a smooth request rate with a configurable burst allowance, keeping its state in Redis so one limit applies across every thread and Redisson instance. Each `tryAcquire` call is non-blocking and returns a `GcraResult` that reports whether the call was limited and, when it was, how long to wait. That makes it a fit for guarding APIs, pacing calls to downstream services, and enforcing per-client quotas.
 
 **Per-Client API Rate Limiting**
 
-API gateways limit each caller independently and tell a throttled client when to come back. Encoding the client id in the limiter name gives one limiter per API key, user, or IP. On each request a single token is requested, and the `GcraResult` supplies everything needed for the response: `getRetryAfterSeconds()` for the HTTP `Retry-After` header on a 429, and `getMaxTokens()`/`getAvailableTokens()` for `X-RateLimit-*` headers.
+API gateways limit each caller independently and tell a throttled client when to come back. Encoding the client id in the limiter name gives one limiter per API key, user, or IP. The rate is configured once (`trySetRate()` is idempotent, so it's safe to call before each request); on each request a single token is requested, and the `GcraResult` supplies everything needed for the response: `getRetryAfterSeconds()` for the HTTP `Retry-After` header on a 429, and `getMaxTokens()`/`getAvailableTokens()` for `X-RateLimit-*` headers.
 
 === "Sync"
     ```
-    // one limiter per API key - state lives in a single Redis key per client
+    // one limiter per API key
     RGcra gcra = redisson.getGcra("ratelimit:" + apiKey);
 
     // up to 100 requests per second per client, with a burst of 50 additional
-    GcraResult result = gcra.tryAcquire(50, 100, Duration.ofSeconds(1));
+    gcra.trySetRate(50, 100, Duration.ofSeconds(1));
+
+    GcraResult result = gcra.tryAcquire();
 
     if (result.isLimited()) {
         // reject with HTTP 429 and tell the client when to retry
@@ -2500,7 +2513,7 @@ API gateways limit each caller independently and tell a throttled client when to
     RGcraAsync gcra = redisson.getGcra("ratelimit:" + apiKey);
 
     // isLimited(), getRetryAfterSeconds() and getAvailableTokens() read off the result
-    RFuture<GcraResult> result = gcra.tryAcquireAsync(50, 100, Duration.ofSeconds(1));
+    RFuture<GcraResult> result = gcra.tryAcquireAsync();
     ```
 === "Reactive"
     ```
@@ -2508,7 +2521,7 @@ API gateways limit each caller independently and tell a throttled client when to
     RGcraReactive gcra = redisson.getGcra("ratelimit:" + apiKey);
 
     // isLimited(), getRetryAfterSeconds() and getAvailableTokens() read off the result
-    Mono<GcraResult> result = gcra.tryAcquire(50, 100, Duration.ofSeconds(1));
+    Mono<GcraResult> result = gcra.tryAcquire();
     ```
 === "RxJava3"
     ```
@@ -2516,7 +2529,7 @@ API gateways limit each caller independently and tell a throttled client when to
     RGcraRx gcra = redisson.getGcra("ratelimit:" + apiKey);
 
     // isLimited(), getRetryAfterSeconds() and getAvailableTokens() read off the result
-    Single<GcraResult> result = gcra.tryAcquire(50, 100, Duration.ofSeconds(1));
+    Single<GcraResult> result = gcra.tryAcquire();
     ```
 
 **Protecting Downstream Dependencies**
@@ -2528,7 +2541,9 @@ When calling a fragile third-party API, payment provider, or email/SMS gateway t
     RGcra gcra = redisson.getGcra("downstream:payments-api");
 
     // the provider tolerates ~10 calls per second; permit a small burst of 5
-    GcraResult result = gcra.tryAcquire(5, 10, Duration.ofSeconds(1));
+    gcra.trySetRate(5, 10, Duration.ofSeconds(1));
+
+    GcraResult result = gcra.tryAcquire();
 
     if (result.isLimited()) {
         // pace ourselves - schedule a retry once tokens replenish
@@ -2543,7 +2558,7 @@ When calling a fragile third-party API, payment provider, or email/SMS gateway t
     RGcraAsync gcra = redisson.getGcra("downstream:payments-api");
 
     // when limited, defer the call by result.getRetryAfterSeconds()
-    RFuture<GcraResult> result = gcra.tryAcquireAsync(5, 10, Duration.ofSeconds(1));
+    RFuture<GcraResult> result = gcra.tryAcquireAsync();
     ```
 === "Reactive"
     ```
@@ -2551,7 +2566,7 @@ When calling a fragile third-party API, payment provider, or email/SMS gateway t
     RGcraReactive gcra = redisson.getGcra("downstream:payments-api");
 
     // when limited, defer the call by result.getRetryAfterSeconds()
-    Mono<GcraResult> result = gcra.tryAcquire(5, 10, Duration.ofSeconds(1));
+    Mono<GcraResult> result = gcra.tryAcquire();
     ```
 === "RxJava3"
     ```
@@ -2559,7 +2574,7 @@ When calling a fragile third-party API, payment provider, or email/SMS gateway t
     RGcraRx gcra = redisson.getGcra("downstream:payments-api");
 
     // when limited, defer the call by result.getRetryAfterSeconds()
-    Single<GcraResult> result = gcra.tryAcquire(5, 10, Duration.ofSeconds(1));
+    Single<GcraResult> result = gcra.tryAcquire();
     ```
 
 **Weighted, Cost-Based Quotas**
@@ -2570,11 +2585,12 @@ Not every operation costs the same: a bulk export, a large upload, or a heavy qu
     ```
     RGcra gcra = redisson.getGcra("quota:" + accountId);
 
+    // budget of 1000 tokens per minute, with a burst of 200
+    gcra.trySetRate(200, 1000, Duration.ofMinutes(1));
+
     // charge each request by its cost (rows exported, payload size, ...)
     int cost = estimateCost(request);
-
-    // budget of 1000 tokens per minute, with a burst of 200
-    GcraResult result = gcra.tryAcquire(200, 1000, Duration.ofMinutes(1), cost);
+    GcraResult result = gcra.tryAcquire(cost);
 
     if (result.isLimited()) {
         // not enough budget right now - retry after result.getRetryAfterSeconds()
@@ -2587,7 +2603,7 @@ Not every operation costs the same: a bulk export, a large upload, or a heavy qu
     RGcraAsync gcra = redisson.getGcra("quota:" + accountId);
 
     int cost = estimateCost(request);
-    RFuture<GcraResult> result = gcra.tryAcquireAsync(200, 1000, Duration.ofMinutes(1), cost);
+    RFuture<GcraResult> result = gcra.tryAcquireAsync(cost);
     ```
 === "Reactive"
     ```
@@ -2595,7 +2611,7 @@ Not every operation costs the same: a bulk export, a large upload, or a heavy qu
     RGcraReactive gcra = redisson.getGcra("quota:" + accountId);
 
     int cost = estimateCost(request);
-    Mono<GcraResult> result = gcra.tryAcquire(200, 1000, Duration.ofMinutes(1), cost);
+    Mono<GcraResult> result = gcra.tryAcquire(cost);
     ```
 === "RxJava3"
     ```
@@ -2603,5 +2619,5 @@ Not every operation costs the same: a bulk export, a large upload, or a heavy qu
     RGcraRx gcra = redisson.getGcra("quota:" + accountId);
 
     int cost = estimateCost(request);
-    Single<GcraResult> result = gcra.tryAcquire(200, 1000, Duration.ofMinutes(1), cost);
+    Single<GcraResult> result = gcra.tryAcquire(cost);
     ```

--- a/redisson/src/main/java/org/redisson/RedissonGcra.java
+++ b/redisson/src/main/java/org/redisson/RedissonGcra.java
@@ -15,17 +15,27 @@
  */
 package org.redisson;
 
+import org.redisson.api.GcraConfig;
 import org.redisson.api.GcraResult;
 import org.redisson.api.RFuture;
 import org.redisson.api.RGcra;
 import org.redisson.client.codec.StringCodec;
+import org.redisson.client.protocol.RedisCommand;
 import org.redisson.client.protocol.RedisCommands;
+import org.redisson.client.protocol.decoder.GcraResultDecoder;
+import org.redisson.client.protocol.decoder.MapEntriesDecoder;
+import org.redisson.client.protocol.decoder.MultiDecoder;
 import org.redisson.command.CommandAsyncExecutor;
 
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  *
@@ -34,31 +44,132 @@ import java.util.List;
  */
 public final class RedissonGcra extends RedissonExpirable implements RGcra {
 
+    private static final RedisCommand<GcraResult> EVAL_GCRA = new RedisCommand<>("EVAL", new GcraResultDecoder());
+
+    private static final RedisCommand HGETALL = new RedisCommand("HGETALL",
+            new MapEntriesDecoder((MultiDecoder<GcraConfig>) (parts, state) -> {
+                if (parts.isEmpty()) {
+                    return null;
+                }
+                Map<String, String> map = new HashMap<>(parts.size() / 2);
+                for (int i = 1; i < parts.size(); i += 2) {
+                    map.put(parts.get(i - 1).toString(), parts.get(i).toString());
+                }
+                long maxBurst = Long.parseLong(map.get("maxBurst"));
+                long tokensPerPeriod = Long.parseLong(map.get("rate"));
+                Duration period = fromSeconds(map.get("period"));
+                return new GcraConfig(maxBurst, tokensPerPeriod, period);
+            }));
+
     public RedissonGcra(CommandAsyncExecutor commandExecutor, String name) {
         super(commandExecutor, name);
     }
 
+    String getConfigName() {
+        return suffixName(getRawName(), "config");
+    }
+
     @Override
+    public boolean trySetRate(long maxBurst, long tokensPerPeriod, Duration period) {
+        return get(trySetRateAsync(maxBurst, tokensPerPeriod, period));
+    }
+
+    @Override
+    public RFuture<Boolean> trySetRateAsync(long maxBurst, long tokensPerPeriod, Duration period) {
+        validate(maxBurst, tokensPerPeriod, period);
+
+        return commandExecutor.evalWriteNoRetryAsync(getRawName(), StringCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
+                  "redis.call('hsetnx', KEYS[1], 'maxBurst', ARGV[1]);"
+                + "redis.call('hsetnx', KEYS[1], 'rate', ARGV[2]);"
+                + "return redis.call('hsetnx', KEYS[1], 'period', ARGV[3]);",
+                Collections.singletonList(getConfigName()),
+                maxBurst, tokensPerPeriod, toSeconds(period));
+    }
+
+    @Override
+    public void setRate(long maxBurst, long tokensPerPeriod, Duration period) {
+        get(setRateAsync(maxBurst, tokensPerPeriod, period));
+    }
+
+    @Override
+    public RFuture<Void> setRateAsync(long maxBurst, long tokensPerPeriod, Duration period) {
+        validate(maxBurst, tokensPerPeriod, period);
+
+        return commandExecutor.evalWriteAsync(getRawName(), StringCodec.INSTANCE, RedisCommands.EVAL_VOID,
+                  "redis.call('hset', KEYS[1], 'maxBurst', ARGV[1], 'rate', ARGV[2], 'period', ARGV[3]);"
+                + "redis.call('del', KEYS[2]);",
+                Arrays.asList(getConfigName(), getRawName()),
+                maxBurst, tokensPerPeriod, toSeconds(period));
+    }
+
+    @Override
+    public GcraConfig getConfig() {
+        return get(getConfigAsync());
+    }
+
+    @Override
+    public RFuture<GcraConfig> getConfigAsync() {
+        return commandExecutor.readAsync(getConfigName(), StringCodec.INSTANCE, HGETALL, getConfigName());
+    }
+
+    @Override
+    public GcraResult tryAcquire() {
+        return get(tryAcquireAsync());
+    }
+
+    @Override
+    public RFuture<GcraResult> tryAcquireAsync() {
+        return tryAcquireAsync(1);
+    }
+
+    @Override
+    public GcraResult tryAcquire(long tokens) {
+        return get(tryAcquireAsync(tokens));
+    }
+
+    @Override
+    public RFuture<GcraResult> tryAcquireAsync(long tokens) {
+        validateTokens(tokens);
+
+        return commandExecutor.evalWriteAsync(getRawName(), StringCodec.INSTANCE, EVAL_GCRA,
+                  "local maxBurst = redis.call('hget', KEYS[1], 'maxBurst');"
+                + "local rate = redis.call('hget', KEYS[1], 'rate');"
+                + "local period = redis.call('hget', KEYS[1], 'period');"
+                + "assert(maxBurst ~= false and rate ~= false and period ~= false, 'GCRA rate is not set');"
+                + "if tonumber(ARGV[1]) == 1 then "
+                    + "return redis.call('GCRA', KEYS[2], maxBurst, rate, period);"
+                + "end;"
+                + "return redis.call('GCRA', KEYS[2], maxBurst, rate, period, 'TOKENS', ARGV[1]);",
+                Arrays.asList(getConfigName(), getRawName()),
+                tokens);
+    }
+
+    @Override
+    @Deprecated
     public GcraResult tryAcquire(long maxBurst, long tokensPerPeriod, Duration period) {
         return get(tryAcquireAsync(maxBurst, tokensPerPeriod, period));
     }
 
     @Override
+    @Deprecated
     public RFuture<GcraResult> tryAcquireAsync(long maxBurst, long tokensPerPeriod, Duration period) {
         return tryAcquireAsync(maxBurst, tokensPerPeriod, period, 1);
     }
 
     @Override
+    @Deprecated
     public GcraResult tryAcquire(long maxBurst, long tokensPerPeriod, Duration period, long tokens) {
         return get(tryAcquireAsync(maxBurst, tokensPerPeriod, period, tokens));
     }
 
     @Override
+    @Deprecated
     public RFuture<GcraResult> tryAcquireAsync(long maxBurst, long tokensPerPeriod, Duration period, long tokens) {
-        validate(maxBurst, tokensPerPeriod, period, tokens);
+        validate(maxBurst, tokensPerPeriod, period);
+        validateTokens(tokens);
 
         List<Object> params = new ArrayList<>(6);
-        params.add(name);
+        params.add(getRawName());
         params.add(maxBurst);
         params.add(tokensPerPeriod);
         params.add(toSeconds(period));
@@ -70,7 +181,27 @@ public final class RedissonGcra extends RedissonExpirable implements RGcra {
         return commandExecutor.writeAsync(getRawName(), StringCodec.INSTANCE, RedisCommands.GCRA, params.toArray());
     }
 
-    static void validate(long maxBurst, long tokensPerPeriod, Duration period, long tokens) {
+    @Override
+    public RFuture<Boolean> expireAsync(long timeToLive, TimeUnit timeUnit, String param, String... keys) {
+        return super.expireAsync(timeToLive, timeUnit, param, getRawName(), getConfigName());
+    }
+
+    @Override
+    protected RFuture<Boolean> expireAtAsync(long timestamp, String param, String... keys) {
+        return super.expireAtAsync(timestamp, param, getRawName(), getConfigName());
+    }
+
+    @Override
+    public RFuture<Boolean> clearExpireAsync() {
+        return clearExpireAsync(getRawName(), getConfigName());
+    }
+
+    @Override
+    public RFuture<Boolean> deleteAsync() {
+        return deleteAsync(getRawName(), getConfigName());
+    }
+
+    static void validate(long maxBurst, long tokensPerPeriod, Duration period) {
         if (maxBurst < 0) {
             throw new IllegalArgumentException("maxBurst can't be negative");
         }
@@ -80,6 +211,9 @@ public final class RedissonGcra extends RedissonExpirable implements RGcra {
         if (period == null || period.isZero() || period.isNegative()) {
             throw new IllegalArgumentException("period must be positive");
         }
+    }
+
+    static void validateTokens(long tokens) {
         if (tokens <= 0) {
             throw new IllegalArgumentException("tokens must be positive");
         }
@@ -90,5 +224,9 @@ public final class RedissonGcra extends RedissonExpirable implements RGcra {
                 .add(BigDecimal.valueOf(period.getNano(), 9))
                 .stripTrailingZeros()
                 .toPlainString();
+    }
+
+    static Duration fromSeconds(String seconds) {
+        return Duration.ofNanos(new BigDecimal(seconds).movePointRight(9).longValueExact());
     }
 }

--- a/redisson/src/main/java/org/redisson/api/GcraConfig.java
+++ b/redisson/src/main/java/org/redisson/api/GcraConfig.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2013-2026 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.api;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * Rate configuration of {@link RGcra} object.
+ *
+ * @author Nikita Koksharov
+ *
+ */
+public final class GcraConfig {
+
+    private final long maxBurst;
+    private final long tokensPerPeriod;
+    private final Duration period;
+
+    public GcraConfig(long maxBurst, long tokensPerPeriod, Duration period) {
+        this.maxBurst = maxBurst;
+        this.tokensPerPeriod = tokensPerPeriod;
+        this.period = period;
+    }
+
+    /**
+     * Returns maximum burst size set through
+     * {@link RGcra#trySetRate(long, long, Duration)} or {@link RGcra#setRate(long, long, Duration)} method.
+     *
+     * @return maximum burst size
+     */
+    public long getMaxBurst() {
+        return maxBurst;
+    }
+
+    /**
+     * Returns token replenishment rate per period set through
+     * {@link RGcra#trySetRate(long, long, Duration)} or {@link RGcra#setRate(long, long, Duration)} method.
+     *
+     * @return token amount replenished per period
+     */
+    public long getTokensPerPeriod() {
+        return tokensPerPeriod;
+    }
+
+    /**
+     * Returns replenishment period set through
+     * {@link RGcra#trySetRate(long, long, Duration)} or {@link RGcra#setRate(long, long, Duration)} method.
+     *
+     * @return replenishment period
+     */
+    public Duration getPeriod() {
+        return period;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        GcraConfig that = (GcraConfig) o;
+        return maxBurst == that.maxBurst
+                && tokensPerPeriod == that.tokensPerPeriod
+                && Objects.equals(period, that.period);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(maxBurst, tokensPerPeriod, period);
+    }
+
+    @Override
+    public String toString() {
+        return "GcraConfig{"
+                + "maxBurst=" + maxBurst
+                + ", tokensPerPeriod=" + tokensPerPeriod
+                + ", period=" + period
+                + '}';
+    }
+}

--- a/redisson/src/main/java/org/redisson/api/RGcra.java
+++ b/redisson/src/main/java/org/redisson/api/RGcra.java
@@ -28,13 +28,61 @@ import java.time.Duration;
 public interface RGcra extends RGcraAsync, RExpirable {
 
     /**
+     * Sets the rate configuration only if it hasn't been set before.
+     *
+     * @param maxBurst maximum burst size
+     * @param tokensPerPeriod token replenishment rate per period
+     * @param period replenishment period
+     * @return {@code true} if the rate was set, or {@code false} if it was already set before
+     */
+    boolean trySetRate(long maxBurst, long tokensPerPeriod, Duration period);
+
+    /**
+     * Sets the rate configuration overwriting the previous value and resetting the consumed tokens.
+     *
+     * @param maxBurst maximum burst size
+     * @param tokensPerPeriod token replenishment rate per period
+     * @param period replenishment period
+     */
+    void setRate(long maxBurst, long tokensPerPeriod, Duration period);
+
+    /**
+     * Returns the rate configuration set through
+     * {@link #trySetRate(long, long, Duration)} or {@link #setRate(long, long, Duration)} method.
+     *
+     * @return rate configuration or {@code null} if the rate wasn't set
+     */
+    GcraConfig getConfig();
+
+    /**
+     * Applies the GCRA algorithm with a single token request
+     * using the rate configuration set through
+     * {@link #trySetRate(long, long, Duration)} or {@link #setRate(long, long, Duration)} method.
+     *
+     * @return GCRA result
+     */
+    GcraResult tryAcquire();
+
+    /**
+     * Applies the GCRA algorithm with a custom token request size
+     * using the rate configuration set through
+     * {@link #trySetRate(long, long, Duration)} or {@link #setRate(long, long, Duration)} method.
+     *
+     * @param tokens requested token amount
+     * @return GCRA result
+     */
+    GcraResult tryAcquire(long tokens);
+
+    /**
      * Applies the GCRA algorithm with a single token request.
      *
      * @param maxBurst maximum burst size
      * @param tokensPerPeriod token replenishment rate per period
      * @param period replenishment period
      * @return GCRA result
+     * @deprecated use {@link #trySetRate(long, long, Duration)} with {@link #tryAcquire()} instead
      */
+    @Deprecated
     GcraResult tryAcquire(long maxBurst, long tokensPerPeriod, Duration period);
 
     /**
@@ -45,7 +93,9 @@ public interface RGcra extends RGcraAsync, RExpirable {
      * @param period replenishment period
      * @param tokens requested token amount
      * @return GCRA result
+     * @deprecated use {@link #trySetRate(long, long, Duration)} with {@link #tryAcquire(long)} instead
      */
+    @Deprecated
     GcraResult tryAcquire(long maxBurst, long tokensPerPeriod, Duration period, long tokens);
 
 }

--- a/redisson/src/main/java/org/redisson/api/RGcraAsync.java
+++ b/redisson/src/main/java/org/redisson/api/RGcraAsync.java
@@ -28,13 +28,62 @@ import java.time.Duration;
 public interface RGcraAsync extends RExpirableAsync {
 
     /**
+     * Sets the rate configuration only if it hasn't been set before.
+     *
+     * @param maxBurst maximum burst size
+     * @param tokensPerPeriod token replenishment rate per period
+     * @param period replenishment period
+     * @return {@code true} if the rate was set, or {@code false} if it was already set before
+     */
+    RFuture<Boolean> trySetRateAsync(long maxBurst, long tokensPerPeriod, Duration period);
+
+    /**
+     * Sets the rate configuration overwriting the previous value and resetting the consumed tokens.
+     *
+     * @param maxBurst maximum burst size
+     * @param tokensPerPeriod token replenishment rate per period
+     * @param period replenishment period
+     * @return void
+     */
+    RFuture<Void> setRateAsync(long maxBurst, long tokensPerPeriod, Duration period);
+
+    /**
+     * Returns the rate configuration set through
+     * {@link #trySetRateAsync(long, long, Duration)} or {@link #setRateAsync(long, long, Duration)} method.
+     *
+     * @return rate configuration or {@code null} if the rate wasn't set
+     */
+    RFuture<GcraConfig> getConfigAsync();
+
+    /**
+     * Applies the GCRA algorithm with a single token request
+     * using the rate configuration set through
+     * {@link #trySetRateAsync(long, long, Duration)} or {@link #setRateAsync(long, long, Duration)} method.
+     *
+     * @return GCRA result
+     */
+    RFuture<GcraResult> tryAcquireAsync();
+
+    /**
+     * Applies the GCRA algorithm with a custom token request size
+     * using the rate configuration set through
+     * {@link #trySetRateAsync(long, long, Duration)} or {@link #setRateAsync(long, long, Duration)} method.
+     *
+     * @param tokens requested token amount
+     * @return GCRA result
+     */
+    RFuture<GcraResult> tryAcquireAsync(long tokens);
+
+    /**
      * Applies the GCRA algorithm with a single token request.
      *
      * @param maxBurst maximum burst size
      * @param tokensPerPeriod token replenishment rate per period
      * @param period replenishment period
      * @return GCRA result
+     * @deprecated use {@link #trySetRateAsync(long, long, Duration)} with {@link #tryAcquireAsync()} instead
      */
+    @Deprecated
     RFuture<GcraResult> tryAcquireAsync(long maxBurst, long tokensPerPeriod, Duration period);
 
     /**
@@ -45,7 +94,9 @@ public interface RGcraAsync extends RExpirableAsync {
      * @param period replenishment period
      * @param tokens requested token amount
      * @return GCRA result
+     * @deprecated use {@link #trySetRateAsync(long, long, Duration)} with {@link #tryAcquireAsync(long)} instead
      */
+    @Deprecated
     RFuture<GcraResult> tryAcquireAsync(long maxBurst, long tokensPerPeriod, Duration period, long tokens);
 
 }

--- a/redisson/src/main/java/org/redisson/api/RGcraReactive.java
+++ b/redisson/src/main/java/org/redisson/api/RGcraReactive.java
@@ -30,13 +30,62 @@ import java.time.Duration;
 public interface RGcraReactive extends RExpirableReactive {
 
     /**
+     * Sets the rate configuration only if it hasn't been set before.
+     *
+     * @param maxBurst maximum burst size
+     * @param tokensPerPeriod token replenishment rate per period
+     * @param period replenishment period
+     * @return {@code true} if the rate was set, or {@code false} if it was already set before
+     */
+    Mono<Boolean> trySetRate(long maxBurst, long tokensPerPeriod, Duration period);
+
+    /**
+     * Sets the rate configuration overwriting the previous value and resetting the consumed tokens.
+     *
+     * @param maxBurst maximum burst size
+     * @param tokensPerPeriod token replenishment rate per period
+     * @param period replenishment period
+     * @return void
+     */
+    Mono<Void> setRate(long maxBurst, long tokensPerPeriod, Duration period);
+
+    /**
+     * Returns the rate configuration set through
+     * {@link #trySetRate(long, long, Duration)} or {@link #setRate(long, long, Duration)} method.
+     *
+     * @return rate configuration or {@code null} if the rate wasn't set
+     */
+    Mono<GcraConfig> getConfig();
+
+    /**
+     * Applies the GCRA algorithm with a single token request
+     * using the rate configuration set through
+     * {@link #trySetRate(long, long, Duration)} or {@link #setRate(long, long, Duration)} method.
+     *
+     * @return GCRA result
+     */
+    Mono<GcraResult> tryAcquire();
+
+    /**
+     * Applies the GCRA algorithm with a custom token request size
+     * using the rate configuration set through
+     * {@link #trySetRate(long, long, Duration)} or {@link #setRate(long, long, Duration)} method.
+     *
+     * @param tokens requested token amount
+     * @return GCRA result
+     */
+    Mono<GcraResult> tryAcquire(long tokens);
+
+    /**
      * Applies the GCRA algorithm with a single token request.
      *
      * @param maxBurst maximum burst size
      * @param tokensPerPeriod token replenishment rate per period
      * @param period replenishment period
      * @return GCRA result
+     * @deprecated use {@link #trySetRate(long, long, Duration)} with {@link #tryAcquire()} instead
      */
+    @Deprecated
     Mono<GcraResult> tryAcquire(long maxBurst, long tokensPerPeriod, Duration period);
 
     /**
@@ -47,7 +96,9 @@ public interface RGcraReactive extends RExpirableReactive {
      * @param period replenishment period
      * @param tokens requested token amount
      * @return GCRA result
+     * @deprecated use {@link #trySetRate(long, long, Duration)} with {@link #tryAcquire(long)} instead
      */
+    @Deprecated
     Mono<GcraResult> tryAcquire(long maxBurst, long tokensPerPeriod, Duration period, long tokens);
 
 }

--- a/redisson/src/main/java/org/redisson/api/RGcraRx.java
+++ b/redisson/src/main/java/org/redisson/api/RGcraRx.java
@@ -30,13 +30,62 @@ import java.time.Duration;
 public interface RGcraRx extends RExpirableRx {
 
     /**
+     * Sets the rate configuration only if it hasn't been set before.
+     *
+     * @param maxBurst maximum burst size
+     * @param tokensPerPeriod token replenishment rate per period
+     * @param period replenishment period
+     * @return {@code true} if the rate was set, or {@code false} if it was already set before
+     */
+    Single<Boolean> trySetRate(long maxBurst, long tokensPerPeriod, Duration period);
+
+    /**
+     * Sets the rate configuration overwriting the previous value and resetting the consumed tokens.
+     *
+     * @param maxBurst maximum burst size
+     * @param tokensPerPeriod token replenishment rate per period
+     * @param period replenishment period
+     * @return void
+     */
+    Single<Void> setRate(long maxBurst, long tokensPerPeriod, Duration period);
+
+    /**
+     * Returns the rate configuration set through
+     * {@link #trySetRate(long, long, Duration)} or {@link #setRate(long, long, Duration)} method.
+     *
+     * @return rate configuration or {@code null} if the rate wasn't set
+     */
+    Single<GcraConfig> getConfig();
+
+    /**
+     * Applies the GCRA algorithm with a single token request
+     * using the rate configuration set through
+     * {@link #trySetRate(long, long, Duration)} or {@link #setRate(long, long, Duration)} method.
+     *
+     * @return GCRA result
+     */
+    Single<GcraResult> tryAcquire();
+
+    /**
+     * Applies the GCRA algorithm with a custom token request size
+     * using the rate configuration set through
+     * {@link #trySetRate(long, long, Duration)} or {@link #setRate(long, long, Duration)} method.
+     *
+     * @param tokens requested token amount
+     * @return GCRA result
+     */
+    Single<GcraResult> tryAcquire(long tokens);
+
+    /**
      * Applies the GCRA algorithm with a single token request.
      *
      * @param maxBurst maximum burst size
      * @param tokensPerPeriod token replenishment rate per period
      * @param period replenishment period
      * @return GCRA result
+     * @deprecated use {@link #trySetRate(long, long, Duration)} with {@link #tryAcquire()} instead
      */
+    @Deprecated
     Single<GcraResult> tryAcquire(long maxBurst, long tokensPerPeriod, Duration period);
 
     /**
@@ -47,7 +96,9 @@ public interface RGcraRx extends RExpirableRx {
      * @param period replenishment period
      * @param tokens requested token amount
      * @return GCRA result
+     * @deprecated use {@link #trySetRate(long, long, Duration)} with {@link #tryAcquire(long)} instead
      */
+    @Deprecated
     Single<GcraResult> tryAcquire(long maxBurst, long tokensPerPeriod, Duration period, long tokens);
 
 }

--- a/redisson/src/test/java/org/redisson/RedissonGcraTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonGcraTest.java
@@ -1,8 +1,10 @@
 package org.redisson;
 
 import org.junit.jupiter.api.Test;
+import org.redisson.api.GcraConfig;
 import org.redisson.api.GcraResult;
 import org.redisson.api.RGcra;
+import org.redisson.client.RedisException;
 
 import java.time.Duration;
 
@@ -17,8 +19,121 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class RedissonGcraTest extends RedisDockerTest {
 
     @Test
+    public void testTrySetRate() {
+        RGcra gcra = redisson.getGcra("testTrySetRate");
+
+        assertThat(gcra.trySetRate(2, 4, Duration.ofSeconds(1))).isTrue();
+        assertThat(gcra.trySetRate(10, 20, Duration.ofSeconds(5))).isFalse();
+
+        GcraConfig config = gcra.getConfig();
+        assertThat(config.getMaxBurst()).isEqualTo(2);
+        assertThat(config.getTokensPerPeriod()).isEqualTo(4);
+        assertThat(config.getPeriod()).isEqualTo(Duration.ofSeconds(1));
+    }
+
+    @Test
     public void testTryAcquire() {
-        RGcra gcra = redisson.getGcra("test");
+        RGcra gcra = redisson.getGcra("testTryAcquire");
+        gcra.trySetRate(2, 4, Duration.ofSeconds(1));
+
+        GcraResult first = gcra.tryAcquire();
+        GcraResult second = gcra.tryAcquire();
+        GcraResult third = gcra.tryAcquire();
+        GcraResult fourth = gcra.tryAcquire();
+
+        assertThat(first.isLimited()).isFalse();
+        assertThat(second.isLimited()).isFalse();
+        assertThat(third.isLimited()).isFalse();
+        assertThat(fourth.isLimited()).isTrue();
+
+        assertThat(first.getMaxTokens()).isEqualTo(3);
+        assertThat(fourth.getMaxTokens()).isEqualTo(3);
+
+        assertThat(first.getRetryAfterSeconds()).isEqualTo(-1);
+        assertThat(fourth.getRetryAfterSeconds()).isGreaterThanOrEqualTo(0);
+    }
+
+    @Test
+    public void testTryAcquireWithTokens() {
+        RGcra gcra = redisson.getGcra("testTryAcquireWithTokens");
+        gcra.trySetRate(2, 4, Duration.ofMillis(250));
+
+        GcraResult result = gcra.tryAcquire(2);
+
+        assertThat(result.isLimited()).isFalse();
+        assertThat(result.getMaxTokens()).isEqualTo(3);
+        assertThat(result.getRetryAfterSeconds()).isEqualTo(-1);
+    }
+
+    @Test
+    public void testSetRate() {
+        RGcra gcra = redisson.getGcra("testSetRate");
+
+        gcra.trySetRate(2, 4, Duration.ofSeconds(1));
+        assertThat(gcra.tryAcquire().isLimited()).isFalse();
+        assertThat(gcra.tryAcquire().isLimited()).isFalse();
+        assertThat(gcra.tryAcquire().isLimited()).isFalse();
+        assertThat(gcra.tryAcquire().isLimited()).isTrue();
+
+        // overwrites the rate and resets the consumed tokens
+        gcra.setRate(5, 10, Duration.ofSeconds(2));
+
+        GcraConfig config = gcra.getConfig();
+        assertThat(config.getMaxBurst()).isEqualTo(5);
+        assertThat(config.getTokensPerPeriod()).isEqualTo(10);
+        assertThat(config.getPeriod()).isEqualTo(Duration.ofSeconds(2));
+
+        assertThat(gcra.tryAcquire().isLimited()).isFalse();
+    }
+
+    @Test
+    public void testGetConfigNotSet() {
+        RGcra gcra = redisson.getGcra("testGetConfigNotSet");
+
+        assertThat(gcra.getConfig()).isNull();
+    }
+
+    @Test
+    public void testTryAcquireRateNotSet() {
+        RGcra gcra = redisson.getGcra("testTryAcquireRateNotSet");
+
+        assertThatThrownBy(gcra::tryAcquire)
+                .isInstanceOf(RedisException.class)
+                .hasMessageContaining("GCRA rate is not set");
+    }
+
+    @Test
+    public void testValidation() {
+        RGcra gcra = redisson.getGcra("testValidation");
+
+        assertThatThrownBy(() -> gcra.trySetRate(-1, 1, Duration.ofSeconds(1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("maxBurst");
+        assertThatThrownBy(() -> gcra.trySetRate(1, 0, Duration.ofSeconds(1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("tokensPerPeriod");
+        assertThatThrownBy(() -> gcra.trySetRate(1, 1, Duration.ZERO))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("period");
+        assertThatThrownBy(() -> gcra.tryAcquire(0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("tokens");
+    }
+
+    @Test
+    public void testDelete() {
+        RGcra gcra = redisson.getGcra("testDelete");
+        gcra.trySetRate(2, 4, Duration.ofSeconds(1));
+        gcra.tryAcquire();
+
+        assertThat(gcra.delete()).isTrue();
+        assertThat(gcra.getConfig()).isNull();
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testDeprecatedTryAcquire() {
+        RGcra gcra = redisson.getGcra("testDeprecatedTryAcquire");
 
         GcraResult first = gcra.tryAcquire(2, 4, Duration.ofSeconds(1));
         GcraResult second = gcra.tryAcquire(2, 4, Duration.ofSeconds(1));
@@ -29,42 +144,5 @@ public class RedissonGcraTest extends RedisDockerTest {
         assertThat(second.isLimited()).isFalse();
         assertThat(third.isLimited()).isFalse();
         assertThat(fourth.isLimited()).isTrue();
-
-        assertThat(first.getMaxTokens()).isEqualTo(3);
-        assertThat(second.getMaxTokens()).isEqualTo(3);
-        assertThat(third.getMaxTokens()).isEqualTo(3);
-        assertThat(fourth.getMaxTokens()).isEqualTo(3);
-
-        assertThat(first.getRetryAfterSeconds()).isEqualTo(-1);
-        assertThat(fourth.getRetryAfterSeconds()).isGreaterThanOrEqualTo(0);
-    }
-
-    @Test
-    public void testTryAcquireWithTokens() {
-        RGcra gcra = redisson.getGcra("test");
-
-        GcraResult result = gcra.tryAcquire(2, 4, Duration.ofMillis(250), 2);
-
-        assertThat(result.isLimited()).isFalse();
-        assertThat(result.getMaxTokens()).isEqualTo(3);
-        assertThat(result.getRetryAfterSeconds()).isEqualTo(-1);
-    }
-
-    @Test
-    public void testValidation() {
-        RGcra gcra = redisson.getGcra("test");
-
-        assertThatThrownBy(() -> gcra.tryAcquire(-1, 1, Duration.ofSeconds(1)))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("maxBurst");
-        assertThatThrownBy(() -> gcra.tryAcquire(1, 0, Duration.ofSeconds(1)))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("tokensPerPeriod");
-        assertThatThrownBy(() -> gcra.tryAcquire(1, 1, Duration.ZERO))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("period");
-        assertThatThrownBy(() -> gcra.tryAcquire(1, 1, Duration.ofSeconds(1), 0))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("tokens");
     }
 }


### PR DESCRIPTION
Implements the `RGcra` API redesign requested in #7181.

### What changed

The rate (`maxBurst`, `tokensPerPeriod`, `period`) is now configured **once** and then consumed with a no-arg `tryAcquire()`, mirroring the existing `RRateLimiter` API:

```java
RGcra gcra = redisson.getGcra("myLimiter");

gcra.trySetRate(2, 4, Duration.ofSeconds(1)); // set once (only if absent)
GcraResult r = gcra.tryAcquire();             // single token
GcraResult b = gcra.tryAcquire(3);            // custom token amount
GcraConfig cfg = gcra.getConfig();
```

New methods (added to `RGcra`, `RGcraAsync`, `RGcraReactive`, `RGcraRx`):

- `boolean trySetRate(long maxBurst, long tokensPerPeriod, Duration period)` — set-if-absent
- `void setRate(long maxBurst, long tokensPerPeriod, Duration period)` — overwrite + reset consumed tokens
- `GcraConfig getConfig()` — new value type
- `GcraResult tryAcquire()` / `GcraResult tryAcquire(long tokens)`

### Design

- The rate is stored in a companion `{name}:config` hash (same slot as the object key); the native GCRA state stays in the object key.
- `tryAcquire()` reads the config and invokes the native `GCRA` command atomically inside a single Lua script, so it stays one round-trip.
- `setRate` resets state by deleting the GCRA key; `delete`/`expire`/`clearExpire` cover both keys.

### Backward compatibility

The previous `tryAcquire(maxBurst, tokensPerPeriod, period[, tokens])` methods are kept and marked `@Deprecated`, so existing code keeps compiling.

### Testing

`RedissonGcraTest` was extended to cover `trySetRate`/`setRate`/`getConfig`, the rate-not-set error, validation, and multi-key `delete`, plus the deprecated methods. All tests pass locally against the `redis:8.8-m03` image (the milestone that ships the `GCRA` command, as used for the original #7059).

Docs (`GCRA Rate Limiter` section) updated to the new API.