### PR TITLE
Remove redundant junit-bom import from redisson-spring-boot-starter (#7228)

### DIFF
--- a/redisson-spring/redisson-spring-boot-starter/pom.xml
+++ b/redisson-spring/redisson-spring-boot-starter/pom.xml
@@ -114,14 +114,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-
-            <dependency>
-                <groupId>org.junit</groupId>
-                <artifactId>junit-bom</artifactId>
-                <version>6.0.1</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## Description

When `redisson-spring-boot-starter` is consumed alongside `spring-boot-starter-parent` (Spring Boot 4.1), Maven emits an `Ignored POM import` warning for every managed JUnit artifact:

```
Ignored POM import for: org.junit.jupiter:junit-jupiter:jar:6.0.1@compile as already imported org.junit.jupiter:junit-jupiter:jar:6.0.3@compile.
```

The starter's `dependencyManagement` imports `spring-boot-dependencies` first, which already manages the JUnit BOM (`junit-bom` 6.0.3 for Spring Boot 4.1). The explicit `junit-bom` 6.0.1 import that follows is always overridden and ignored, so it only produces warning noise.

## Fix

Drop the redundant `junit-bom` import:

```diff
-            <dependency>
-                <groupId>org.junit</groupId>
-                <artifactId>junit-bom</artifactId>
-                <version>6.0.1</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
```

## Verification

`mvn -pl redisson-spring/redisson-spring-boot-starter -am dependency:tree` before and after the change: `junit-jupiter` still resolves to `6.0.3` (via `spring-boot-dependencies`), so the effective JUnit version is unchanged and the `Ignored POM import` warnings are gone.

Fixes #7228

## AI assistance disclosure

This fix was prepared with AI assistance. I verified the root cause and the resolved dependency versions by hand before opening the PR.
