### PR TITLE
Fix pubsub semaphore leak when entry is missing

### DIFF
--- a/redisson/src/main/java/org/redisson/pubsub/PublishSubscribeService.java
+++ b/redisson/src/main/java/org/redisson/pubsub/PublishSubscribeService.java
@@ -450,6 +450,7 @@ public class PublishSubscribeService {
                                                                 AsyncSemaphore semaphore, RedisPubSubListener<?>... listeners) {
         MasterSlaveEntry entry = getEntry(new ChannelName(channelName));
         if (entry == null) {
+            semaphore.release();
             int slot = connectionManager.calcSlot(channelName);
             return connectionManager.getServiceManager().createNodeNotFoundFuture(channelName, slot);
         }

--- a/redisson/src/test/java/org/redisson/pubsub/PublishSubscribeTest.java
+++ b/redisson/src/test/java/org/redisson/pubsub/PublishSubscribeTest.java
@@ -6,6 +6,7 @@ import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
 import mockit.Tested;
+import mockit.Verifications;
 import org.junit.jupiter.api.Test;
 import org.redisson.RedissonLockEntry;
 import org.redisson.client.BaseRedisPubSubListener;
@@ -88,7 +89,7 @@ public class PublishSubscribeTest {
 
     @Test
     public void testSubscribeNoTimeoutReleasesSemaphoreIfEntryIsMissing(@Mocked ServiceManager serviceManager) {
-        String channelName = "redisson_lock__channel__test";
+        String channelName = "test-channel";
         AsyncSemaphore semaphore = new AsyncSemaphore(1);
         CompletableFuture<PubSubConnectionEntry> failedFuture = new CompletableFuture<>();
         failedFuture.completeExceptionally(new RedisNodeNotFoundException("missing node"));
@@ -100,6 +101,9 @@ public class PublishSubscribeTest {
                     }
                     if ("calcSlot".equals(method.getName())) {
                         return 1;
+                    }
+                    if ("getWriteEntry".equals(method.getName())) {
+                        return null;
                     }
                     return null;
                 });
@@ -113,11 +117,21 @@ public class PublishSubscribeTest {
 
         PublishSubscribeService service = new PublishSubscribeService(connectionManager);
 
+        // Simulate the caller already holding the semaphore permit.
+        // subscribeNoTimeout should return it when no master node exists.
         semaphore.acquire().join();
+        CompletableFuture<Void> waiter = semaphore.acquire();
+        assertFalse(waiter.isDone());
+
         CompletableFuture<PubSubConnectionEntry> subscribeFuture = service.subscribeNoTimeout(
                 LongCodec.INSTANCE, channelName, semaphore, new BaseRedisPubSubListener());
 
         assertSame(failedFuture, subscribeFuture);
-        assertTrue(semaphore.acquire().isDone());
+        assertTrue(subscribeFuture.isCompletedExceptionally());
+        assertTrue(waiter.isDone());
+        new Verifications() {{
+            serviceManager.createNodeNotFoundFuture(channelName, 1);
+            times = 1;
+        }};
     }
 }

