### PR TITLE
Drop inactive Redis connections from the free pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Upgrade to __[Redisson PRO](https://redisson.pro/feature-comparison.html)__ with
 
 ### 18-June-2026 - 4.6.1 released
 
+Fixed - ConnectionsHolder drops inactive channels instead of reusing them after bare channel close (thanks to @HarshDevelops)
 Fixed - ConnectionsHolder init-connection double release (thanks to @yipeng09)  
 Fixed - AsyncSemaphore.tryRun() over-increment on cancelled waiters (thanks to @yipeng09)  
 Fixed - AsyncSemaphore race condition  

--- a/redisson/src/main/java/org/redisson/client/handler/PingConnectionHandler.java
+++ b/redisson/src/main/java/org/redisson/client/handler/PingConnectionHandler.java
@@ -95,7 +95,9 @@ public class PingConnectionHandler extends ChannelInboundHandlerAdapter {
                     }
 
                     log.debug("channel: {} closed due to PING response timeout set in {} ms", ctx.channel(), config.getPingConnectionInterval());
-                    ctx.channel().close();
+                    // Mark the RedisConnection closed so the pool does not reuse an inactive channel.
+                    // See https://github.com/redisson/redisson/issues/7236
+                    connection.closeAsync();
                 } else {
                     sendPing(ctx);
                 }

