### PR TITLE
Scope failed slave detector to replica clients

### DIFF
--- a/redisson/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
@@ -47,6 +47,8 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
 
     public static final int MAX_SLOT = 16384;
 
+    private static final FailedNodeDetector DEFAULT_FAILED_NODE_DETECTOR = new FailedConnectionDetector();
+
     protected final ClusterSlotRange singleSlotRange = new ClusterSlotRange(0, MAX_SLOT-1);
 
     private final Logger log = LoggerFactory.getLogger(getClass());
@@ -454,7 +456,7 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
     protected RedisClientConfig createRedisConfig(NodeType type, RedisURI address, int timeout, int commandTimeout, String sslHostname) {
         Config serviceCfg = serviceManager.getCfg();
         RedisClientConfig redisConfig = new RedisClientConfig();
-        FailedNodeDetector failedNodeDetector = new FailedConnectionDetector();
+        FailedNodeDetector failedNodeDetector = DEFAULT_FAILED_NODE_DETECTOR;
         if (type == NodeType.SLAVE) {
             failedNodeDetector = config.getFailedSlaveNodeDetector();
         }

--- a/redisson/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/MasterSlaveConnectionManager.java
@@ -454,6 +454,10 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
     protected RedisClientConfig createRedisConfig(NodeType type, RedisURI address, int timeout, int commandTimeout, String sslHostname) {
         Config serviceCfg = serviceManager.getCfg();
         RedisClientConfig redisConfig = new RedisClientConfig();
+        FailedNodeDetector failedNodeDetector = new FailedConnectionDetector();
+        if (type == NodeType.SLAVE) {
+            failedNodeDetector = config.getFailedSlaveNodeDetector();
+        }
         redisConfig.setAddress(address)
                 .setTimer(serviceManager.getTimer())
                 .setExecutor(serviceManager.getExecutor())
@@ -480,7 +484,7 @@ public class MasterSlaveConnectionManager implements ConnectionManager {
                 .setUsername(Objects.toString(serviceCfg.getUsername(), config.getUsername()))
                 .setPassword(Objects.toString(serviceCfg.getPassword(), config.getPassword()))
                 .setNettyHook(serviceCfg.getNettyHook())
-                .setFailedNodeDetector(config.getFailedSlaveNodeDetector())
+                .setFailedNodeDetector(failedNodeDetector)
                 .setProtocol(serviceCfg.getProtocol())
                 .setCapabilities(serviceCfg.getValkeyCapabilities())
                 .setReconnectionDelay(config.getReconnectionDelay())

--- a/redisson/src/test/java/org/redisson/connection/MasterSlaveConnectionManagerTest.java
+++ b/redisson/src/test/java/org/redisson/connection/MasterSlaveConnectionManagerTest.java
@@ -55,6 +55,8 @@ public class MasterSlaveConnectionManagerTest {
                     .isInstanceOf(FailedCommandsTimeoutDetector.class);
             Assertions.assertThat(sentinelConfig.getFailedNodeDetector())
                     .isInstanceOf(FailedConnectionDetector.class);
+            Assertions.assertThat(masterConfig.getFailedNodeDetector())
+                    .isSameAs(sentinelConfig.getFailedNodeDetector());
         } finally {
             manager.shutdown(0, 0, TimeUnit.SECONDS);
         }

--- a/redisson/src/test/java/org/redisson/connection/MasterSlaveConnectionManagerTest.java
+++ b/redisson/src/test/java/org/redisson/connection/MasterSlaveConnectionManagerTest.java
@@ -8,6 +8,8 @@ import mockit.Mocked;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.redisson.api.NodeType;
+import org.redisson.client.FailedCommandsTimeoutDetector;
+import org.redisson.client.FailedConnectionDetector;
 import org.redisson.client.RedisClient;
 import org.redisson.client.RedisClientConfig;
 import org.redisson.client.RedisConnectionException;
@@ -26,6 +28,37 @@ import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 
 public class MasterSlaveConnectionManagerTest {
+
+    @Test
+    void failedSlaveNodeDetectorIsOnlyAssignedToSlaves() {
+        Config config = new Config();
+        config.setLazyInitialization(true);
+        MasterSlaveServersConfig msConfig = config.useMasterSlaveServers();
+        msConfig.setMasterAddress("redis://127.0.0.1:6379");
+        msConfig.setReadMode(ReadMode.MASTER);
+        msConfig.setFailedSlaveNodeDetector(new FailedCommandsTimeoutDetector(10000, 2));
+
+        MasterSlaveConnectionManager manager = new MasterSlaveConnectionManager(msConfig, config);
+        try {
+            RedisURI address = new RedisURI("redis://127.0.0.1:6379");
+
+            RedisClientConfig masterConfig = manager.createRedisConfig(
+                    NodeType.MASTER, address, 1000, 1000, null);
+            RedisClientConfig slaveConfig = manager.createRedisConfig(
+                    NodeType.SLAVE, address, 1000, 1000, null);
+            RedisClientConfig sentinelConfig = manager.createRedisConfig(
+                    NodeType.SENTINEL, address, 1000, 1000, null);
+
+            Assertions.assertThat(masterConfig.getFailedNodeDetector())
+                    .isInstanceOf(FailedConnectionDetector.class);
+            Assertions.assertThat(slaveConfig.getFailedNodeDetector())
+                    .isInstanceOf(FailedCommandsTimeoutDetector.class);
+            Assertions.assertThat(sentinelConfig.getFailedNodeDetector())
+                    .isInstanceOf(FailedConnectionDetector.class);
+        } finally {
+            manager.shutdown(0, 0, TimeUnit.SECONDS);
+        }
+    }
 
     MasterSlaveConnectionManager buildSlowConnectionManager(BaseMasterSlaveServersConfig<?> msConfig, Config config) {
         return new MasterSlaveConnectionManager(msConfig, config) {


### PR DESCRIPTION
Fixes #7269.

`failedSlaveNodeDetector` was assigned to every Redis client created by `MasterSlaveConnectionManager`, including masters and sentinels. A command-based detector could therefore interpret master write timeouts as failed-replica signals and pass the master into `shutdownAndReconnectAsync(...)`.

This change:

- assigns the configured failed-slave detector only to `NodeType.SLAVE`;
- retains the default `FailedConnectionDetector` for master and sentinel clients; and
- adds a focused test covering all three node types.

Test:

```text
JAVA_HOME=<JDK 25> mvn -pl redisson -Punit-test \
  -Dtest=MasterSlaveConnectionManagerTest test
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
```
