### PR TITLE
Fix: Avoid waking connection waiters on Netty event loop

### DIFF
--- a/redisson/src/main/java/org/redisson/connection/ConnectionsHolder.java
+++ b/redisson/src/main/java/org/redisson/connection/ConnectionsHolder.java
@@ -56,7 +56,7 @@ public class ConnectionsHolder<T extends RedisConnection> {
     public ConnectionsHolder(RedisClient client, int poolMaxSize,
                              Function<RedisClient, CompletionStage<T>> connectionCallback,
                              ServiceManager serviceManager, boolean changeUsage) {
-        this.freeConnectionsCounter = new AsyncSemaphore(poolMaxSize, serviceManager.getGroup());
+        this.freeConnectionsCounter = new AsyncSemaphore(poolMaxSize, serviceManager.getExecutor());
         this.client = client;
         this.connectionCallback = connectionCallback;
         this.serviceManager = serviceManager;

--- a/redisson/src/main/java/org/redisson/misc/AsyncSemaphore.java
+++ b/redisson/src/main/java/org/redisson/misc/AsyncSemaphore.java
@@ -17,6 +17,7 @@ package org.redisson.misc;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -120,7 +121,18 @@ public final class AsyncSemaphore {
 
     public void release() {
         counter.incrementAndGet();
-        tryForkAndRun();
+        if (listeners.isEmpty()) {
+            return;
+        }
+        if (executorService != null) {
+            try {
+                executorService.execute(this::tryRun);
+                return;
+            } catch (RejectedExecutionException e) {
+                // fallback to the caller thread during shutdown
+            }
+        }
+        tryRun();
     }
 
     @Override

--- a/redisson/src/test/java/org/redisson/RedissonTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonTest.java
@@ -1446,4 +1446,60 @@ public class RedissonTest extends RedisDockerTest {
         });
     }
 
+    @Test
+    public void testConnectionReleaseDoesNotCauseCommandWriteTimeout() throws Exception {
+        String key = "testConnectionReleaseDoesNotCauseCommandWriteTimeout";
+        redisson.getBucket(key).set("value");
+
+        Config c = createConfig();
+        c.setNettyThreads(1);
+        c.useSingleServer()
+                .setConnectionPoolSize(2)
+                .setConnectionMinimumIdleSize(2)
+                .setRetryAttempts(0)
+                .setTimeout(500)
+                .setPingConnectionInterval(0);
+
+        RedissonClient r = Redisson.create(c);
+        CountDownLatch waiterCallbackStarted = new CountDownLatch(1);
+        CountDownLatch unblockRelease = new CountDownLatch(1);
+        try {
+            ConnectionManager connectionManager = Reflect.on(r).get("connectionManager");
+            MasterSlaveEntry masterSlaveEntry = connectionManager.getEntry(0);
+            ClientConnectionsEntry entry = masterSlaveEntry.getEntry();
+            ConnectionsHolder<RedisConnection> holder = entry.getConnectionsHolder();
+            RedisConnection connection1 = holder.acquireConnection(RedisCommands.GET).get(3, TimeUnit.SECONDS);
+            RedisConnection connection2 = holder.acquireConnection(RedisCommands.GET).get(3, TimeUnit.SECONDS);
+
+            CompletableFuture<RedisConnection> waiter = holder.acquireConnection(RedisCommands.GET);
+            waiter.whenComplete((connection, ex) -> {
+                waiterCallbackStarted.countDown();
+                try {
+                    unblockRelease.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                if (connection != null) {
+                    holder.releaseConnection(entry, connection);
+                }
+            });
+
+            CompletableFuture<Void> releaseStarted = new CompletableFuture<>();
+            connectionManager.getServiceManager().getGroup().next().execute(() -> {
+                releaseStarted.complete(null);
+                holder.releaseConnection(entry, connection1);
+            });
+            releaseStarted.get(1, TimeUnit.SECONDS);
+            assertThat(waiterCallbackStarted.await(1, TimeUnit.SECONDS)).isTrue();
+
+            holder.releaseConnection(entry, connection2);
+
+            RBucket<String> bucket = r.getBucket(key);
+            assertThat(bucket.get()).isEqualTo("value");
+        } finally {
+            unblockRelease.countDown();
+            r.shutdown();
+        }
+    }
+
 }

--- a/redisson/src/test/java/org/redisson/connection/ConnectionsHolderTest.java
+++ b/redisson/src/test/java/org/redisson/connection/ConnectionsHolderTest.java
@@ -12,6 +12,9 @@ import org.redisson.misc.AsyncSemaphore;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
@@ -19,12 +22,63 @@ import java.util.function.Function;
 public class ConnectionsHolderTest {
 
     private MasterSlaveConnectionManager buildManager() {
+        return buildManager(null);
+    }
+
+    private MasterSlaveConnectionManager buildManager(ThreadPoolExecutor executor) {
         Config config = new Config();
         config.setLazyInitialization(true);
+        if (executor != null) {
+            config.setExecutor(executor);
+        }
         MasterSlaveServersConfig msConfig = config.useMasterSlaveServers();
         msConfig.setMasterAddress("redis://127.0.0.1:6379");
         msConfig.setReadMode(ReadMode.MASTER);
         return new MasterSlaveConnectionManager(msConfig, config);
+    }
+
+    @Test
+    void testConnectionCounterUsesServiceExecutorToWakeWaiter() throws Exception {
+        ThreadPoolExecutor executor = new ThreadPoolExecutor(1, 1, 0, TimeUnit.MILLISECONDS,
+                new LinkedBlockingQueue<>());
+        CountDownLatch taskStarted = new CountDownLatch(1);
+        CountDownLatch unblock = new CountDownLatch(1);
+        MasterSlaveConnectionManager manager = buildManager(executor);
+        try {
+            executor.execute(() -> {
+                taskStarted.countDown();
+                try {
+                    unblock.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+            Assertions.assertThat(taskStarted.await(1, TimeUnit.SECONDS)).isTrue();
+
+            ConnectionsHolder<RedisConnection> holder =
+                    new ConnectionsHolder<>(null, 1, r -> new CompletableFuture<>(), manager.getServiceManager(), false);
+            AsyncSemaphore counter = holder.getFreeConnectionsCounter();
+
+            CompletableFuture<Void> acquired = counter.acquire();
+            Assertions.assertThat(acquired).isCompleted();
+
+            CompletableFuture<Void> waiter = counter.acquire();
+            Assertions.assertThat(waiter).isNotDone();
+
+            counter.release();
+
+            Assertions.assertThat(waiter).isNotDone();
+            Assertions.assertThat(executor.getQueue()).hasSize(1);
+
+            unblock.countDown();
+
+            waiter.get(1, TimeUnit.SECONDS);
+            Assertions.assertThat(waiter).isCompleted();
+        } finally {
+            unblock.countDown();
+            manager.shutdown(0, 0, TimeUnit.SECONDS);
+            executor.shutdownNow();
+        }
     }
 
     @Test
@@ -76,4 +130,5 @@ public class ConnectionsHolderTest {
             manager.shutdown(0, 0, TimeUnit.SECONDS);
         }
     }
+
 }

--- a/redisson/src/test/java/org/redisson/misc/AsyncSemaphoreTest.java
+++ b/redisson/src/test/java/org/redisson/misc/AsyncSemaphoreTest.java
@@ -7,8 +7,56 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 public class AsyncSemaphoreTest {
+
+    @Test
+    void testReleaseWithExecutorCompletesWaiterAsynchronously() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        CountDownLatch taskStarted = new CountDownLatch(1);
+        CountDownLatch unblock = new CountDownLatch(1);
+
+        try {
+            executor.execute(() -> {
+                taskStarted.countDown();
+                try {
+                    unblock.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+            assertThat(taskStarted.await(1, TimeUnit.SECONDS)).isTrue();
+
+            AsyncSemaphore semaphore = new AsyncSemaphore(0, executor);
+
+            CompletableFuture<Void> waiter = semaphore.acquire();
+            semaphore.release();
+
+            assertThat(waiter).isNotDone();
+
+            unblock.countDown();
+            waiter.get(1, TimeUnit.SECONDS);
+
+            assertThat(waiter).isCompleted();
+        } finally {
+            unblock.countDown();
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void testReleaseFallsBackIfExecutorRejectsWakeup() {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        executor.shutdown();
+        AsyncSemaphore semaphore = new AsyncSemaphore(0, executor);
+
+        CompletableFuture<Void> waiter = semaphore.acquire();
+
+        assertThatCode(semaphore::release).doesNotThrowAnyException();
+        assertThat(waiter).isCompleted();
+        assertThat(semaphore.getCounter()).isZero();
+    }
 
     @RepeatedTest(2)
     void testReleaseRacingAcquire() throws Exception {


### PR DESCRIPTION
## What problem does this PR solve?

Issue: https://github.com/redisson/redisson/issues/7155

Under high concurrency, especially when using Java virtual threads, Redisson may eventually throw:

`org.redisson.client.RedisTimeoutException: Command still hasn't been written into connection!`

## Root cause

The problem happens because connection release may run on a Netty event loop thread.

Before this change, `ConnectionsHolder` created the connection pool semaphore with the Netty event loop group as executor:

```
this.freeConnectionsCounter = new AsyncSemaphore(poolMaxSize, serviceManager.getGroup());
```

When release() is called, it directly execute `tryForkAndRun()`:

```
public void release() {
    counter.incrementAndGet();
    tryForkAndRun();
}
```

In the common case, tryForkAndRun() falls through to tryRun() on the caller thread. tryRun() polls the waiter queue:

```
CompletableFuture<Void> future = listeners.poll();
```

The queue is based on `FastRemovalQueue`, with virtual threads and high concurrency, many acquire/release operations can compete for this lock. If the Netty event loop thread gets blocked while releasing a connection, pending Netty write tasks cannot be processed in time, which can finally lead to command timeout.

  ## Fix

The fix is to avoid doing waiter wakeup directly on the Netty event loop thread.

Connection waiters are now resumed through Redisson's worker executor. Also, release() now avoids touching the waiter queue when there are no waiting listeners.

```
this.freeConnectionsCounter = new AsyncSemaphore(poolMaxSize, serviceManager.getExecutor());
```

AsyncSemaphore.release() now schedules waiter processing through the configured executor:

```
public void release() {
    counter.incrementAndGet();
    if (listeners.isEmpty()) {
        return;
    }
    if (executorService != null) {
        try {
            executorService.execute(this::tryRun);
            return;
        } catch (RejectedExecutionException e) {
            // fallback to the caller thread during shutdown
        }
    }
    tryRun();
}
```

This keeps semaphore accounting unchanged, but prevents the normal connection release path from synchronously polling the waiter queue on a Netty event loop thread.

## Tests

Added regression tests for both `AsyncSemaphore` and connection pool behavior:

  - AsyncSemaphoreTest.testReleaseWithExecutorCompletesWaiterAsynchronously
    verifies that `release()` does not complete a queued waiter directly when an executor is configured

  - AsyncSemaphoreTest.testReleaseFallsBackIfExecutorRejectsWakeup
    verifies that executor rejection during shutdown does not throw exceptions and the permit is still released correctly

  - ConnectionsHolderTest.testConnectionCounterUsesServiceExecutorToWakeWaiter
    verifies that connection pool waiters are woken up through the service executor instead of running directly on the caller thread

Test command:

`mvn -pl redisson -Punit-test -DskipITs -Dtest=org.redisson.misc.AsyncSemaphoreTest,org.redisson.connection.ConnectionsHolderTest test`

