### PR TITLE
Harden failed command detector accounting

### DIFF
--- a/redisson/src/main/java/org/redisson/client/FailedCommandsDetector.java
+++ b/redisson/src/main/java/org/redisson/client/FailedCommandsDetector.java
@@ -15,8 +15,12 @@
  */
 package org.redisson.client;
 
+import java.util.Map;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * Detects failed Redis node if it has reached specified amount of command execution errors
@@ -32,6 +36,8 @@ public class FailedCommandsDetector implements FailedNodeDetector {
     protected long failedCommandsLimit;
 
     private final ConcurrentNavigableMap<Long, Long> failedCommands = new ConcurrentSkipListMap<>();
+    private final AtomicLong failedCommandsCount = new AtomicLong();
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
 
     public FailedCommandsDetector() {
     }
@@ -90,25 +96,50 @@ public class FailedCommandsDetector implements FailedNodeDetector {
     }
 
     @Override
-    public synchronized void onCommandFailed(Throwable cause) {
-        failedCommands.merge(getCurrentTime(), 1L, Long::sum);
+    public void onCommandFailed(Throwable cause) {
+        lock.readLock().lock();
+        try {
+            failedCommands.merge(getCurrentTime(), 1L, Long::sum);
+            failedCommandsCount.incrementAndGet();
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
     @Override
-    public synchronized boolean isNodeFailed() {
+    public boolean isNodeFailed() {
         if (failedCommandsLimit == 0) {
             throw new IllegalArgumentException("failedCommandsLimit isn't set");
         }
 
-        long start = getCurrentTime() - checkInterval;
-        failedCommands.headMap(start).clear();
-
-        long failures = failedCommands.values().stream().mapToLong(Long::longValue).sum();
-        if (failures >= failedCommandsLimit) {
-            failedCommands.clear();
-            return true;
+        long failures = failedCommandsCount.get();
+        if (failures < failedCommandsLimit) {
+            Map.Entry<Long, Long> firstFailure = failedCommands.firstEntry();
+            long start = getCurrentTime() - checkInterval;
+            if (firstFailure == null || firstFailure.getKey() >= start) {
+                return false;
+            }
         }
-        return false;
+
+        lock.writeLock().lock();
+        try {
+            long start = getCurrentTime() - checkInterval;
+            ConcurrentNavigableMap<Long, Long> expiredCommands = failedCommands.headMap(start);
+            long expiredCommandsCount = expiredCommands.values().stream()
+                    .mapToLong(Long::longValue)
+                    .sum();
+            expiredCommands.clear();
+
+            failures = failedCommandsCount.addAndGet(-expiredCommandsCount);
+            if (failures >= failedCommandsLimit) {
+                failedCommands.clear();
+                failedCommandsCount.set(0);
+                return true;
+            }
+            return false;
+        } finally {
+            lock.writeLock().unlock();
+        }
     }
 
     protected long getCurrentTime() {

--- a/redisson/src/main/java/org/redisson/client/FailedCommandsDetector.java
+++ b/redisson/src/main/java/org/redisson/client/FailedCommandsDetector.java
@@ -15,8 +15,8 @@
  */
 package org.redisson.client;
 
-import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.NavigableMap;
+import java.util.TreeMap;
 
 /**
  * Detects failed Redis node if it has reached specified amount of command execution errors
@@ -31,7 +31,7 @@ public class FailedCommandsDetector implements FailedNodeDetector {
 
     protected long failedCommandsLimit;
 
-    private final Queue<Long> failedCommands = new ConcurrentLinkedQueue<>();
+    private final NavigableMap<Long, Long> failedCommands = new TreeMap<>();
 
     public FailedCommandsDetector() {
     }
@@ -90,8 +90,8 @@ public class FailedCommandsDetector implements FailedNodeDetector {
     }
 
     @Override
-    public void onCommandFailed(Throwable cause) {
-        failedCommands.add(getCurrentTime());
+    public synchronized void onCommandFailed(Throwable cause) {
+        failedCommands.merge(getCurrentTime(), 1L, Long::sum);
     }
 
     @Override
@@ -101,11 +101,10 @@ public class FailedCommandsDetector implements FailedNodeDetector {
         }
 
         long start = getCurrentTime() - checkInterval;
-        while (failedCommands.peek() != null && failedCommands.peek() < start) {
-            failedCommands.poll();
-        }
+        failedCommands.headMap(start).clear();
 
-        if (failedCommands.size() >= failedCommandsLimit) {
+        long failures = failedCommands.values().stream().mapToLong(Long::longValue).sum();
+        if (failures >= failedCommandsLimit) {
             failedCommands.clear();
             return true;
         }

--- a/redisson/src/main/java/org/redisson/client/FailedCommandsDetector.java
+++ b/redisson/src/main/java/org/redisson/client/FailedCommandsDetector.java
@@ -15,8 +15,8 @@
  */
 package org.redisson.client;
 
-import java.util.NavigableMap;
-import java.util.TreeMap;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 
 /**
  * Detects failed Redis node if it has reached specified amount of command execution errors
@@ -31,7 +31,7 @@ public class FailedCommandsDetector implements FailedNodeDetector {
 
     protected long failedCommandsLimit;
 
-    private final NavigableMap<Long, Long> failedCommands = new TreeMap<>();
+    private final ConcurrentNavigableMap<Long, Long> failedCommands = new ConcurrentSkipListMap<>();
 
     public FailedCommandsDetector() {
     }

--- a/redisson/src/main/java/org/redisson/client/FailedCommandsDetector.java
+++ b/redisson/src/main/java/org/redisson/client/FailedCommandsDetector.java
@@ -15,8 +15,8 @@
  */
 package org.redisson.client;
 
-import java.util.NavigableSet;
-import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
  * Detects failed Redis node if it has reached specified amount of command execution errors
@@ -31,7 +31,7 @@ public class FailedCommandsDetector implements FailedNodeDetector {
 
     protected long failedCommandsLimit;
 
-    private final NavigableSet<Long> failedCommands = new ConcurrentSkipListSet<>();
+    private final Queue<Long> failedCommands = new ConcurrentLinkedQueue<>();
 
     public FailedCommandsDetector() {
     }
@@ -91,23 +91,29 @@ public class FailedCommandsDetector implements FailedNodeDetector {
 
     @Override
     public void onCommandFailed(Throwable cause) {
-        failedCommands.add(System.currentTimeMillis());
+        failedCommands.add(getCurrentTime());
     }
 
     @Override
-    public boolean isNodeFailed() {
+    public synchronized boolean isNodeFailed() {
         if (failedCommandsLimit == 0) {
             throw new IllegalArgumentException("failedCommandsLimit isn't set");
         }
 
-        long start = System.currentTimeMillis() - checkInterval;
-        failedCommands.headSet(start).clear();
+        long start = getCurrentTime() - checkInterval;
+        while (failedCommands.peek() != null && failedCommands.peek() < start) {
+            failedCommands.poll();
+        }
 
-        if (failedCommands.tailSet(start).size() >= failedCommandsLimit) {
+        if (failedCommands.size() >= failedCommandsLimit) {
             failedCommands.clear();
             return true;
         }
         return false;
+    }
+
+    protected long getCurrentTime() {
+        return System.currentTimeMillis();
     }
 
     @Override

--- a/redisson/src/main/java/org/redisson/command/RedisExecutor.java
+++ b/redisson/src/main/java/org/redisson/command/RedisExecutor.java
@@ -703,7 +703,7 @@ public class RedisExecutor<V, R> {
         detector.onCommandFailed(cause);
         if (detector.isNodeFailed()) {
             log.error("Redis node {} has been marked as failed according to the detection logic defined in {}",
-                            entry.getClient().getAddr(), detector);
+                            client.getAddr(), detector);
             entry.shutdownAndReconnectAsync(client, cause);
         }
     }

--- a/redisson/src/test/java/org/redisson/client/FailedCommandsDetectorTest.java
+++ b/redisson/src/test/java/org/redisson/client/FailedCommandsDetectorTest.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2013-2026 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.client;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FailedCommandsDetectorTest {
+
+    @Test
+    void countsFailuresWithTheSameTimestamp() {
+        TestFailedCommandsDetector detector = new TestFailedCommandsDetector(1000, 3);
+
+        detector.onCommandFailed(new RedisTimeoutException("first"));
+        detector.onCommandFailed(new RedisTimeoutException("second"));
+        detector.onCommandFailed(new RedisTimeoutException("third"));
+
+        assertThat(detector.isNodeFailed()).isTrue();
+        assertThat(detector.isNodeFailed()).isFalse();
+    }
+
+    @Test
+    void removesFailuresOutsideTheCheckInterval() {
+        TestFailedCommandsDetector detector = new TestFailedCommandsDetector(1000, 2);
+        detector.onCommandFailed(new RedisTimeoutException("expired"));
+
+        detector.advanceTime(1001);
+        detector.onCommandFailed(new RedisTimeoutException("current"));
+
+        assertThat(detector.isNodeFailed()).isFalse();
+    }
+
+    @Test
+    void thresholdCanOnlyBeConsumedOnceConcurrently() throws Exception {
+        TestFailedCommandsDetector detector = new TestFailedCommandsDetector(1000, 1);
+        detector.onCommandFailed(new RedisTimeoutException("failed"));
+
+        int callers = 8;
+        ExecutorService executor = Executors.newFixedThreadPool(callers);
+        CountDownLatch ready = new CountDownLatch(callers);
+        CountDownLatch start = new CountDownLatch(1);
+        try {
+            List<Future<Boolean>> results = new ArrayList<>();
+            for (int i = 0; i < callers; i++) {
+                results.add(executor.submit(() -> {
+                    ready.countDown();
+                    start.await();
+                    return detector.isNodeFailed();
+                }));
+            }
+            ready.await();
+            start.countDown();
+
+            int failedTransitions = 0;
+            for (Future<Boolean> result : results) {
+                if (result.get()) {
+                    failedTransitions++;
+                }
+            }
+            assertThat(failedTransitions).isOne();
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private static final class TestFailedCommandsDetector extends FailedCommandsDetector {
+
+        private final AtomicLong time = new AtomicLong();
+
+        private TestFailedCommandsDetector(long checkInterval, int failedCommandsLimit) {
+            super(checkInterval, failedCommandsLimit);
+        }
+
+        @Override
+        protected long getCurrentTime() {
+            return time.get();
+        }
+
+        private void advanceTime(long delta) {
+            time.addAndGet(delta);
+        }
+    }
+}

--- a/redisson/src/test/java/org/redisson/client/FailedCommandsDetectorTest.java
+++ b/redisson/src/test/java/org/redisson/client/FailedCommandsDetectorTest.java
@@ -53,6 +53,19 @@ class FailedCommandsDetectorTest {
     }
 
     @Test
+    void removesExpiredFailuresInsertedAfterCurrentFailures() {
+        TestFailedCommandsDetector detector = new TestFailedCommandsDetector(1000, 2);
+        detector.setTime(1001);
+        detector.onCommandFailed(new RedisTimeoutException("current"));
+        detector.setTime(0);
+        detector.onCommandFailed(new RedisTimeoutException("expired"));
+
+        detector.setTime(1001);
+
+        assertThat(detector.isNodeFailed()).isFalse();
+    }
+
+    @Test
     void thresholdCanOnlyBeConsumedOnceConcurrently() throws Exception {
         TestFailedCommandsDetector detector = new TestFailedCommandsDetector(1000, 1);
         detector.onCommandFailed(new RedisTimeoutException("failed"));
@@ -100,6 +113,10 @@ class FailedCommandsDetectorTest {
 
         private void advanceTime(long delta) {
             time.addAndGet(delta);
+        }
+
+        private void setTime(long value) {
+            time.set(value);
         }
     }
 }

--- a/redisson/src/test/java/org/redisson/client/FailedCommandsDetectorTest.java
+++ b/redisson/src/test/java/org/redisson/client/FailedCommandsDetectorTest.java
@@ -19,15 +19,23 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class FailedCommandsDetectorTest {
+
+    private static final int CONCURRENT_CALLERS = 8;
+    private static final RedisTimeoutException FAILURE = new RedisTimeoutException("failed");
 
     @Test
     void countsFailuresWithTheSameTimestamp() {
@@ -42,13 +50,28 @@ class FailedCommandsDetectorTest {
     }
 
     @Test
-    void removesFailuresOutsideTheCheckInterval() {
+    void retainsFailuresAtTheCheckIntervalBoundary() {
+        TestFailedCommandsDetector detector = new TestFailedCommandsDetector(1000, 1);
+        detector.onCommandFailed(FAILURE);
+
+        detector.advanceTime(1000);
+
+        assertThat(detector.isNodeFailed()).isTrue();
+    }
+
+    @Test
+    void removesFailuresOutsideTheCheckIntervalAndKeepsCountConsistent() {
         TestFailedCommandsDetector detector = new TestFailedCommandsDetector(1000, 2);
         detector.onCommandFailed(new RedisTimeoutException("expired"));
 
         detector.advanceTime(1001);
         detector.onCommandFailed(new RedisTimeoutException("current"));
 
+        assertThat(detector.isNodeFailed()).isFalse();
+
+        detector.onCommandFailed(new RedisTimeoutException("second-current"));
+
+        assertThat(detector.isNodeFailed()).isTrue();
         assertThat(detector.isNodeFailed()).isFalse();
     }
 
@@ -63,42 +86,105 @@ class FailedCommandsDetectorTest {
         detector.setTime(1001);
 
         assertThat(detector.isNodeFailed()).isFalse();
+
+        detector.onCommandFailed(new RedisTimeoutException("second-current"));
+
+        assertThat(detector.isNodeFailed()).isTrue();
+    }
+
+    @Test
+    void commandFailuresCanBeRecordedConcurrently() throws Exception {
+        BlockingTimeDetector detector = new BlockingTimeDetector(1000, 2);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        detector.blockNextTimeRead();
+        try {
+            Future<?> first = executor.submit(() -> detector.onCommandFailed(FAILURE));
+            detector.awaitBlockedTimeRead();
+
+            Future<?> second = executor.submit(() -> detector.onCommandFailed(FAILURE));
+            second.get(5, TimeUnit.SECONDS);
+
+            detector.releaseTimeRead();
+            first.get(5, TimeUnit.SECONDS);
+
+            assertThat(detector.isNodeFailed()).isTrue();
+        } finally {
+            detector.releaseTimeRead();
+            executor.shutdownNow();
+        }
     }
 
     @Test
     void thresholdCanOnlyBeConsumedOnceConcurrently() throws Exception {
         TestFailedCommandsDetector detector = new TestFailedCommandsDetector(1000, 1);
-        detector.onCommandFailed(new RedisTimeoutException("failed"));
-
-        int callers = 8;
-        ExecutorService executor = Executors.newFixedThreadPool(callers);
-        CountDownLatch ready = new CountDownLatch(callers);
-        CountDownLatch start = new CountDownLatch(1);
+        detector.onCommandFailed(FAILURE);
+        ExecutorService executor = Executors.newFixedThreadPool(CONCURRENT_CALLERS);
         try {
-            List<Future<Boolean>> results = new ArrayList<>();
-            for (int i = 0; i < callers; i++) {
-                results.add(executor.submit(() -> {
-                    ready.countDown();
-                    start.await();
-                    return detector.isNodeFailed();
-                }));
-            }
-            ready.await();
-            start.countDown();
+            List<Boolean> results = runConcurrently(
+                    executor, CONCURRENT_CALLERS, detector::isNodeFailed);
 
-            int failedTransitions = 0;
-            for (Future<Boolean> result : results) {
-                if (result.get()) {
-                    failedTransitions++;
-                }
-            }
-            assertThat(failedTransitions).isOne();
+            assertThat(results.stream().filter(Boolean::booleanValue).count()).isOne();
+            assertThat(detector.isNodeFailed()).isFalse();
         } finally {
             executor.shutdownNow();
         }
     }
 
-    private static final class TestFailedCommandsDetector extends FailedCommandsDetector {
+    @Test
+    void failureWaitingForThresholdResetIsKeptForTheNextTransition() throws Exception {
+        BlockingTimeDetector detector = new BlockingTimeDetector(1000, 1);
+        detector.onCommandFailed(FAILURE);
+        detector.blockNextTimeRead();
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<Boolean> transition = executor.submit(detector::isNodeFailed);
+            detector.awaitBlockedTimeRead();
+
+            CountDownLatch writerStarted = new CountDownLatch(1);
+            Future<?> nextFailure = executor.submit(() -> {
+                writerStarted.countDown();
+                detector.onCommandFailed(FAILURE);
+            });
+            assertThat(writerStarted.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThatThrownBy(() -> nextFailure.get(1, TimeUnit.SECONDS))
+                    .isInstanceOf(TimeoutException.class);
+
+            detector.releaseTimeRead();
+
+            assertThat(transition.get(5, TimeUnit.SECONDS)).isTrue();
+            nextFailure.get(5, TimeUnit.SECONDS);
+            assertThat(detector.isNodeFailed()).isTrue();
+            assertThat(detector.isNodeFailed()).isFalse();
+        } finally {
+            detector.releaseTimeRead();
+            executor.shutdownNow();
+        }
+    }
+
+    private static <T> List<T> runConcurrently(
+            ExecutorService executor, int callers, Callable<T> task) throws Exception {
+        CountDownLatch ready = new CountDownLatch(callers);
+        CountDownLatch start = new CountDownLatch(1);
+        List<Future<T>> futures = new ArrayList<>();
+        for (int i = 0; i < callers; i++) {
+            futures.add(executor.submit(() -> {
+                ready.countDown();
+                start.await();
+                return task.call();
+            }));
+        }
+
+        assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+        start.countDown();
+
+        List<T> results = new ArrayList<>();
+        for (Future<T> future : futures) {
+            results.add(future.get(5, TimeUnit.SECONDS));
+        }
+        return results;
+    }
+
+    private static class TestFailedCommandsDetector extends FailedCommandsDetector {
 
         private final AtomicLong time = new AtomicLong();
 
@@ -119,4 +205,49 @@ class FailedCommandsDetectorTest {
             time.set(value);
         }
     }
+
+    private static final class BlockingTimeDetector extends TestFailedCommandsDetector {
+
+        private final AtomicBoolean blockNextTimeRead = new AtomicBoolean();
+        private volatile CountDownLatch blockedTimeRead;
+        private volatile CountDownLatch releaseTimeRead;
+
+        private BlockingTimeDetector(long checkInterval, int failedCommandsLimit) {
+            super(checkInterval, failedCommandsLimit);
+        }
+
+        private void blockNextTimeRead() {
+            blockedTimeRead = new CountDownLatch(1);
+            releaseTimeRead = new CountDownLatch(1);
+            blockNextTimeRead.set(true);
+        }
+
+        private void awaitBlockedTimeRead() throws InterruptedException {
+            assertThat(blockedTimeRead.await(5, TimeUnit.SECONDS)).isTrue();
+        }
+
+        private void releaseTimeRead() {
+            CountDownLatch release = releaseTimeRead;
+            if (release != null) {
+                release.countDown();
+            }
+        }
+
+        @Override
+        protected long getCurrentTime() {
+            if (blockNextTimeRead.compareAndSet(true, false)) {
+                blockedTimeRead.countDown();
+                try {
+                    if (!releaseTimeRead.await(5, TimeUnit.SECONDS)) {
+                        throw new AssertionError("Timed out waiting to release time read");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError(e);
+                }
+            }
+            return super.getCurrentTime();
+        }
+    }
+
 }


### PR DESCRIPTION
Fixes #7267.

This change hardens failed-command accounting and the diagnostics emitted when the threshold is reached:

- replaces the timestamp set with ordered per-millisecond counters so simultaneous failures are counted independently and expiration remains ordered;
- serializes failure recording, threshold evaluation, and reset so concurrent callers cannot consume the same transition more than once;
- retains rolling-window expiration and reset-after-threshold behavior;
- logs the actual failed connection client's address rather than the shard entry's primary address; and
- adds deterministic tests for duplicate timestamps, expiration, and concurrent threshold consumption.

A failed batch execution still contributes one detector signal. This patch does not weight a batch by its number of operations.

Test:

```text
JAVA_HOME=<JDK 25> mvn -pl redisson -Punit-test \
  -Dtest=FailedCommandsDetectorTest,FailedNodeDetectorCopyTest test
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
```
