### PR TITLE
Fixed - cluster monitor spams 'added slaves detected' when slaves aren't used #7113

### DIFF
--- a/redisson/src/main/java/org/redisson/connection/ClusterConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/ClusterConnectionManager.java
@@ -709,6 +709,10 @@ public class ClusterConnectionManager extends MasterSlaveConnectionManager {
             }
             
             if (config.isSlaveNotUsed()) {
+                // slaves aren't connected in this mode, but the partition state must still be
+                // updated so the same slaves aren't re-detected as added on every topology scan
+                currentPart.addSlaveAddress(uri);
+                currentPart.removeFailedSlaveAddress(uri);
                 continue;
             }
 


### PR DESCRIPTION
Fixes #7113

### Problem

When a cluster client is configured with `readMode = MASTER` and `subscriptionMode = MASTER` (i.e. `isSlaveNotUsed()` is `true`), the cluster monitor logs

```
added slaves detected for master ...
```

at `INFO` level for every master/slave pair on **every** topology scan (~5s), forever. It surfaces after a rolling Redis restart (e.g. in k8s) where slave node IP addresses change. The reporter noted the lines are identical and repeat, "so it feels like it's not persisting the slave changes" — which is exactly the cause. This is a regression that appeared around 4.3.0 (4.2.0 was fine).

### Root cause

In `ClusterConnectionManager.addRemoveSlaves(...)`, newly discovered slaves are collected into `addedSlaves` and processed. For the `isSlaveNotUsed()` case the loop simply `continue`s without connecting the slave — but it also never records the slave in `currentPart`:

```java
if (config.isSlaveNotUsed()) {
    continue;
}
```

`currentPart` (from `lastUri2Partition`) is the persistent per-master partition state whose slave-address set is compared against the freshly scanned partition on each cycle. Because the added slaves are never written back to `currentPart`, the next scan re-computes the same set as "added" and logs again — indefinitely. The regular (slaves-used) code paths do persist the change via `currentPart.addSlaveAddress(uri)` / `currentPart.removeFailedSlaveAddress(uri)` in their completion callbacks; only the slaves-not-used branch was missing it.

Note the initial partition stored in `lastUri2Partition` already carries slave addresses regardless of `isSlaveNotUsed()`, so keeping `currentPart` in sync here restores the intended invariant rather than introducing new state.

### Fix

Persist the discovered slaves into `currentPart` in the `isSlaveNotUsed()` branch, mirroring the other paths, so they are not re-detected as added on the next scan:

```java
if (config.isSlaveNotUsed()) {
    currentPart.addSlaveAddress(uri);
    currentPart.removeFailedSlaveAddress(uri);
    continue;
}
```

### Testing

Verified the module compiles and passes checkstyle. A deterministic automated repro requires a live cluster whose slave node IPs change across topology scans, which the docker-based cluster test harness (fixed IPs) cannot reproduce, so no unit test is added — consistent with prior cluster-topology fixes in this class.
