### PR TITLE
Poll every queue at least once before the pollFromAny timeout expires

### DIFF
--- a/redisson/src/main/java/org/redisson/client/protocol/RedisCommands.java
+++ b/redisson/src/main/java/org/redisson/client/protocol/RedisCommands.java
@@ -434,6 +434,10 @@ public interface RedisCommands {
     RedisCommand<Object> BZPOPMIN_VALUE = new RedisCommand<Object>("BZPOPMIN", new ScoredSortedSetPolledObjectDecoder());
     RedisCommand<Object> BZPOPMAX_VALUE = new RedisCommand<Object>("BZPOPMAX", new ScoredSortedSetPolledObjectDecoder());
 
+    // non-blocking counterparts, whose reply is [value, score] instead of [key, value, score]
+    RedisCommand<Object> ZPOPMIN_VALUE = new RedisCommand<Object>("ZPOPMIN", new ScoredSortedSetPolledObjectDecoder(0));
+    RedisCommand<Object> ZPOPMAX_VALUE = new RedisCommand<Object>("ZPOPMAX", new ScoredSortedSetPolledObjectDecoder(0));
+
     RedisCommand<org.redisson.api.Entry<String, Object>> BLPOP_NAME = new RedisCommand<>("BLPOP",
                     new ListObjectDecoder(0) {
                         @Override

--- a/redisson/src/main/java/org/redisson/client/protocol/decoder/ScoredSortedSetPolledObjectDecoder.java
+++ b/redisson/src/main/java/org/redisson/client/protocol/decoder/ScoredSortedSetPolledObjectDecoder.java
@@ -30,20 +30,37 @@ import org.redisson.client.protocol.Decoder;
  */
 public class ScoredSortedSetPolledObjectDecoder implements MultiDecoder<Object> {
 
+    private final int valueIndex;
+
+    /**
+     * Decodes the reply of a blocking poll, {@code [key, value, score]}.
+     */
+    public ScoredSortedSetPolledObjectDecoder() {
+        this(1);
+    }
+
+    /**
+     * @param valueIndex position of the value in the reply. Everything before it is a key
+     *                   decoded as a string, everything after it is a score decoded as a double.
+     */
+    public ScoredSortedSetPolledObjectDecoder(int valueIndex) {
+        this.valueIndex = valueIndex;
+    }
+
     @Override
     public Object decode(List<Object> parts, State state) {
         if (!parts.isEmpty()) {
-            return parts.get(1);
+            return parts.get(valueIndex);
         }
         return null;
     }
 
     @Override
     public Decoder<Object> getDecoder(Codec codec, int paramNum, State state, long size) {
-        if (paramNum == 0) {
+        if (paramNum < valueIndex) {
             return StringCodec.INSTANCE.getValueDecoder();
         }
-        if (paramNum == 2) {
+        if (paramNum > valueIndex) {
             return DoubleCodec.INSTANCE.getValueDecoder();
         }
         return MultiDecoder.super.getDecoder(codec, paramNum, state, size);

--- a/redisson/src/main/java/org/redisson/command/CommandAsyncService.java
+++ b/redisson/src/main/java/org/redisson/command/CommandAsyncService.java
@@ -69,6 +69,23 @@ public class CommandAsyncService implements CommandAsyncExecutor {
 
     static final Logger log = LoggerFactory.getLogger(CommandAsyncService.class);
 
+    /**
+     * Non-blocking counterpart of every blocking command that {@link #pollFromAnyAsync} rotates
+     * over, used to visit each name once before the rotation starts blocking.
+     */
+    private static final Map<RedisCommand<?>, RedisCommand<?>> NON_BLOCKING_POLL_COMMANDS = nonBlockingPollCommands();
+
+    private static Map<RedisCommand<?>, RedisCommand<?>> nonBlockingPollCommands() {
+        Map<RedisCommand<?>, RedisCommand<?>> commands = new IdentityHashMap<>();
+        commands.put(RedisCommands.BLPOP_VALUE, RedisCommands.LPOP);
+        commands.put(RedisCommands.BLPOP_NAME, RedisCommands.LPOP);
+        commands.put(RedisCommands.BRPOP_VALUE, RedisCommands.RPOP);
+        commands.put(RedisCommands.BRPOP_NAME, RedisCommands.RPOP);
+        commands.put(RedisCommands.BZPOPMIN_VALUE, RedisCommands.ZPOPMIN_VALUE);
+        commands.put(RedisCommands.BZPOPMAX_VALUE, RedisCommands.ZPOPMAX_VALUE);
+        return Collections.unmodifiableMap(commands);
+    }
+
     final Codec codec;
     final ConnectionManager connectionManager;
     final RedissonObjectBuilder objectBuilder;
@@ -998,13 +1015,27 @@ public class CommandAsyncService implements CommandAsyncExecutor {
     public <V> RFuture<V> pollFromAnyAsync(String name, Codec codec, RedisCommand<?> command, long secondsTimeout, String... queueNames) {
         List<String> mappedNames = Arrays.stream(queueNames).map(m -> connectionManager.getServiceManager().getNameMapper().map(m)).collect(Collectors.toList());
         if (getServiceManager().getCfg().isClusterConfig() && queueNames.length > 0) {
-            AtomicReference<Iterator<String>> ref = new AtomicReference<>();
             List<String> names = new ArrayList<>();
             names.add(name);
             names.addAll(mappedNames);
-            ref.set(names.iterator());
-            AtomicLong counter = new AtomicLong(secondsTimeout);
-            CompletionStage<V> result = poll(codec, ref, names, counter, command);
+
+            // On a cluster the names can live on different nodes, so one blocking command cannot
+            // cover them all and each name is polled in turn with a 1 second block. That makes the
+            // timeout a budget of attempts, and a timeout shorter than the number of names runs out
+            // before the last names are polled even once, hiding elements that are sitting in them.
+            // A single node does not behave that way, because BLPOP inspects every key before it
+            // blocks. Take one non-blocking pass over the names first to get the same reachability,
+            // then start the blocking rotation with the whole timeout still available.
+            CompletionStage<V> result = this.<V>sweep(codec, names, 0, command).thenCompose(res -> {
+                if (res != null) {
+                    return CompletableFuture.completedFuture(res);
+                }
+
+                AtomicReference<Iterator<String>> ref = new AtomicReference<>();
+                ref.set(names.iterator());
+                AtomicLong counter = new AtomicLong(secondsTimeout);
+                return this.<V>poll(codec, ref, names, counter, command);
+            });
             return new CompletableFutureWrapper<>(result);
         } else {
             List<Object> params = new ArrayList<>(queueNames.length + 1);
@@ -1013,6 +1044,29 @@ public class CommandAsyncService implements CommandAsyncExecutor {
             params.add(secondsTimeout);
             return writeAsync(name, codec, command, params.toArray());
         }
+    }
+
+    private <V> CompletionStage<V> sweep(Codec codec, List<String> names, int index, RedisCommand<?> command) {
+        RedisCommand<?> nonBlocking = NON_BLOCKING_POLL_COMMANDS.get(command);
+        if (nonBlocking == null || index >= names.size()) {
+            // a command without a non-blocking counterpart simply skips the pass and is left
+            // with the plain rotation, which still reaches every name when the timeout allows it
+            return CompletableFuture.completedFuture(null);
+        }
+
+        String currentName = names.get(index);
+        RFuture<Object> future = writeAsync(currentName, codec, nonBlocking, currentName);
+        return future.thenCompose(res -> {
+            if (res != null) {
+                if (command == RedisCommands.BLPOP_NAME || command == RedisCommands.BRPOP_NAME) {
+                    // the blocking commands report which name the element came from, the
+                    // non-blocking ones return the element alone and the name is known here
+                    return CompletableFuture.completedFuture((V) new org.redisson.api.Entry<>(currentName, res));
+                }
+                return CompletableFuture.completedFuture((V) res);
+            }
+            return this.<V>sweep(codec, names, index + 1, command);
+        });
     }
 
     private <V> CompletionStage<V> poll(Codec codec, AtomicReference<Iterator<String>> ref,

--- a/redisson/src/test/java/org/redisson/RedissonBlockingQueueTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonBlockingQueueTest.java
@@ -428,6 +428,70 @@ public class RedissonBlockingQueueTest extends RedissonQueueTest {
     }
 
     @Test
+    @Timeout(60)
+    public void testPollFromAnyWithNameReachesLastQueueOnCluster() {
+        // On a cluster every name is polled in turn with a 1 second block, so the timeout doubles
+        // as a budget of attempts. With a timeout shorter than the number of names the last ones
+        // were never polled at all and an element sitting there was reported as absent. A single
+        // node answers straight away here, because BLPOP inspects every key before it blocks.
+        testInCluster(client -> {
+            RBlockingQueue<String> first = client.getBlockingQueue("queue:clusterPollAny1");
+            RBlockingQueue<String> second = client.getBlockingQueue("queue:clusterPollAny2");
+            RBlockingQueue<String> third = client.getBlockingQueue("queue:clusterPollAny3");
+            first.clear();
+            second.clear();
+            third.clear();
+            // only the queue that the old rotation could never reach holds an element
+            third.add("hello");
+
+            long startTime = System.currentTimeMillis();
+            Entry<String, String> r;
+            try {
+                r = first.pollFromAnyWithName(Duration.ofSeconds(2),
+                        "queue:clusterPollAny2", "queue:clusterPollAny3");
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+
+            assertThat(r).isNotNull();
+            assertThat(r.getKey()).isEqualTo("queue:clusterPollAny3");
+            assertThat(r.getValue()).isEqualTo("hello");
+            // an element that is already there is returned without blocking on the names before it
+            assertThat(System.currentTimeMillis() - startTime).isLessThan(1000);
+        });
+    }
+
+    @Test
+    @Timeout(60)
+    public void testPollFromAnyWithNameStopsAtTimeoutOnCluster() {
+        // Reaching every name must not cost a blocking attempt per name, otherwise the timeout
+        // turns from an upper bound into a lower one: five empty names would keep a two second
+        // poll busy for five seconds. Contract is "waiting up to the specified wait time".
+        testInCluster(client -> {
+            String[] others = {"queue:clusterPollAnyEmpty2", "queue:clusterPollAnyEmpty3",
+                               "queue:clusterPollAnyEmpty4", "queue:clusterPollAnyEmpty5"};
+            RBlockingQueue<String> first = client.getBlockingQueue("queue:clusterPollAnyEmpty1");
+            first.clear();
+            for (String other : others) {
+                client.getBlockingQueue(other).clear();
+            }
+
+            long startTime = System.currentTimeMillis();
+            Entry<String, String> r;
+            try {
+                r = first.pollFromAnyWithName(Duration.ofSeconds(2), others);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+
+            assertThat(r).isNull();
+            assertThat(System.currentTimeMillis() - startTime).isBetween(1900L, 4000L);
+        });
+    }
+
+    @Test
     public void testPollLastFromAnyWithName() throws InterruptedException {
         RBlockingQueue<Integer> queue1 = redisson.getBlockingQueue("queue:polLast");
         RBlockingQueue<Integer> queue2 = redisson.getBlockingQueue("queue:polLast1");

--- a/redisson/src/test/java/org/redisson/RedissonScoredSortedSetTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonScoredSortedSetTest.java
@@ -171,6 +171,52 @@ public class RedissonScoredSortedSetTest extends RedisDockerTest {
     }
 
     @Test
+    public void testPollFirstFromAnyReachesLastSetOnCluster() {
+        // same rotation as RBlockingQueue.pollFromAny, so the last names have to stay reachable
+        // when the timeout is shorter than the number of names
+        testInCluster(client -> {
+            RScoredSortedSet<String> first = client.getScoredSortedSet("set:clusterPollAny1");
+            RScoredSortedSet<String> second = client.getScoredSortedSet("set:clusterPollAny2");
+            RScoredSortedSet<String> third = client.getScoredSortedSet("set:clusterPollAny3");
+            first.clear();
+            second.clear();
+            third.clear();
+            third.add(0.1, "hello");
+
+            long startTime = System.currentTimeMillis();
+            String value = first.pollFirstFromAny(2, TimeUnit.SECONDS,
+                    "set:clusterPollAny2", "set:clusterPollAny3");
+
+            assertThat(value).isEqualTo("hello");
+            assertThat(System.currentTimeMillis() - startTime).isLessThan(1000);
+        });
+    }
+
+    @Test
+    public void testPollLastFromAnyReachesLastSetOnCluster() {
+        testInCluster(client -> {
+            RScoredSortedSet<String> first = client.getScoredSortedSet("set:clusterPollLastAny1");
+            RScoredSortedSet<String> second = client.getScoredSortedSet("set:clusterPollLastAny2");
+            RScoredSortedSet<String> third = client.getScoredSortedSet("set:clusterPollLastAny3");
+            first.clear();
+            second.clear();
+            third.clear();
+            third.add(0.1, "lowest");
+            third.add(0.9, "highest");
+
+            String value = first.pollLastFromAny(2, TimeUnit.SECONDS,
+                    "set:clusterPollLastAny2", "set:clusterPollLastAny3");
+            // polled again rather than read back, because reads go to a replica by default
+            String next = first.pollLastFromAny(2, TimeUnit.SECONDS,
+                    "set:clusterPollLastAny2", "set:clusterPollLastAny3");
+
+            // the highest score first, and only one element per call
+            assertThat(value).isEqualTo("highest");
+            assertThat(next).isEqualTo("lowest");
+        });
+    }
+
+    @Test
     public void testPollFirstFromAnyCount() {
         RScoredSortedSet<Integer> queue1 = redisson.getScoredSortedSet("queue:pollany");
         RScoredSortedSet<Integer> queue2 = redisson.getScoredSortedSet("queue:pollany1");


### PR DESCRIPTION
Fixes #7256.

### Problem

On a cluster the queue names passed to `pollFromAny*` can hash to different nodes, so `BLPOP` cannot be issued for all of them at once. `CommandAsyncService.poll` visits the names in turn, blocking one second on each, and decrements a counter seeded with the requested timeout in seconds.

That makes the timeout a budget of attempts rather than a deadline. When the timeout is shorter than the number of names the budget runs out before the trailing names are polled even once, so an element sitting in one of them is reported as absent. In the reported case the caller polls `dummyName`, `emptyList` and `list` with a two second timeout: the rotation gives up after the first two and `list`, which holds the element, is never reached.

A single node does not behave this way, because `BLPOP` inspects every key before it blocks. This is a cluster-only discrepancy.

### Change

Do on the cluster path what `BLPOP` does natively on a single node: take one non-blocking pass over the names before the rotation starts blocking. Every name is then reachable however short the timeout is, and the timeout stays an upper bound because the pass does not wait on any name.

`poll` itself is byte for byte identical to master; the change is purely additive.

The pass needs the non-blocking counterpart of each blocking command that reaches this path:

| blocking | non-blocking | note |
| --- | --- | --- |
| `BLPOP_VALUE` | `LPOP` | same decoded shape |
| `BRPOP_VALUE` | `RPOP` | same decoded shape |
| `BLPOP_NAME` | `LPOP` | the name is the one the pass is visiting |
| `BRPOP_NAME` | `RPOP` | the name is the one the pass is visiting |
| `BZPOPMIN_VALUE` | `ZPOPMIN` | reply is `[value, score]`, not `[key, value, score]` |
| `BZPOPMAX_VALUE` | `ZPOPMAX` | reply is `[value, score]`, not `[key, value, score]` |

Only the sorted set pair needed anything new, and `ScoredSortedSetPolledObjectDecoder` already had the right shape, so it now takes the position of the value instead of hard coding `1`. At index `1` it decodes exactly as before.

### Scope

`CommandAsyncService#pollFromAnyAsync` is shared, so this affects more than `RBlockingQueue`: `RBlockingQueue.pollFromAny`, `pollFromAnyWithName` and `pollLastFromAnyWithName`, `RBoundedBlockingQueue` through delegation, `RBlockingDeque.pollLastFromAny`, and `RScoredSortedSet.pollFirstFromAny` and `pollLastFromAny`. All six get both the reachability fix and the faster return. The priority and transfer variants throw `UnsupportedOperationException` before reaching here and are unaffected.

An unmapped command would simply skip the pass and keep today's behaviour rather than break.

### Verification

Six node cluster from the existing `testInCluster` harness (`redis:latest`, resolving to 8.8.1 here), RESP2.

New tests, each confirmed to fail without the corresponding part of the fix:

- `testPollFromAnyWithNameReachesLastQueueOnCluster` — element only in the queue the rotation could not reach. Fails on master with `Expecting actual not to be null`.
- `testPollFirstFromAnyReachesLastSetOnCluster` and `testPollLastFromAnyReachesLastSetOnCluster` — same for the sorted set path, and they cover the new `ZPOPMIN`/`ZPOPMAX` decoding. Both fail on master.
- `testPollFromAnyWithNameStopsAtTimeoutOnCluster` — five empty names, two second timeout, asserts `null` within a bounded elapsed time. This is the guard for the opposite direction: if the poll ever stopped honouring the timeout as an upper bound, an all empty call would run long or hang and the suite would otherwise stay green.

Suites:

- `RedissonScoredSortedSetTest` — `Tests run: 123, Failures: 0, Errors: 0`.
- `RedissonBlockingQueueTest` — `Tests run: 36, Failures: 1`. The failure is `testPollLastAndOfferFirstTo`, which schedules a `put` at five seconds against a five second timeout. It fails the same way on an unmodified master checkout on this machine (`Tests run: 34, Failures: 1`, same test, 5.037 s), and it goes through `BRPOPLPUSH` via `writeAsync`, never entering `pollFromAnyAsync`. Unrelated to this change.
- `mvn -T 1C -B clean verify -DskipTests -Dmaven.test.skip=false`, the CI command: `BUILD SUCCESS`.

### Timing

Measured on the same cluster. All queues empty, so this is the worst case. The names reached on master follow from the counter arithmetic; the milliseconds are measured:

| names | timeout | master | after |
| --- | --- | --- | --- |
| 3 | 2 s | 2098 ms, 2 of 3 names reached | 2100 ms, all 3 reached |
| 10 | 2 s | 2 of 10 reached | 2112 ms, all 10 reached |
| 20 | 1 s | 1 of 20 reached | 1091 ms, all 20 reached |

And when the element is in the last name, which master never finds at these timeouts:

| names | timeout | after |
| --- | --- | --- |
| 3 | 2 s | 8 ms |
| 20 | 1 s | 26 ms |

The pass costs one round trip per name, not one second per name, so the timeout stays a bound as the name count grows. It also removes the wait on the success path: previously an element in the last of three names took about two seconds to surface even when the timeout was generous, because each earlier name was blocked on first.

The non-blocking commands are also outside `BLOCKING_COMMAND_NAMES`, so the pass does not occupy a connection from the blocking pool.