--- a/redisson/src/main/java/org/redisson/connection/ConnectionsHolder.java
+++ b/redisson/src/main/java/org/redisson/connection/ConnectionsHolder.java
@@ -93,14 +93,15 @@ public class ConnectionsHolder<T extends RedisConnection> {
 
     private T pollConnection(RedisCommand<?> command) {
         int size = freeConnections.size();
+        int dropped = 0;
         for (int i = 0; i < size; i++) {
             T conn = freeConnections.poll();
             if (conn == null) {
                 return null;
             }
             if (conn.isActive()) {
-                if (i > 0) {
-                    log.debug("skipped connections with inactive channel: {}", i);
+                if (dropped > 0) {
+                    log.debug("dropped connections with inactive channel: {}", dropped);
                 }
                 if (changeUsage) {
                     conn.incUsage();
@@ -108,7 +109,14 @@ public class ConnectionsHolder<T extends RedisConnection> {
                 return conn;
             }
 
-            freeConnections.addLast(conn);
+            // Do not re-queue inactive channels: they can otherwise be borrowed again after
+            // a bare channel close (closed flag still false) and produce write timeouts.
+            // See https://github.com/redisson/redisson/issues/7236
+            allConnections.remove(conn);
+            if (!conn.isClosed()) {
+                conn.closeAsync();
+            }
+            dropped++;
         }
         return null;
     }
@@ -123,12 +131,19 @@ public class ConnectionsHolder<T extends RedisConnection> {
             return;
         }
 
-        connection.setLastUsageTime(System.nanoTime());
-        if (connection.isActive()) {
-            freeConnections.addFirst(connection);
-        } else {
-            freeConnections.addLast(connection);
+        if (!connection.isActive()) {
+            // Channel closed without RedisConnection.closeAsync() (e.g. PING timeout path).
+            // Drop it so it is not returned to the free pool.
+            allConnections.remove(connection);
+            connection.closeAsync();
+            if (changeUsage) {
+                connection.decUsage();
+            }
+            return;
         }
+
+        connection.setLastUsageTime(System.nanoTime());
+        freeConnections.addFirst(connection);
         if (changeUsage) {
             connection.decUsage();
         }

--- a/redisson/src/test/java/org/redisson/connection/ConnectionsHolderTest.java
+++ b/redisson/src/test/java/org/redisson/connection/ConnectionsHolderTest.java
@@ -1,5 +1,6 @@
 package org.redisson.connection;
 
+import io.netty.channel.embedded.EmbeddedChannel;
 import mockit.Mocked;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -72,6 +73,80 @@ public class ConnectionsHolderTest {
             // returns to the pool max — never inflated above it, which would jam idle eviction
             Assertions.assertThat(counter.getCounter()).isEqualTo(poolMaxSize);
             Assertions.assertThat(holder.getFreeConnections()).hasSize(poolMaxSize);
+        } finally {
+            manager.shutdown(0, 0, TimeUnit.SECONDS);
+        }
+    }
+
+    /**
+     * Inactive free-pool entries (channel closed without RedisConnection.closeAsync)
+     * must be discarded, not re-queued for reuse. See redisson/redisson#7236.
+     */
+    @Test
+    void testInactiveConnectionDroppedFromFreePoolOnPoll() throws Exception {
+        MasterSlaveConnectionManager manager = buildManager();
+        try {
+            EmbeddedChannel channel = new EmbeddedChannel();
+            RedisConnection connection = new RedisConnection(null, channel, new CompletableFuture<>());
+            channel.close().syncUninterruptibly();
+            Assertions.assertThat(connection.isActive()).isFalse();
+            Assertions.assertThat(connection.isClosed()).isFalse();
+
+            Function<RedisClient, CompletionStage<RedisConnection>> failingCallback = r -> {
+                CompletableFuture<RedisConnection> f = new CompletableFuture<>();
+                f.completeExceptionally(new RuntimeException("no new connection"));
+                return f;
+            };
+            ConnectionsHolder<RedisConnection> holder =
+                    new ConnectionsHolder<>(null, 2, failingCallback, manager.getServiceManager(), true);
+            holder.getFreeConnections().add(connection);
+            holder.getAllConnections().add(connection);
+
+            CompletableFuture<RedisConnection> acquired = holder.acquireConnection(null);
+            try {
+                acquired.get(2, TimeUnit.SECONDS);
+                Assertions.fail("expected acquire to fail after dropping inactive connection");
+            } catch (Exception expected) {
+                // createConnection fails after inactive free entry is dropped
+            }
+
+            Assertions.assertThat(holder.getFreeConnections()).doesNotContain(connection);
+            Assertions.assertThat(holder.getAllConnections()).doesNotContain(connection);
+            Assertions.assertThat(connection.isClosed()).isTrue();
+        } finally {
+            manager.shutdown(0, 0, TimeUnit.SECONDS);
+        }
+    }
+
+    /**
+     * Releasing an inactive connection must not return it to the free pool.
+     */
+    @Test
+    void testInactiveConnectionNotReleasedToFreePool(@Mocked RedisClient redisClient) throws Exception {
+        MasterSlaveConnectionManager manager = buildManager();
+        try {
+            EmbeddedChannel channel = new EmbeddedChannel();
+            RedisConnection connection = new RedisConnection(null, channel, new CompletableFuture<>());
+            connection.incUsage();
+            channel.close().syncUninterruptibly();
+            Assertions.assertThat(connection.isActive()).isFalse();
+            Assertions.assertThat(connection.isClosed()).isFalse();
+
+            ConnectionsHolder<RedisConnection> holder =
+                    new ConnectionsHolder<>(null, 2, r -> new CompletableFuture<>(),
+                            manager.getServiceManager(), true);
+            holder.getAllConnections().add(connection);
+
+            MasterSlaveServersConfig msConfig = new MasterSlaveServersConfig();
+            msConfig.setSubscriptionConnectionPoolSize(0);
+            msConfig.setSubscriptionConnectionMinimumIdleSize(0);
+            ClientConnectionsEntry entry = new ClientConnectionsEntry(
+                    redisClient, 0, 2, manager, org.redisson.api.NodeType.MASTER, msConfig);
+            holder.releaseConnection(entry, connection);
+
+            Assertions.assertThat(holder.getFreeConnections()).doesNotContain(connection);
+            Assertions.assertThat(holder.getAllConnections()).doesNotContain(connection);
+            Assertions.assertThat(connection.isClosed()).isTrue();
         } finally {
             manager.shutdown(0, 0, TimeUnit.SECONDS);
         }


### PR DESCRIPTION
Fixes #7236

## What was wrong

When a Netty channel was closed without RedisConnection.closeAsync() (for example after a PING timeout), RedisConnection.closed stayed false while isActive() became false. ConnectionsHolder still put those entries back into the free pool. They could be borrowed again, and later writes failed with write timeouts.

## What changed

ConnectionsHolder now discards inactive free-pool entries and marks them closed instead of re-queueing them. PingConnectionHandler closes the RedisConnection (not only the channel) on PING timeout so the closed flag is set.

## Testing

- RED: ConnectionsHolderTest inactive-connection tests fail without the pool change
- GREEN: mvn -pl redisson -Dtest=ConnectionsHolderTest test - 4 tests, 0 failures (JDK 25)
- Signed-off-by (DCO)