### PR TITLE
Fix failed replica recovery during pool selection

### DIFF
--- a/redisson/src/main/java/org/redisson/connection/pool/ConnectionPool.java
+++ b/redisson/src/main/java/org/redisson/connection/pool/ConnectionPool.java
@@ -124,9 +124,7 @@ abstract class ConnectionPool<T extends RedisConnection> {
                     FailedNodeDetector detector = entry.getClient().getConfig().getFailedNodeDetector();
                     detector.onConnectFailed(e);
                     if (detector.isNodeFailed()) {
-                        log.error("Redis node {} has been marked as failed according to the detection logic defined in {}",
-                                        entry.getClient().getAddr(), detector);
-                        masterSlaveEntry.shutdownAndReconnectAsync(entry.getClient(), e);
+                        shutdownAndReconnect(entry, detector, e);
                     }
                 }
                 cancelableFuture.completeExceptionally(e);
@@ -147,11 +145,24 @@ abstract class ConnectionPool<T extends RedisConnection> {
     }
         
     private boolean isHealthy(ClientConnectionsEntry entry) {
-        if (entry.getNodeType() == NodeType.SLAVE
-                && entry.getClient().getConfig().getFailedNodeDetector().isNodeFailed()) {
+        if (entry.getNodeType() != NodeType.SLAVE) {
+            return true;
+        }
+
+        FailedNodeDetector detector = entry.getClient().getConfig().getFailedNodeDetector();
+        if (detector.isNodeFailed()) {
+            RedisConnectionException cause = new RedisConnectionException(
+                    "Redis node has been marked as failed according to the detection logic defined in " + detector);
+            shutdownAndReconnect(entry, detector, cause);
             return false;
         }
         return true;
+    }
+
+    private void shutdownAndReconnect(ClientConnectionsEntry entry, FailedNodeDetector detector, Throwable cause) {
+        log.error("Redis node {} has been marked as failed according to the detection logic defined in {}",
+                entry.getClient().getAddr(), detector);
+        masterSlaveEntry.shutdownAndReconnectAsync(entry.getClient(), cause);
     }
 
 }

--- a/redisson/src/main/java/org/redisson/connection/pool/ConnectionPool.java
+++ b/redisson/src/main/java/org/redisson/connection/pool/ConnectionPool.java
@@ -63,7 +63,20 @@ abstract class ConnectionPool<T extends RedisConnection> {
     public Tuple<CompletableFuture<T>, Throwable> getTuple(RedisCommand<?> command, boolean trackChanges) {
         Collection<ClientConnectionsEntry> entries = masterSlaveEntry.getAllEntries();
         List<ClientConnectionsEntry> entriesCopy = new ArrayList<>(entries);
-        entriesCopy.removeIf(n -> n.isFreezed() || !isHealthy(n));
+        entriesCopy.removeIf(entry -> {
+            if (entry.isFreezed()) {
+                return true;
+            }
+            if (isHealthy(entry)) {
+                return false;
+            }
+
+            FailedNodeDetector detector = entry.getClient().getConfig().getFailedNodeDetector();
+            RedisConnectionException cause = new RedisConnectionException(
+                    "Redis node has been marked as failed according to the detection logic defined in " + detector);
+            shutdownAndReconnect(entry, detector, cause);
+            return true;
+        });
         if (!entriesCopy.isEmpty()) {
             ClientConnectionsEntry entry = config.getLoadBalancer().getEntry(entriesCopy, command);
             if (entry != null) {
@@ -150,13 +163,7 @@ abstract class ConnectionPool<T extends RedisConnection> {
         }
 
         FailedNodeDetector detector = entry.getClient().getConfig().getFailedNodeDetector();
-        if (detector.isNodeFailed()) {
-            RedisConnectionException cause = new RedisConnectionException(
-                    "Redis node has been marked as failed according to the detection logic defined in " + detector);
-            shutdownAndReconnect(entry, detector, cause);
-            return false;
-        }
-        return true;
+        return !detector.isNodeFailed();
     }
 
     private void shutdownAndReconnect(ClientConnectionsEntry entry, FailedNodeDetector detector, Throwable cause) {

--- a/redisson/src/test/java/org/redisson/connection/pool/ConnectionPoolTest.java
+++ b/redisson/src/test/java/org/redisson/connection/pool/ConnectionPoolTest.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2013-2026 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.connection.pool;
+
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.Verifications;
+import org.junit.jupiter.api.Test;
+import org.redisson.api.NodeType;
+import org.redisson.client.FailedCommandsDetector;
+import org.redisson.client.RedisClient;
+import org.redisson.client.RedisClientConfig;
+import org.redisson.client.RedisConnection;
+import org.redisson.client.RedisConnectionException;
+import org.redisson.client.protocol.RedisCommands;
+import org.redisson.config.MasterSlaveServersConfig;
+import org.redisson.connection.ClientConnectionsEntry;
+import org.redisson.connection.ConnectionManager;
+import org.redisson.connection.MasterSlaveEntry;
+import org.redisson.misc.Tuple;
+
+import java.net.InetSocketAddress;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConnectionPoolTest {
+
+    @Test
+    void failedNodeDetectedDuringSelectionIsDisconnected(
+            @Mocked ConnectionManager connectionManager,
+            @Mocked MasterSlaveEntry masterSlaveEntry,
+            @Mocked ClientConnectionsEntry entry,
+            @Mocked RedisClient client,
+            @Mocked RedisClientConfig clientConfig) {
+        FailedCommandsDetector detector = new FailedCommandsDetector(10000, 1);
+        detector.onCommandFailed(new RedisConnectionException("test"));
+        InetSocketAddress address = new InetSocketAddress("127.0.0.1", 6379);
+
+        new Expectations() {{
+            masterSlaveEntry.getAllEntries();
+            result = Collections.singletonList(entry);
+            entry.isFreezed();
+            result = false;
+            entry.getNodeType();
+            result = NodeType.SLAVE;
+            entry.getClient();
+            result = client;
+            client.getConfig();
+            result = clientConfig;
+            clientConfig.getFailedNodeDetector();
+            result = detector;
+            client.getAddr();
+            result = address;
+            masterSlaveEntry.getClient();
+            result = client;
+        }};
+
+        SlaveConnectionPool pool = new SlaveConnectionPool(
+                new MasterSlaveServersConfig(), connectionManager, masterSlaveEntry);
+
+        Tuple<java.util.concurrent.CompletableFuture<RedisConnection>, Throwable> result =
+                pool.getTuple(RedisCommands.GET, false);
+
+        assertThat(result.getT1()).isNull();
+        assertThat(result.getT2()).isInstanceOf(RedisConnectionException.class);
+        new Verifications() {{
+            masterSlaveEntry.shutdownAndReconnectAsync(client, (Throwable) any);
+            times = 1;
+        }};
+    }
+}


### PR DESCRIPTION
Fixes #7265.

When `ConnectionPool.getTuple()` observes that a slave's failed-node detector has reached its threshold, start the same disconnect and reconnect flow already used for connection acquisition failures.

Previously, pool selection only filtered the entry from one candidate list. `FailedCommandsDetector.isNodeFailed()` clears the recorded failures when its threshold is reached, so the replica could become eligible again without ever being frozen or health-checked.

This change:

- centralizes the existing failure log and `shutdownAndReconnectAsync(...)` call;
- invokes that recovery path when selection detects an unhealthy slave; and
- adds a focused test that verifies selection initiates recovery and returns no failed entry.

Test:

```text
JAVA_HOME=<JDK 25> mvn -pl redisson -Punit-test -Dtest=ConnectionPoolTest test
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```
