### PR TITLE
Fixed read lock watchdog renewal entry leak after reentrant unlock

### DIFF
--- a/redisson/src/main/java/org/redisson/renewal/ReadLockEntry.java
+++ b/redisson/src/main/java/org/redisson/renewal/ReadLockEntry.java
@@ -48,7 +48,7 @@ public class ReadLockEntry extends LockEntry {
         threadId2counter.computeIfPresent(threadId, (t, counter) -> {
             counter--;
             if (counter == 0) {
-                threadsQueue.remove(threadId);
+                threadsQueue.removeIf(v -> v == threadId);
                 threadId2lockName.remove(threadId);
                 threadId2keyPrefix.remove(threadId);
                 return null;

--- a/redisson/src/test/java/org/redisson/renewal/ReadLockEntryTest.java
+++ b/redisson/src/test/java/org/redisson/renewal/ReadLockEntryTest.java
@@ -1,0 +1,40 @@
+package org.redisson.renewal;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReadLockEntryTest {
+
+    @Test
+    void shouldHaveNoThreadsAfterNonReentrantAcquireAndRelease() {
+        ReadLockEntry entry = new ReadLockEntry();
+        long threadId = 1L;
+
+        entry.addThreadId(threadId, "lock", "prefix");
+        entry.removeThreadId(threadId);
+
+        assertThat(entry.hasNoThreads()).isTrue();
+        assertThat(entry.getFirstThreadId()).isNull();
+    }
+
+    @Test
+    void shouldHaveNoThreadsAfterReentrantAcquireAndRelease() {
+        ReadLockEntry entry = new ReadLockEntry();
+        long threadId = 1L;
+
+        // read lock acquired reentrantly by the same thread
+        entry.addThreadId(threadId, "lock", "prefix");
+        entry.addThreadId(threadId, "lock", "prefix");
+
+        // and fully released
+        entry.removeThreadId(threadId);
+        entry.removeThreadId(threadId);
+
+        // every acquire pushes the thread id onto the queue, so a full release
+        // must drop all occurrences - otherwise the renewal entry leaks and the
+        // watchdog keeps renewing a lock that is no longer held
+        assertThat(entry.hasNoThreads()).isTrue();
+        assertThat(entry.getFirstThreadId()).isNull();
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

The watchdog renewal entry for a **read lock** is never released after a reentrant read lock is fully unlocked, causing an unbounded client-side leak: the entry stays in `RenewalTask.name2entry` forever and the watchdog keeps sending renewal `EVAL`s to Redis for a lock that is no longer held.

### Root cause

`addThreadId` appends the thread id to `threadsQueue` on **every** acquire (`scheduleExpirationRenewal` runs per acquire, including reentrant ones). `LockEntry.removeThreadId` correctly drops **all** occurrences with `removeIf`, but the `ReadLockEntry` override removed only a **single** occurrence:

```java
// ReadLockEntry.removeThreadId (before)
threadsQueue.remove(threadId);        // Collection.remove(Object): removes ONE

// LockEntry.removeThreadId (parent, correct)
threadsQueue.removeIf(v -> v == threadId);   // removes ALL
```

So a read lock held reentrantly `N` times leaves `N-1` stale ids in the queue after a full release. `LockEntry.hasNoThreads()` then keeps returning `false`, so `RenewalTask.cancelExpirationRenewal` never removes the entry from `name2entry`, the watchdog `running` flag never clears, and renewal continues indefinitely.

### Reproduction

Single thread, watchdog (no explicit lease time):

```java
RReadWriteLock rw = redisson.getReadWriteLock("myLock");
RLock read = rw.readLock();
read.lock();
read.lock();     // reentrant
read.unlock();
read.unlock();   // fully released
// -> renewal entry for "myLock" is never removed; watchdog keeps renewing it
```

### Fix

Remove **all** occurrences of the thread id in `ReadLockEntry.removeThreadId`, mirroring `LockEntry.removeThreadId`.

### Tests

Added `ReadLockEntryTest` (pure unit test, no Redis required):
- `shouldHaveNoThreadsAfterReentrantAcquireAndRelease` — fails before the fix, passes after.
- `shouldHaveNoThreadsAfterNonReentrantAcquireAndRelease` — guards the non-reentrant path.