### PR TITLE
Fixed NPE when removing listeners from a never-subscribed RReliableTopic

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonReliableTopic.java
+++ b/redisson/src/main/java/org/redisson/RedissonReliableTopic.java
@@ -314,9 +314,18 @@ public final class RedissonReliableTopic extends RedissonExpirable implements RR
     }
 
     private RFuture<Void> removeSubscriber() {
-        subscribed.set(false);
-        readFuture.cancel(false);
-        timeoutTask.cancel();
+        if (!subscribed.compareAndSet(true, false)) {
+            return CompletableFutureWrapper.completedNull();
+        }
+
+        RFuture<Map<StreamMessageId, Map<String, Object>>> rf = readFuture;
+        if (rf != null) {
+            rf.cancel(false);
+        }
+        Timeout tt = timeoutTask;
+        if (tt != null) {
+            tt.cancel();
+        }
 
         return commandExecutor.evalWriteAsync(getRawName(), StringCodec.INSTANCE, RedisCommands.EVAL_VOID,
                 "redis.call('xgroup', 'destroy', KEYS[1], ARGV[1]); "

--- a/redisson/src/test/java/org/redisson/RedissonReliableTopicTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonReliableTopicTest.java
@@ -14,6 +14,7 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 /**
  *
@@ -21,6 +22,15 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  */
 public class RedissonReliableTopicTest extends RedisDockerTest {
+
+    @Test
+    public void testRemoveAllListenersOnNotSubscribedTopic() {
+        RReliableTopic topic = redisson.getReliableTopic("testRemoveAllFresh");
+
+        // no listener was ever added, so no subscription exists - removing
+        // listeners must be a no-op instead of throwing NullPointerException
+        assertThatNoException().isThrownBy(topic::removeAllListeners);
+    }
 
     @Test
     public void testConcurrency() throws InterruptedException {


### PR DESCRIPTION
### What problem does this PR solve?

Calling `removeAllListeners()` (or `removeListener(...)`) on an `RReliableTopic` that has **no active subscription** throws a `NullPointerException`:

```java
RReliableTopic topic = redisson.getReliableTopic("myTopic");
topic.removeAllListeners();   // NPE
```

```
java.lang.NullPointerException: Cannot invoke "org.redisson.api.RFuture.cancel(boolean)"
        because "this.readFuture" is null
    at org.redisson.RedissonReliableTopic.removeSubscriber(RedissonReliableTopic.java:318)
```

### Root cause

`removeSubscriber()` unconditionally cancels `readFuture` and `timeoutTask`:

```java
private RFuture<Void> removeSubscriber() {
    subscribed.set(false);
    readFuture.cancel(false);   // readFuture is null when never subscribed
    timeoutTask.cancel();       // timeoutTask is null too
    ...
}
```

But both fields are only assigned **after** the first `addListener(...)` starts a subscription (`readFuture` in `poll(...)`, `timeoutTask` in `renewExpiration()`). So on a topic that was never subscribed — or before the async subscription completes — they are still `null`. `removeAllListenersAsync()` and `removeListenerAsync(...)` (when the last listener is removed) both call `removeSubscriber()` without any guard.

### Fix

Make `removeSubscriber()` a no-op when there is no active subscription (using `subscribed.compareAndSet(true, false)`, which also makes a double removal safe), and null-guard the two futures to cover the window where a subscription has started but the async setup has not assigned them yet.

### Tests

Added `RedissonReliableTopicTest.testRemoveAllListenersOnNotSubscribedTopic` — fails with the NPE above before the change, passes after. The existing `RedissonReliableTopicTest` suite (subscribe / removeListener paths) still passes.