### PR TITLE
fix: throw on codec mismatch when reusing a name in a transaction

### DIFF
--- a/redisson/src/main/java/org/redisson/transaction/RedissonTransaction.java
+++ b/redisson/src/main/java/org/redisson/transaction/RedissonTransaction.java
@@ -106,10 +106,25 @@ public class RedissonTransaction implements RTransaction {
     @Override
     public <V> RBucket<V> getBucket(String name, Codec codec) {
         checkState();
+        checkCodecMismatch(name, codec);
 
         return (RBucket<V>) instances.computeIfAbsent(name, k -> {
             return new RedissonTransactionalBucket<V>(codec, commandExecutor, options.getTimeout(), name, operations, executed, id);
         });
+    }
+
+    private void checkCodecMismatch(String name, Codec codec) {
+        if (codec == null) {
+            return;
+        }
+        Object existing = instances.get(name);
+        if (existing instanceof org.redisson.api.RObject) {
+            Codec existingCodec = ((org.redisson.api.RObject) existing).getCodec();
+            if (existingCodec == null || !existingCodec.getClass().equals(codec.getClass())) {
+                throw new IllegalArgumentException("Codec mismatch for '" + name
+                        + "': instance created with " + existingCodec + ", requested " + codec);
+            }
+        }
     }
 
     @Override
@@ -144,6 +159,7 @@ public class RedissonTransaction implements RTransaction {
     @Override
     public <V> RSet<V> getSet(String name, Codec codec) {
         checkState();
+        checkCodecMismatch(name, codec);
 
         return (RSet<V>) instances.computeIfAbsent(name, k -> {
             return new RedissonTransactionalSet<V>(codec, commandExecutor, name, operations, options.getTimeout(), executed, id);
@@ -162,6 +178,7 @@ public class RedissonTransaction implements RTransaction {
     @Override
     public <V> RSetCache<V> getSetCache(String name, Codec codec) {
         checkState();
+        checkCodecMismatch(name, codec);
 
         return (RSetCache<V>) instances.computeIfAbsent(name, k -> {
             return new RedissonTransactionalSetCache<V>(codec, commandExecutor, name, operations, options.getTimeout(), executed, id);
@@ -180,6 +197,7 @@ public class RedissonTransaction implements RTransaction {
     @Override
     public <K, V> RMap<K, V> getMap(String name, Codec codec) {
         checkState();
+        checkCodecMismatch(name, codec);
 
         return (RMap<K, V>) instances.computeIfAbsent(name, k -> {
             return new RedissonTransactionalMap<K, V>(codec, commandExecutor, name, operations, options.getTimeout(), executed, id);
@@ -198,6 +216,7 @@ public class RedissonTransaction implements RTransaction {
     @Override
     public <K, V> RMapCache<K, V> getMapCache(String name, Codec codec) {
         checkState();
+        checkCodecMismatch(name, codec);
 
         return (RMapCache<K, V>) instances.computeIfAbsent(name, k -> {
             return new RedissonTransactionalMapCache<K, V>(codec, commandExecutor, name, operations, options.getTimeout(), executed, id);

--- a/redisson/src/test/java/org/redisson/transaction/RedissonTransactionCodecMismatchTest.java
+++ b/redisson/src/test/java/org/redisson/transaction/RedissonTransactionCodecMismatchTest.java
@@ -1,0 +1,57 @@
+package org.redisson.transaction;
+
+import org.junit.jupiter.api.Test;
+import org.redisson.RedisDockerTest;
+import org.redisson.api.RTransaction;
+import org.redisson.api.TransactionOptions;
+import org.redisson.client.codec.StringCodec;
+import org.redisson.codec.JsonJacksonCodec;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * RTransaction must reject a different codec for an object already created
+ * under the same name with another codec, otherwise the wrong codec is used
+ * silently and data is corrupted.
+ *
+ * @see <a href="https://github.com/redisson/redisson/issues/5127">Issue #5127</a>
+ */
+public class RedissonTransactionCodecMismatchTest extends RedisDockerTest {
+
+    @Test
+    public void getBucketCodecMismatchThrows() {
+        RTransaction transaction = redisson.createTransaction(TransactionOptions.defaults());
+        transaction.getBucket("bucket1", new StringCodec());
+
+        assertThatThrownBy(() -> transaction.getBucket("bucket1", new JsonJacksonCodec()))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void getBucketSameCodecDoesNotThrow() {
+        RTransaction transaction = redisson.createTransaction(TransactionOptions.defaults());
+        transaction.getBucket("bucket2", new StringCodec());
+
+        assertThatCode(() -> transaction.getBucket("bucket2", new StringCodec()))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void getSetCodecMismatchThrows() {
+        RTransaction transaction = redisson.createTransaction(TransactionOptions.defaults());
+        transaction.getSet("set1", new StringCodec());
+
+        assertThatThrownBy(() -> transaction.getSet("set1", new JsonJacksonCodec()))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void getMapCodecMismatchThrows() {
+        RTransaction transaction = redisson.createTransaction(TransactionOptions.defaults());
+        transaction.getMap("map1", new StringCodec());
+
+        assertThatThrownBy(() -> transaction.getMap("map1", new JsonJacksonCodec()))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
## What
`RTransaction` now throws `IllegalArgumentException` when a different `Codec` is requested for an object name that was already created with another codec within the same transaction.

## Why
Previously `getBucket("k", codecA)` followed by `getBucket("k", codecB)` silently returned the instance created with `codecA` — the second codec was ignored, and subsequent operations would serialize/deserialize with the wrong codec, silently corrupting data. Issue #5127 (the reporter explicitly expects an error here).

## Root cause
`RedissonTransaction` stores created transactional objects in a single `instances` map keyed by name only. The codec overloads of `getBucket`/`getSet`/`getSetCache`/`getMap`/`getMapCache` all used `instances.computeIfAbsent(name, ...)`, so a second call with a different codec reused the existing instance instead of failing fast.

## How
Added a `checkCodecMismatch(name, codec)` helper invoked at the entry of each codec-specific overload: if an entry already exists under `name` whose codec has a different `Class`, throw `IllegalArgumentException`. The codec-less overloads (default codec) are unchanged. Codec identity is compared by `getClass()` because `Codec` implementations don't override `equals`.

## Testing
- New `RedissonTransactionCodecMismatchTest` (extends `RedisDockerTest`): mismatched codec on `getBucket`/`getSet`/`getMap` throws `IllegalArgumentException`; same codec on `getBucket` does not throw.
- `./mvnw -pl redisson test -Dtest=RedissonTransactionCodecMismatchTest`: tests pass (Testcontainers `redis:8.10`).

Fixes #5127