--- a/redisson/src/test/java/org/redisson/pubsub/PublishSubscribeTest.java
+++ b/redisson/src/test/java/org/redisson/pubsub/PublishSubscribeTest.java
@@ -89,7 +89,7 @@ public class PublishSubscribeTest {
 
     @Test
     public void testSubscribeNoTimeoutReleasesSemaphoreIfEntryIsMissing(@Mocked ServiceManager serviceManager) {
-        String channelName = "test-channel";
+        String channelName = "redisson_lock__channel__test";
         AsyncSemaphore semaphore = new AsyncSemaphore(1);
         CompletableFuture<PubSubConnectionEntry> failedFuture = new CompletableFuture<>();
         failedFuture.completeExceptionally(new RedisNodeNotFoundException("missing node"));
@@ -103,6 +103,7 @@ public class PublishSubscribeTest {
                         return 1;
                     }
                     if ("getWriteEntry".equals(method.getName())) {
+                        // Return null to simulate the case where the Redis node is unavailable
                         return null;
                     }
                     return null;
@@ -117,8 +118,7 @@ public class PublishSubscribeTest {
 
         PublishSubscribeService service = new PublishSubscribeService(connectionManager);
 
-        // Simulate the caller already holding the semaphore permit.
-        // subscribeNoTimeout should return it when no master node exists.
+        // Simulate the caller already holding the semaphore permit, subscribeNoTimeout should return it when no master node exists.
         semaphore.acquire().join();
         CompletableFuture<Void> waiter = semaphore.acquire();
         assertFalse(waiter.isDone());
@@ -129,9 +129,5 @@ public class PublishSubscribeTest {
         assertSame(failedFuture, subscribeFuture);
         assertTrue(subscribeFuture.isCompletedExceptionally());
         assertTrue(waiter.isDone());
-        new Verifications() {{
-            serviceManager.createNodeNotFoundFuture(channelName, 1);
-            times = 1;
-        }};
     }
 }

--- a/redisson/src/test/java/org/redisson/pubsub/PublishSubscribeTest.java
+++ b/redisson/src/test/java/org/redisson/pubsub/PublishSubscribeTest.java
@@ -1,17 +1,26 @@
 package org.redisson.pubsub;
 
 import mockit.Injectable;
+import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
+import mockit.Mocked;
 import mockit.Tested;
 import org.junit.jupiter.api.Test;
 import org.redisson.RedissonLockEntry;
+import org.redisson.client.BaseRedisPubSubListener;
 import org.redisson.client.ChannelName;
+import org.redisson.client.RedisNodeNotFoundException;
 import org.redisson.client.RedisPubSubListener;
 import org.redisson.client.RedisTimeoutException;
 import org.redisson.client.codec.Codec;
+import org.redisson.client.codec.LongCodec;
+import org.redisson.config.MasterSlaveServersConfig;
+import org.redisson.connection.ConnectionManager;
+import org.redisson.connection.ServiceManager;
 import org.redisson.misc.AsyncSemaphore;
 
+import java.lang.reflect.Proxy;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -75,5 +84,40 @@ public class PublishSubscribeTest {
         thread3.join();
         assertTrue(secondPromise.isDone());
         assertFalse(secondPromise.isCompletedExceptionally());
+    }
+
+    @Test
+    public void testSubscribeNoTimeoutReleasesSemaphoreIfEntryIsMissing(@Mocked ServiceManager serviceManager) {
+        String channelName = "redisson_lock__channel__test";
+        AsyncSemaphore semaphore = new AsyncSemaphore(1);
+        CompletableFuture<PubSubConnectionEntry> failedFuture = new CompletableFuture<>();
+        failedFuture.completeExceptionally(new RedisNodeNotFoundException("missing node"));
+        ConnectionManager connectionManager = (ConnectionManager) Proxy.newProxyInstance(
+                ConnectionManager.class.getClassLoader(), new Class[] {ConnectionManager.class},
+                (proxy, method, args) -> {
+                    if ("getServiceManager".equals(method.getName())) {
+                        return serviceManager;
+                    }
+                    if ("calcSlot".equals(method.getName())) {
+                        return 1;
+                    }
+                    return null;
+                });
+
+        new Expectations() {{
+            serviceManager.getConfig();
+            result = new MasterSlaveServersConfig();
+            serviceManager.createNodeNotFoundFuture(channelName, 1);
+            result = failedFuture;
+        }};
+
+        PublishSubscribeService service = new PublishSubscribeService(connectionManager);
+
+        semaphore.acquire().join();
+        CompletableFuture<PubSubConnectionEntry> subscribeFuture = service.subscribeNoTimeout(
+                LongCodec.INSTANCE, channelName, semaphore, new BaseRedisPubSubListener());
+
+        assertSame(failedFuture, subscribeFuture);
+        assertTrue(semaphore.acquire().isDone());
     }
 }


### PR DESCRIPTION
## What problem does this PR solve?

When a pub/sub subscribe request acquires a channel stripe semaphore but no `MasterSlaveEntry` is found for the channel, the current code returns early without releasing the semaphore

After that, other sub/unsub requests using the same stripe may be blocked forever and eventually timeout

This fixes the semaphore leak in the `entry == null` case in [#7264](https://github.com/redisson/redisson/issues/7264)

## Root cause

When `subscribeNoTimeout()` hits the `entry == null` branch, it directly returns `createNodeNotFoundFuture(...)` without releasing the semaphore.

## Fix

Release the semaphore before returning the node-not-found future in the `entry == null` branch.

## Tests

Added `PublishSubscribeTest.testSubscribeNoTimeoutReleasesSemaphoreIfEntryIsMissing`.

The test covers the node-not-found case without starting a Redis server and verifies that the semaphore is released correctly and can be acquired again after the failed subscribe
