### PR TITLE
Add missing permit acquisition

### DIFF
--- a/redisson/src/main/java/org/redisson/connection/ConnectionsHolder.java
+++ b/redisson/src/main/java/org/redisson/connection/ConnectionsHolder.java
@@ -208,7 +208,7 @@ public class ConnectionsHolder<T extends RedisConnection> {
             allConnections.add(conn);
 
             if (changeUsage) {
-                promise.thenApply(c -> c.incUsage());
+                conn.incUsage();
             }
             connectedSuccessful(promise, conn);
         });

--- a/redisson/src/test/java/org/redisson/connection/ConnectionsHolderTest.java
+++ b/redisson/src/test/java/org/redisson/connection/ConnectionsHolderTest.java
@@ -12,11 +12,24 @@ import org.redisson.misc.AsyncSemaphore;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 
 public class ConnectionsHolderTest {
+
+    private static final class ActiveConnection extends RedisConnection {
+
+        private ActiveConnection() {
+            super(null);
+        }
+
+        @Override
+        public boolean isActive() {
+            return true;
+        }
+    }
 
     private MasterSlaveConnectionManager buildManager() {
         Config config = new Config();
@@ -72,6 +85,34 @@ public class ConnectionsHolderTest {
             // returns to the pool max — never inflated above it, which would jam idle eviction
             Assertions.assertThat(counter.getCounter()).isEqualTo(poolMaxSize);
             Assertions.assertThat(holder.getFreeConnections()).hasSize(poolMaxSize);
+        } finally {
+            manager.shutdown(0, 0, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void testCancelledAcquisitionDoesNotLeaveReusedConnectionWithZeroUsage() {
+        MasterSlaveConnectionManager manager = buildManager();
+        try {
+            ActiveConnection connection = new ActiveConnection();
+            CompletableFuture<RedisConnection> physicalConnection = new CompletableFuture<>();
+            ConnectionsHolder<RedisConnection> holder = new ConnectionsHolder<>(null, 1,
+                    r -> physicalConnection, manager.getServiceManager(), true);
+
+            CompletableFuture<RedisConnection> firstAcquisition = holder.acquireConnection(null);
+
+            // Cancel future while physical socket connection is still in flight
+            firstAcquisition.completeExceptionally(new CancellationException("request cancelled"));
+            physicalConnection.complete(connection);
+
+            // ensure consumed permits = 0
+            Assertions.assertThat(connection.getUsage()).isZero();
+
+            // ensure we can still re-acquire the connection
+            CompletableFuture<RedisConnection> nextAcquisition = holder.acquireConnection(null);
+            Assertions.assertThat(nextAcquisition).isCompletedWithValue(connection);
+            // ... and it is correctly tracked
+            Assertions.assertThat(connection.getUsage()).isEqualTo(1);
         } finally {
             manager.shutdown(0, 0, TimeUnit.SECONDS);
         }


### PR DESCRIPTION
When a future returned by acquireConnection was cancelled before the underlying physical connection fully connected, we never incremented the usage counter. This could lead to a "double release" (really, a never-acquired -> release) which'd cause getUsage to start returning a negative counter.

To fix this, we make incUsage independent of the future resolving. If the future is already cancelled, `connectedSuccessful` will release the connection to the pool and thereby decrement usage again.

I discovered these inconsistent counters in a heapdump - I believe this may be the cause for connection pool exhaustion in our case, although I'm not certain.