### PR TITLE
fix: prevent lock watchdog from outliving unlock (#7272)

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonBaseLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonBaseLock.java
@@ -159,9 +159,17 @@ public abstract class RedissonBaseLock extends RedissonExpirable implements RLoc
     }
 
     private RFuture<Void> unlockAsync0(long threadId, String requestId) {
+        // Cancel watchdog synchronously before the Redis unlock so a following
+        // acquire cannot re-arm renewal while this cancel is still in-flight (#7272).
+        // unlockResult=false avoids resetting fixed lease time on reentrant partial unlock;
+        // full release resets lease below via updateLockLeaseTimeOnUnlock.
+        cancelExpirationRenewal(threadId, Boolean.FALSE);
+
         CompletionStage<Boolean> future = unlockInnerAsync(threadId, requestId);
         CompletionStage<Void> f = future.handle((res, e) -> {
-            cancelExpirationRenewal(threadId, res);
+            if (res == null || Boolean.TRUE.equals(res)) {
+                updateLockLeaseTimeOnUnlock(res);
+            }
 
             if (e != null) {
                 if (e instanceof CompletionException) {
@@ -179,6 +187,14 @@ public abstract class RedissonBaseLock extends RedissonExpirable implements RLoc
         });
 
         return new CompletableFutureWrapper<>(f);
+    }
+
+    /**
+     * Called when unlock finishes and the lock is fully released (or was not held).
+     * Subclasses use this to reset watchdog lease time.
+     */
+    protected void updateLockLeaseTimeOnUnlock(Boolean unlockResult) {
+        // no-op by default
     }
 
     @Override

--- a/redisson/src/main/java/org/redisson/RedissonFasterMultiLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonFasterMultiLock.java
@@ -262,24 +262,39 @@ public class RedissonFasterMultiLock extends RedissonBaseLock {
         RFuture<Long> ttlRemainingFuture;
         if (leaseTime > 0) {
             ttlRemainingFuture = tryLockInnerAsync(leaseTime, unit, threadId);
-        } else {
-            ttlRemainingFuture = tryLockInnerAsync(internalLockLeaseTime, TimeUnit.MILLISECONDS, threadId);
-        }
-        CompletionStage<Long> s = handleNoSync(threadId, ttlRemainingFuture);
-        ttlRemainingFuture = new CompletableFutureWrapper<>(s);
-
-        CompletionStage<Long> f = ttlRemainingFuture.thenApply(ttlRemaining -> {
-            // lock acquired
-            if (ttlRemaining == null) {
-                if (leaseTime > 0) {
+            CompletionStage<Long> s = handleNoSync(threadId, ttlRemainingFuture);
+            CompletionStage<Long> f = s.thenApply(ttlRemaining -> {
+                // lock acquired with fixed lease — no watchdog
+                if (ttlRemaining == null) {
                     internalLockLeaseTime = unit.toMillis(leaseTime);
-                } else {
-                    scheduleExpirationRenewal(threadId);
                 }
+                return ttlRemaining;
+            });
+            return new CompletableFutureWrapper<>(f);
+        }
+
+        // Register watchdog before the SET so unlock's cancel cannot race ahead of schedule (#7272)
+        scheduleExpirationRenewal(threadId);
+        ttlRemainingFuture = tryLockInnerAsync(internalLockLeaseTime, TimeUnit.MILLISECONDS, threadId);
+        CompletionStage<Long> s = handleNoSync(threadId, ttlRemainingFuture);
+        CompletableFuture<Long> result = new CompletableFuture<>();
+        s.whenComplete((ttlRemaining, ex) -> {
+            if (ex != null) {
+                cancelExpirationRenewal(threadId, null);
+                result.completeExceptionally(ex);
+                return;
             }
-            return ttlRemaining;
+            if (ttlRemaining != null) {
+                cancelExpirationRenewal(threadId, null);
+                result.complete(ttlRemaining);
+                return;
+            }
+            if (!result.complete(null)) {
+                cancelExpirationRenewal(threadId, null);
+                unlockAsync(threadId);
+            }
         });
-        return new CompletableFutureWrapper<>(f);
+        return new CompletableFutureWrapper<>(result);
     }
     private Long tryAcquire(long leaseTime, TimeUnit unit, long threadId) {
         return get(tryAcquireAsync0(leaseTime, unit, threadId));
@@ -293,26 +308,42 @@ public class RedissonFasterMultiLock extends RedissonBaseLock {
         CompletionStage<Boolean> acquiredFuture;
         if (leaseTime > 0) {
             acquiredFuture = tryLockOnceInnerAsync(leaseTime, unit, RedisCommands.EVAL_BOOLEAN, threadId);
-        } else {
-            acquiredFuture = tryLockOnceInnerAsync(internalLockLeaseTime,
-                    TimeUnit.MILLISECONDS, RedisCommands.EVAL_BOOLEAN, threadId);
+            acquiredFuture = handleNoSync(threadId, acquiredFuture);
+
+            CompletionStage<Boolean> f = acquiredFuture.thenApply(acquired -> {
+                // lock acquired with fixed lease — no watchdog
+                if (acquired) {
+                    internalLockLeaseTime = unit.toMillis(leaseTime);
+                }
+                return acquired;
+            });
+            return new CompletableFutureWrapper<>(f);
         }
 
+        // Register watchdog before the SET so unlock's cancel cannot race ahead of schedule (#7272)
+        scheduleExpirationRenewal(threadId);
+        acquiredFuture = tryLockOnceInnerAsync(internalLockLeaseTime,
+                TimeUnit.MILLISECONDS, RedisCommands.EVAL_BOOLEAN, threadId);
         acquiredFuture = handleNoSync(threadId, acquiredFuture);
 
-        CompletionStage<Boolean> f = acquiredFuture.thenApply(acquired -> {
-            // lock acquired
-            if (acquired) {
-                if (leaseTime > 0) {
-                    internalLockLeaseTime = unit.toMillis(leaseTime);
-                } else {
-                    scheduleExpirationRenewal(threadId);
-                }
+        CompletableFuture<Boolean> result = new CompletableFuture<>();
+        acquiredFuture.whenComplete((acquired, ex) -> {
+            if (ex != null) {
+                cancelExpirationRenewal(threadId, null);
+                result.completeExceptionally(ex);
+                return;
             }
-            return acquired;
+            if (!Boolean.TRUE.equals(acquired)) {
+                cancelExpirationRenewal(threadId, null);
+                result.complete(false);
+                return;
+            }
+            if (!result.complete(true)) {
+                cancelExpirationRenewal(threadId, null);
+                unlockAsync(threadId);
+            }
         });
-        return new CompletableFutureWrapper<>(f);
-
+        return new CompletableFutureWrapper<>(result);
     }
 
     @Override
@@ -580,10 +611,11 @@ public class RedissonFasterMultiLock extends RedissonBaseLock {
     }
 
     private RFuture<Void> unlockAsync0(long threadId, String requestId) {
+        // Cancel watchdog synchronously before Redis unlock (#7272)
+        cancelExpirationRenewal(threadId, Boolean.FALSE);
+
         CompletionStage<Boolean> future = unlockInnerAsync(threadId, requestId);
         CompletionStage<Void> f = future.handle((res, e) -> {
-            cancelExpirationRenewal(threadId, res);
-
             if (e != null) {
                 if (e instanceof CompletionException) {
                     throw (CompletionException) e;

--- a/redisson/src/main/java/org/redisson/RedissonFencedLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonFencedLock.java
@@ -85,22 +85,39 @@ public class RedissonFencedLock extends RedissonLock implements RFencedLock {
         RFuture<List<Long>> ttlRemainingFuture;
         if (leaseTime > 0) {
             ttlRemainingFuture = tryLockInnerAsync(leaseTime, unit, threadId);
-        } else {
-            ttlRemainingFuture = tryLockInnerAsync(internalLockLeaseTime, TimeUnit.MILLISECONDS, threadId);
-        }
-        CompletionStage<List<Long>> f = ttlRemainingFuture.thenApply(res -> {
-            Long ttl = res.get(0);
-            // lock acquired
-            if (ttl == -1) {
-                if (leaseTime > 0) {
+            CompletionStage<List<Long>> f = ttlRemainingFuture.thenApply(res -> {
+                Long ttl = res.get(0);
+                // lock acquired with fixed lease — no watchdog
+                if (ttl == -1) {
                     internalLockLeaseTime = unit.toMillis(leaseTime);
-                } else {
-                    scheduleExpirationRenewal(threadId);
                 }
+                return res;
+            });
+            return new CompletableFutureWrapper<>(f);
+        }
+
+        // Register watchdog before the SET so unlock's cancel cannot race ahead of schedule (#7272)
+        scheduleExpirationRenewal(threadId);
+        ttlRemainingFuture = tryLockInnerAsync(internalLockLeaseTime, TimeUnit.MILLISECONDS, threadId);
+        CompletableFuture<List<Long>> result = new CompletableFuture<>();
+        ttlRemainingFuture.whenComplete((res, ex) -> {
+            if (ex != null) {
+                cancelExpirationRenewal(threadId, null);
+                result.completeExceptionally(ex);
+                return;
             }
-            return res;
+            Long ttl = (res != null && !res.isEmpty()) ? res.get(0) : null;
+            if (ttl == null || ttl != -1L) {
+                cancelExpirationRenewal(threadId, null);
+                result.complete(res);
+                return;
+            }
+            if (!result.complete(res)) {
+                cancelExpirationRenewal(threadId, null);
+                unlockAsync(threadId);
+            }
         });
-        return new CompletableFutureWrapper<>(f);
+        return new CompletableFutureWrapper<>(result);
     }
 
     RFuture<List<Long>> tryLockInnerAsync(long leaseTime, TimeUnit unit, long threadId) {

--- a/redisson/src/main/java/org/redisson/RedissonLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonLock.java
@@ -154,56 +154,104 @@ public class RedissonLock extends RedissonBaseLock {
     }
 
     private RFuture<Long> tryAcquireAsync0(long waitTime, long leaseTime, TimeUnit unit, long threadId) {
-        return getServiceManager().execute(() -> tryAcquireAsync(waitTime, leaseTime, unit, threadId));
+        RFuture<Long> future = getServiceManager().execute(() -> tryAcquireAsync(waitTime, leaseTime, unit, threadId));
+        // get() cancels this outer future on interrupt — drop speculative watchdog / unlock
+        future.toCompletableFuture().whenComplete((r, e) -> {
+            if (future.toCompletableFuture().isCancelled()) {
+                cancelExpirationRenewal(threadId, null);
+                unlockAsync(threadId);
+            }
+        });
+        return future;
     }
 
     private RFuture<Boolean> tryAcquireOnceAsync(long waitTime, long leaseTime, TimeUnit unit, long threadId) {
         CompletionStage<Boolean> acquiredFuture;
         if (leaseTime > 0) {
             acquiredFuture = tryLockInnerAsync(waitTime, leaseTime, unit, threadId, RedisCommands.EVAL_NULL_BOOLEAN);
-        } else {
-            acquiredFuture = tryLockInnerAsync(waitTime, internalLockLeaseTime,
-                    TimeUnit.MILLISECONDS, threadId, RedisCommands.EVAL_NULL_BOOLEAN);
+            acquiredFuture = handleNoSync(threadId, acquiredFuture);
+
+            CompletionStage<Boolean> f = acquiredFuture.thenApply(acquired -> {
+                // lock acquired with fixed lease — no watchdog
+                if (acquired) {
+                    internalLockLeaseTime = unit.toMillis(leaseTime);
+                }
+                return acquired;
+            });
+            return new CompletableFutureWrapper<>(f);
         }
 
+        // Register watchdog before the SET so unlock's cancel cannot race ahead of schedule
+        // (e.g. interrupt during acquire, unlock in finally). See #7272.
+        scheduleExpirationRenewal(threadId);
+        acquiredFuture = tryLockInnerAsync(waitTime, internalLockLeaseTime,
+                TimeUnit.MILLISECONDS, threadId, RedisCommands.EVAL_NULL_BOOLEAN);
         acquiredFuture = handleNoSync(threadId, acquiredFuture);
 
-        CompletionStage<Boolean> f = acquiredFuture.thenApply(acquired -> {
-            // lock acquired
-            if (acquired) {
-                if (leaseTime > 0) {
-                    internalLockLeaseTime = unit.toMillis(leaseTime);
-                } else {
-                    scheduleExpirationRenewal(threadId);
-                }
+        CompletableFuture<Boolean> result = new CompletableFuture<>();
+        acquiredFuture.whenComplete((acquired, ex) -> {
+            if (ex != null) {
+                cancelExpirationRenewal(threadId, null);
+                result.completeExceptionally(ex);
+                return;
             }
-            return acquired;
+            if (!Boolean.TRUE.equals(acquired)) {
+                cancelExpirationRenewal(threadId, null);
+                result.complete(false);
+                return;
+            }
+            // acquired — if the caller already cancelled (interrupt), drop watchdog and unlock
+            if (!result.complete(true)) {
+                cancelExpirationRenewal(threadId, null);
+                unlockAsync(threadId);
+            }
         });
-        return new CompletableFutureWrapper<>(f);
+        return new CompletableFutureWrapper<>(result);
     }
 
     private RFuture<Long> tryAcquireAsync(long waitTime, long leaseTime, TimeUnit unit, long threadId) {
         CompletionStage<Long> ttlRemainingFuture;
         if (leaseTime > 0) {
             ttlRemainingFuture = tryLockInnerAsync(waitTime, leaseTime, unit, threadId, RedisCommands.EVAL_LONG);
-        } else {
-            ttlRemainingFuture = tryLockInnerAsync(waitTime, internalLockLeaseTime,
-                    TimeUnit.MILLISECONDS, threadId, RedisCommands.EVAL_LONG);
+            ttlRemainingFuture = handleNoSync(threadId, ttlRemainingFuture);
+
+            CompletionStage<Long> f = ttlRemainingFuture.thenApply(ttlRemaining -> {
+                // lock acquired with fixed lease — no watchdog
+                if (ttlRemaining == null) {
+                    internalLockLeaseTime = unit.toMillis(leaseTime);
+                }
+                return ttlRemaining;
+            });
+            return new CompletableFutureWrapper<>(f);
         }
+
+        // Register watchdog before the SET so unlock's cancel cannot race ahead of schedule
+        // (e.g. interrupt during acquire, unlock in finally). See #7272.
+        scheduleExpirationRenewal(threadId);
+        ttlRemainingFuture = tryLockInnerAsync(waitTime, internalLockLeaseTime,
+                TimeUnit.MILLISECONDS, threadId, RedisCommands.EVAL_LONG);
         ttlRemainingFuture = handleNoSync(threadId, ttlRemainingFuture);
 
-        CompletionStage<Long> f = ttlRemainingFuture.thenApply(ttlRemaining -> {
-            // lock acquired
-            if (ttlRemaining == null) {
-                if (leaseTime > 0) {
-                    internalLockLeaseTime = unit.toMillis(leaseTime);
-                } else {
-                    scheduleExpirationRenewal(threadId);
-                }
+        CompletableFuture<Long> result = new CompletableFuture<>();
+        ttlRemainingFuture.whenComplete((ttlRemaining, ex) -> {
+            if (ex != null) {
+                cancelExpirationRenewal(threadId, null);
+                result.completeExceptionally(ex);
+                return;
             }
-            return ttlRemaining;
+            // null ttl means acquired
+            if (ttlRemaining != null) {
+                cancelExpirationRenewal(threadId, null);
+                result.complete(ttlRemaining);
+                return;
+            }
+            // acquired — if the caller already cancelled (interrupt), drop watchdog and unlock
+            if (!result.complete(null)) {
+                cancelExpirationRenewal(threadId, null);
+                unlockAsync(threadId);
+            }
         });
-        return new CompletableFutureWrapper<>(f);
+        return new CompletableFutureWrapper<>(result);
     }
 
     @Override
@@ -324,8 +372,7 @@ public class RedissonLock extends RedissonBaseLock {
     }
 
     @Override
-    protected void cancelExpirationRenewal(Long threadId, Boolean unlockResult) {
-        super.cancelExpirationRenewal(threadId, unlockResult);
+    protected void updateLockLeaseTimeOnUnlock(Boolean unlockResult) {
         if (unlockResult == null || unlockResult) {
             internalLockLeaseTime = getServiceManager().getCfg().getLockWatchdogTimeout();
         }
@@ -450,7 +497,14 @@ public class RedissonLock extends RedissonBaseLock {
 
     @Override
     public RFuture<Boolean> tryLockAsync(long threadId) {
-        return getServiceManager().execute(() -> tryAcquireOnceAsync(-1, -1, null, threadId));
+        RFuture<Boolean> future = getServiceManager().execute(() -> tryAcquireOnceAsync(-1, -1, null, threadId));
+        future.toCompletableFuture().whenComplete((r, e) -> {
+            if (future.toCompletableFuture().isCancelled()) {
+                cancelExpirationRenewal(threadId, null);
+                unlockAsync(threadId);
+            }
+        });
+        return future;
     }
 
     @Override

--- a/redisson/src/main/java/org/redisson/RedissonSpinLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonSpinLock.java
@@ -105,19 +105,31 @@ public final class RedissonSpinLock extends RedissonBaseLock {
             CompletionStage<Long> s = handleNoSync(threadId, acquiredFuture);
             return new CompletableFutureWrapper<>(s);
         }
+
+        // Register watchdog before the SET so unlock's cancel cannot race ahead of schedule (#7272)
+        scheduleExpirationRenewal(threadId);
         RFuture<Long> ttlRemainingFuture = tryLockInnerAsync(internalLockLeaseTime,
                 TimeUnit.MILLISECONDS, threadId, RedisCommands.EVAL_LONG);
 
         CompletionStage<Long> s = handleNoSync(threadId, ttlRemainingFuture);
-        ttlRemainingFuture = new CompletableFutureWrapper<>(s);
-
-        ttlRemainingFuture.thenAccept(ttlRemaining -> {
-            // lock acquired
-            if (ttlRemaining == null) {
-                scheduleExpirationRenewal(threadId);
+        CompletableFuture<Long> result = new CompletableFuture<>();
+        s.whenComplete((ttlRemaining, ex) -> {
+            if (ex != null) {
+                cancelExpirationRenewal(threadId, null);
+                result.completeExceptionally(ex);
+                return;
+            }
+            if (ttlRemaining != null) {
+                cancelExpirationRenewal(threadId, null);
+                result.complete(ttlRemaining);
+                return;
+            }
+            if (!result.complete(null)) {
+                cancelExpirationRenewal(threadId, null);
+                unlockAsync(threadId);
             }
         });
-        return ttlRemainingFuture;
+        return new CompletableFutureWrapper<>(result);
     }
 
     @Override
@@ -179,8 +191,7 @@ public final class RedissonSpinLock extends RedissonBaseLock {
     }
 
     @Override
-    protected void cancelExpirationRenewal(Long threadId, Boolean unlockResult) {
-        super.cancelExpirationRenewal(threadId, unlockResult);
+    protected void updateLockLeaseTimeOnUnlock(Boolean unlockResult) {
         if (unlockResult == null || unlockResult) {
             internalLockLeaseTime = getServiceManager().getCfg().getLockWatchdogTimeout();
         }

--- a/redisson/src/test/java/org/redisson/RedissonLockExpirationRenewalTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonLockExpirationRenewalTest.java
@@ -12,6 +12,7 @@ import org.testcontainers.containers.GenericContainer;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -152,6 +153,55 @@ public class RedissonLockExpirationRenewalTest extends RedisDockerTest {
 
             executor.shutdownNow();
         }
+    }
+
+    /**
+     * Watchdog must not outlive unlock when acquire is interrupted mid-flight
+     * and release runs in finally (cancel vs schedule race). See #7272.
+     */
+    @Test
+    public void testWatchdogDoesNotOutliveInterruptedAcquire() throws Exception {
+        String name = "test:watchdog:interrupt-leak";
+        redisson.getKeys().delete(name);
+
+        AtomicBoolean stop = new AtomicBoolean();
+        Thread worker = new Thread(() -> {
+            RLock lock = redisson.getLock(name);
+            while (!stop.get()) {
+                Thread.interrupted(); // clear so the next interrupt lands during acquire
+                try {
+                    lock.lockInterruptibly();
+                } catch (InterruptedException | RuntimeException e) {
+                    // acquire interrupted (may be wrapped as RedisException)
+                } finally {
+                    Thread.interrupted(); // allow unlock to complete without immediate re-interrupt
+                    try {
+                        lock.unlock();
+                    } catch (RuntimeException ignored) {
+                        // not held
+                    }
+                }
+            }
+        });
+        worker.start();
+
+        long until = System.currentTimeMillis() + 8_000;
+        while (System.currentTimeMillis() < until) {
+            worker.interrupt();
+            Thread.sleep(2);
+        }
+        stop.set(true);
+        worker.join(10_000);
+        if (worker.isAlive()) {
+            worker.interrupt();
+            worker.join(5_000);
+        }
+
+        Thread.sleep(LOCK_WATCHDOG_TIMEOUT * 3);
+        long ttl = redisson.getMap(name).remainTimeToLive();
+        redisson.getKeys().delete(name);
+
+        assertThat(ttl).as("orphan lock still renewed by watchdog after interrupted acquire/unlock").isLessThanOrEqualTo(0L);
     }
 
 }

--- a/redisson/src/test/java/org/redisson/RedissonLockExpirationRenewalTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonLockExpirationRenewalTest.java
@@ -3,6 +3,7 @@ package org.redisson;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.redisson.api.RFuture;
 import org.redisson.api.RLock;
 import org.redisson.api.RMap;
 import org.redisson.api.RReadWriteLock;
@@ -12,6 +13,7 @@ import org.testcontainers.containers.GenericContainer;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -158,6 +160,11 @@ public class RedissonLockExpirationRenewalTest extends RedisDockerTest {
     /**
      * Watchdog must not outlive unlock when acquire is interrupted mid-flight
      * and release runs in finally (cancel vs schedule race). See #7272.
+     * <p>
+     * Matches the issue reproducer: continuous interrupts (no sleep between
+     * them), several workers, multi-second storm. Also cancels in-flight
+     * {@code tryLockAsync} futures so the cancel-handler path is exercised
+     * without relying on a single narrow race window.
      */
     @Test
     public void testWatchdogDoesNotOutliveInterruptedAcquire() throws Exception {
@@ -165,43 +172,118 @@ public class RedissonLockExpirationRenewalTest extends RedisDockerTest {
         redisson.getKeys().delete(name);
 
         AtomicBoolean stop = new AtomicBoolean();
-        Thread worker = new Thread(() -> {
-            RLock lock = redisson.getLock(name);
-            while (!stop.get()) {
-                Thread.interrupted(); // clear so the next interrupt lands during acquire
-                try {
-                    lock.lockInterruptibly();
-                } catch (InterruptedException | RuntimeException e) {
-                    // acquire interrupted (may be wrapped as RedisException)
-                } finally {
-                    Thread.interrupted(); // allow unlock to complete without immediate re-interrupt
+        int workers = 4;
+        Thread[] threads = new Thread[workers];
+        for (int w = 0; w < workers; w++) {
+            threads[w] = new Thread(() -> {
+                RLock lock = redisson.getLock(name);
+                while (!stop.get()) {
+                    Thread.interrupted(); // clear so the next interrupt lands during acquire
                     try {
-                        lock.unlock();
-                    } catch (RuntimeException ignored) {
-                        // not held
+                        lock.lockInterruptibly();
+                    } catch (InterruptedException | RuntimeException e) {
+                        // acquire interrupted (may be wrapped as RedisException)
+                    } finally {
+                        Thread.interrupted(); // allow unlock to complete without immediate re-interrupt
+                        try {
+                            lock.unlock();
+                        } catch (RuntimeException ignored) {
+                            // not held
+                        }
                     }
                 }
-            }
-        });
-        worker.start();
+            }, "watchdog-interrupt-worker-" + w);
+            threads[w].start();
+        }
 
-        long until = System.currentTimeMillis() + 8_000;
+        // Continuous interrupt storm (issue #7272 reproducer used ~20s busy loop).
+        long until = System.currentTimeMillis() + 20_000;
         while (System.currentTimeMillis() < until) {
-            worker.interrupt();
-            Thread.sleep(2);
+            for (Thread t : threads) {
+                t.interrupt();
+            }
         }
         stop.set(true);
-        worker.join(10_000);
-        if (worker.isAlive()) {
-            worker.interrupt();
-            worker.join(5_000);
+        for (Thread t : threads) {
+            t.interrupt();
+            t.join(10_000);
+            if (t.isAlive()) {
+                t.interrupt();
+                t.join(5_000);
+            }
         }
 
+        // Longer than watchdog TTL: a released key must be gone; a renewed orphan stays.
         Thread.sleep(LOCK_WATCHDOG_TIMEOUT * 3);
         long ttl = redisson.getMap(name).remainTimeToLive();
+        boolean stillLocked = redisson.getLock(name).isLocked();
         redisson.getKeys().delete(name);
 
-        assertThat(ttl).as("orphan lock still renewed by watchdog after interrupted acquire/unlock").isLessThanOrEqualTo(0L);
+        assertThat(stillLocked)
+                .as("orphan lock still held/renewed after interrupted acquire/unlock")
+                .isFalse();
+        assertThat(ttl)
+                .as("orphan lock key still present with ttl=" + ttl + "ms after workers stopped")
+                .isLessThanOrEqualTo(0L);
+    }
+
+    /**
+     * Cancel of an in-flight {@code tryLockAsync} must drop speculative watchdog
+     * registration and unlock if SET already succeeded. Without the cancel handler
+     * on the outer future (#7272), cancelling the acquire leaves the key held and
+     * renewed forever — the outer future is cancelled but the inner SET/schedule
+     * still runs.
+     * <p>
+     * Important: do not call {@code forceUnlock()} after a successful cancel — that
+     * would mask the leak by cancelling renewal itself.
+     */
+    @Test
+    public void testCancelledTryLockAsyncDoesNotLeaveWatchdog() throws Exception {
+        String name = "test:watchdog:cancel-async";
+        redisson.getKeys().delete(name);
+        RLock lock = redisson.getLock(name);
+
+        int cancelledInFlight = 0;
+        for (int i = 0; i < 400; i++) {
+            RFuture<Boolean> future = lock.tryLockAsync();
+            // Yield once so the acquire is dispatched, then cancel the outer future.
+            Thread.yield();
+            boolean cancelled = future.cancel(true);
+            if (cancelled) {
+                cancelledInFlight++;
+                // Production fix must cancelExpirationRenewal + unlockAsync.
+                // Do not forceUnlock — that would hide an orphaned watchdog.
+            } else {
+                // Already completed: normal unlock (not the cancel race under test).
+                try {
+                    Boolean acquired = future.toCompletableFuture().join();
+                    if (Boolean.TRUE.equals(acquired)) {
+                        lock.unlock();
+                    }
+                } catch (RuntimeException ignored) {
+                    // acquire failed
+                }
+            }
+        }
+
+        assertThat(cancelledInFlight)
+                .as("expected some in-flight cancels to exercise the race")
+                .isGreaterThan(0);
+
+        // Allow cancel handlers / unlockAsync to settle, then wait past watchdog TTL.
+        Thread.sleep(500);
+        Thread.sleep(LOCK_WATCHDOG_TIMEOUT * 3);
+
+        long ttl = redisson.getMap(name).remainTimeToLive();
+        boolean stillLocked = lock.isLocked();
+        redisson.getKeys().delete(name);
+
+        assertThat(stillLocked)
+                .as("cancelled tryLockAsync left lock held (watchdog still renewing)")
+                .isFalse();
+        assertThat(ttl)
+                .as("tryLockAsync cancel left a watchdog-renewed orphan key ttl=" + ttl)
+                .isLessThanOrEqualTo(0L);
     }
 
 }

--- a/redisson/src/test/java/org/redisson/renewal/LockEntryTest.java
+++ b/redisson/src/test/java/org/redisson/renewal/LockEntryTest.java
@@ -1,0 +1,40 @@
+package org.redisson.renewal;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Counter semantics used when watchdog is registered before SET and cancelled
+ * on failed acquire (see #7272 pre-schedule fix).
+ */
+public class LockEntryTest {
+
+    @Test
+    public void speculativeRegisterThenCancelLeavesNoThreads() {
+        LockEntry entry = new LockEntry();
+        long threadId = 42L;
+
+        // pre-schedule before SET
+        entry.addThreadId(threadId, "lock:42");
+        assertThat(entry.hasNoThreads()).isFalse();
+
+        // acquire failed → undo
+        entry.removeThreadId(threadId);
+        assertThat(entry.hasNoThreads()).isTrue();
+    }
+
+    @Test
+    public void reentrantAcquireAndFullReleaseClearsEntry() {
+        LockEntry entry = new LockEntry();
+        long threadId = 7L;
+
+        entry.addThreadId(threadId, "lock:7");
+        entry.addThreadId(threadId, "lock:7");
+        entry.removeThreadId(threadId);
+        assertThat(entry.hasNoThreads()).isFalse();
+        entry.removeThreadId(threadId);
+        assertThat(entry.hasNoThreads()).isTrue();
+    }
+
+}


### PR DESCRIPTION
### What problem does this PR solve?

Fixes #7272 — lock watchdog renewal can outlive `unlock()` when `cancelLockRenewal` races the acquire path's async `scheduleExpirationRenewal`.

After an interrupted `lockInterruptibly()` (or any case where unlock runs before the acquire's post-SET schedule callback), cancel can find no entry and no-op, then the late `scheduleExpirationRenewal` arms renewal forever. The key's TTL keeps jumping back to `lockWatchdogTimeout` with no holder.

### How it works

1. **Pre-register the watchdog** before the acquire `SET` (watchdog / `leaseTime <= 0` path only), so unlock's cancel always sees the entry.
2. **Cancel renewal synchronously at unlock start** (before the Redis unlock), so a following acquire cannot re-arm while cancel is still waiting on Redis.
3. **On failed acquire**, undo the speculative registration.
4. **On cancelled/interrupted acquire**, if the caller already cancelled the future after SET succeeded, drop the watchdog and unlock (same pattern as existing async lock paths).

### Tests

- `LockEntryTest` — counter semantics for speculative register / cancel / reentrant release (no Redis).
- `RedissonLockExpirationRenewalTest#testWatchdogDoesNotOutliveInterruptedAcquire` — interrupt + unlock loop must not leave a renewed orphan (Docker Redis).
- Existing `testLockIsNotRenewedAfterInterruptedTryLock`, reentrant renew, and basic lock tests pass.

### Checklist

- [x] DCO signed (`Signed-off-by: arimu1 <19286898+arimu1@users.noreply.github.com>`)
- [x] One issue per PR
- [x] No unrelated changes