### PR TITLE
Fixed - RReliableTopic listener reading consumer group state from a slave #7262

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonReliableTopic.java
+++ b/redisson/src/main/java/org/redisson/RedissonReliableTopic.java
@@ -18,7 +18,6 @@ package org.redisson;
 import io.netty.util.Timeout;
 import org.redisson.api.RFuture;
 import org.redisson.api.RReliableTopic;
-import org.redisson.api.RStream;
 import org.redisson.api.stream.StreamMessageId;
 import org.redisson.api.listener.MessageListener;
 import org.redisson.api.stream.StreamReadGroupArgs;
@@ -73,7 +72,7 @@ public final class RedissonReliableTopic extends RedissonExpirable implements RR
     private final String subscriberId;
     private volatile RFuture<Map<StreamMessageId, Map<String, Object>>> readFuture;
     private volatile Timeout timeoutTask;
-    private final RStream<String, Object> stream;
+    private final RedissonStream<String, Object> stream;
     private final AtomicBoolean subscribed = new AtomicBoolean();
     private final String timeoutName;
 
@@ -167,7 +166,7 @@ public final class RedissonReliableTopic extends RedissonExpirable implements RR
     }
 
     private void poll(String id) {
-        RFuture<Map<StreamMessageId, Map<String, Object>>> f = stream.pendingRangeAsync(id, StreamMessageId.MIN, StreamMessageId.MAX, 100);
+        RFuture<Map<StreamMessageId, Map<String, Object>>> f = stream.pendingRangeFromMasterAsync(id, StreamMessageId.MIN, StreamMessageId.MAX, 100);
         CompletionStage<Map<StreamMessageId, Map<String, Object>>> ff = f.thenCompose(r -> {
             if (!subscribed.get()) {
                 return CompletableFuture.completedFuture(r);

--- a/redisson/src/main/java/org/redisson/RedissonStream.java
+++ b/redisson/src/main/java/org/redisson/RedissonStream.java
@@ -868,18 +868,32 @@ public class RedissonStream<K, V> extends RedissonExpirable implements RStream<K
     }
 
     private static final RedisCommand<Map<StreamMessageId, Map<Object, Object>>> EVAL_XRANGE = new RedisCommand("EVAL", RedisCommands.XRANGE.getReplayMultiDecoder());
-    
-    @Override
-    public RFuture<Map<StreamMessageId, Map<K, V>>> pendingRangeAsync(String groupName, StreamMessageId startId,
-            StreamMessageId endId, int count) {
-        return commandExecutor.evalReadAsync(getRawName(), codec, EVAL_XRANGE,
+
+    private static final String PENDING_RANGE_SCRIPT =
                 "local pendingData = redis.call('xpending', KEYS[1], ARGV[1], ARGV[2], ARGV[3], ARGV[4]);" +
                 "local result = {}; " +
                 "for i = 1, #pendingData, 1 do " +
                     "local value = redis.call('xrange', KEYS[1], pendingData[i][1], pendingData[i][1]);" +
-                    "table.insert(result, value[1]);" + 
+                    "table.insert(result, value[1]);" +
                 "end; " +
-                "return result;",
+                "return result;";
+
+    @Override
+    public RFuture<Map<StreamMessageId, Map<K, V>>> pendingRangeAsync(String groupName, StreamMessageId startId,
+            StreamMessageId endId, int count) {
+        return commandExecutor.evalReadAsync(getRawName(), codec, EVAL_XRANGE, PENDING_RANGE_SCRIPT,
+                Collections.<Object>singletonList(getRawName()),
+                groupName, startId, endId, count);
+    }
+
+    /**
+     * Same as {@link #pendingRangeAsync(String, StreamMessageId, StreamMessageId, int)}
+     * but always executed on the master node. Used by callers which read consumer group
+     * state they have just written themselves, where a replica may not have it yet.
+     */
+    RFuture<Map<StreamMessageId, Map<K, V>>> pendingRangeFromMasterAsync(String groupName, StreamMessageId startId,
+            StreamMessageId endId, int count) {
+        return commandExecutor.evalWriteAsync(getRawName(), codec, EVAL_XRANGE, PENDING_RANGE_SCRIPT,
                 Collections.<Object>singletonList(getRawName()),
                 groupName, startId, endId, count);
     }

--- a/redisson/src/main/java/org/redisson/RedissonStream.java
+++ b/redisson/src/main/java/org/redisson/RedissonStream.java
@@ -828,18 +828,32 @@ public class RedissonStream<K, V> extends RedissonExpirable implements RStream<K
     }
 
     private static final RedisCommand<Map<StreamMessageId, Map<Object, Object>>> EVAL_XRANGE = new RedisCommand("EVAL", RedisCommands.XRANGE.getReplayMultiDecoder());
-    
-    @Override
-    public RFuture<Map<StreamMessageId, Map<K, V>>> pendingRangeAsync(String groupName, StreamMessageId startId,
-            StreamMessageId endId, int count) {
-        return commandExecutor.evalReadAsync(getRawName(), codec, EVAL_XRANGE,
+
+    private static final String PENDING_RANGE_SCRIPT =
                 "local pendingData = redis.call('xpending', KEYS[1], ARGV[1], ARGV[2], ARGV[3], ARGV[4]);" +
                 "local result = {}; " +
                 "for i = 1, #pendingData, 1 do " +
                     "local value = redis.call('xrange', KEYS[1], pendingData[i][1], pendingData[i][1]);" +
-                    "table.insert(result, value[1]);" + 
+                    "table.insert(result, value[1]);" +
                 "end; " +
-                "return result;",
+                "return result;";
+
+    @Override
+    public RFuture<Map<StreamMessageId, Map<K, V>>> pendingRangeAsync(String groupName, StreamMessageId startId,
+            StreamMessageId endId, int count) {
+        return commandExecutor.evalReadAsync(getRawName(), codec, EVAL_XRANGE, PENDING_RANGE_SCRIPT,
+                Collections.<Object>singletonList(getRawName()),
+                groupName, startId, endId, count);
+    }
+
+    /**
+     * Same as {@link #pendingRangeAsync(String, StreamMessageId, StreamMessageId, int)}
+     * but always executed on the master node. Used by callers which read consumer group
+     * state they have just written themselves, where a replica may not have it yet.
+     */
+    RFuture<Map<StreamMessageId, Map<K, V>>> pendingRangeFromMasterAsync(String groupName, StreamMessageId startId,
+            StreamMessageId endId, int count) {
+        return commandExecutor.evalWriteAsync(getRawName(), codec, EVAL_XRANGE, PENDING_RANGE_SCRIPT,
                 Collections.<Object>singletonList(getRawName()),
                 groupName, startId, endId, count);
     }

--- a/redisson/src/test/java/org/redisson/RedissonReliableTopicTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonReliableTopicTest.java
@@ -6,7 +6,9 @@ import org.redisson.api.RReliableTopic;
 import org.redisson.api.RedissonClient;
 import org.redisson.api.listener.MessageListener;
 import org.redisson.config.Config;
+import org.testcontainers.containers.GenericContainer;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.Queue;
@@ -22,6 +24,37 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
  *
  */
 public class RedissonReliableTopicTest extends RedisDockerTest {
+
+    @Test
+    public void testSubscriberDoesNotReadConsumerGroupFromSlave() throws InterruptedException {
+        withSentinel((nodes, config) -> {
+            RedissonClient sentinelRedisson = Redisson.create(config);
+            try {
+                RReliableTopic rt = sentinelRedisson.getReliableTopic("testSlaveRead");
+                AtomicInteger counter = new AtomicInteger();
+                rt.addListener(Integer.class, (ch, m) -> counter.incrementAndGet());
+
+                assertThat(rt.publish(1)).isEqualTo(1);
+                Awaitility.await().atMost(Duration.ofSeconds(10))
+                        .untilAsserted(() -> assertThat(counter).hasValue(1));
+
+                // the subscriber reads the consumer group it has just created on the master,
+                // so none of its scripts may be executed on a slave
+                assertThat(commandStats(nodes.get(0))).contains("cmdstat_xpending:");
+                assertThat(commandStats(nodes.get(1))).doesNotContain("cmdstat_xpending:");
+            } finally {
+                sentinelRedisson.shutdown();
+            }
+        }, 1);
+    }
+
+    private String commandStats(GenericContainer<?> node) {
+        try {
+            return node.execInContainer("redis-cli", "info", "commandstats").getStdout();
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     @Test
     public void testRemoveAllListenersOnNotSubscribedTopic() {


### PR DESCRIPTION
Fixes #7262

### Problem

`RedissonReliableTopic.addListenerAsync()` creates the consumer group on the master:

```java
commandExecutor.evalWriteNoRetryAsync(... "redis.call('xgroup', 'create', KEYS[1], ARGV[2], ARGV[1], 'MKSTREAM');" ...)
```

and then immediately starts `poll()`, whose first call was

```java
stream.pendingRangeAsync(id, StreamMessageId.MIN, StreamMessageId.MAX, 100);
```

`RedissonStream.pendingRangeAsync()` uses `evalReadAsync`, so under the default
`ReadMode.SLAVE` that script runs on a replica. It reads consumer group state that this
same client wrote to the master microseconds earlier. If the group has not been replicated
yet, the replica answers `NOGROUP`, and `poll()` treats `NOGROUP` as terminal and returns
without logging. The listener is then permanently silent: it never issues `XREADGROUP`,
while the group and the timeout ZSET entry remain in place, so `publishAsync()` still counts
that subscriber via `xinfo groups` and reports a non-zero delivery count for a message no
one will read.

The rest of the subscriber loop (`XREADGROUP`, `XACK`, trimming, expiration renewal) already
runs on the master, so this one read was the only part of the loop that could see stale state.

### Change

`RedissonStream` gets a package-private `pendingRangeFromMasterAsync(...)` that runs the
existing XPENDING/XRANGE script through `evalWriteAsync`, and `RedissonReliableTopic.poll()`
uses it. The public `pendingRangeAsync(...)` API is unchanged, and the script itself is now a
constant shared by both so the two cannot drift apart.

### Verification

Local, JDK 17, Docker.

Added `RedissonReliableTopicTest#testSubscriberDoesNotReadConsumerGroupFromSlave`. It runs a
master plus one replica through the existing `withSentinel(...)` harness (default read mode),
adds a listener, publishes, waits for delivery, and then reads `INFO commandstats` from both
nodes. `cmdstat_xpending` must appear on the master and must not appear on the replica.

* with this change: `Tests run: 1, Failures: 0`
* negative control, only `poll()` reverted to `pendingRangeAsync`: `Tests run: 1, Failures: 1`,
  and the failure output shows the master's commandstats containing `xadd`, `xtrim`,
  `xreadgroup` but no `xpending` entry, i.e. the read had gone to the replica
* `RedissonReliableTopicTest`: `Tests run: 9, Failures: 0`
* `RedissonStreamTest`: `Tests run: 63, Failures: 0`
* full build with the CI command and the CI JDK (`mvn -T 1C -B clean verify -DskipTests
  -Dmaven.test.skip=false`, Temurin 25 as pinned in `.github/workflows/maven.yml`):
  `BUILD SUCCESS`, 78 modules, 0 Checkstyle violations, `pmd:pmd` and `pmd:cpd` clean.
  (An earlier run of the same command on JDK 17 stopped in pmd with `PmdRunnable:
  java.lang.StackOverflowError`; that reproduces on unmodified master with JDK 17, so it was a
  toolchain artefact and not something in this change.)

### Not included

The report also proposes not treating `NOGROUP` as terminal and cleaning up the phantom
subscriber when the group is really gone (for example after the topic key expires). Those
change observable behaviour of a live listener, so I left them out of this fix; happy to
follow up in a separate PR if you want them.

