### PR TITLE
Avoid redundant cluster management connections

### DIFF
--- a/redisson/src/main/java/org/redisson/connection/ClusterConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/ClusterConnectionManager.java
@@ -379,8 +379,7 @@ public class ClusterConnectionManager extends MasterSlaveConnectionManager {
             return result;
         }
 
-        CompletionStage<RedisConnection> connectionFuture = connectToNode(cfg, partition.getMasterAddress(), configEndpointHostName);
-        return connectionFuture.thenCompose(connection -> {
+        return ensureMasterNodeConnection(cfg, partition.getMasterAddress()).thenCompose(ignored -> {
             MasterSlaveServersConfig config = create(cfg);
             config.setMasterAddress(partition.getMasterAddress().toURIString());
 
@@ -397,7 +396,8 @@ public class ClusterConnectionManager extends MasterSlaveConnectionManager {
                 entry = new MasterSlaveEntry(ClusterConnectionManager.this, config);
             }
 
-            CompletableFuture<RedisClient> f = entry.setupMasterEntry(new RedisURI(config.getMasterAddress()), configEndpointHostName);
+            CompletableFuture<RedisClient> f = setupAndValidateMasterEntry(
+                    entry, new RedisURI(config.getMasterAddress()));
             CompletableFuture<MasterSlaveEntry> entryFuture = f.thenCompose(masterClient -> {
                 if (!config.isSlaveNotUsed()) {
                     return entry.initSlaveBalancer(r -> configEndpointHostName).handle((r, ex) -> {
@@ -429,6 +429,44 @@ public class ClusterConnectionManager extends MasterSlaveConnectionManager {
             });
             return entryFuture;
         }).toCompletableFuture();
+    }
+
+    CompletionStage<Void> ensureMasterNodeConnection(ClusterServersConfig cfg, RedisURI address) {
+        if (configEndpointHostName != null) {
+            // The configuration endpoint connection is used for every topology scan, while
+            // setupMasterEntry initializes and validates the discovered master's command pool.
+            return CompletableFuture.completedFuture(null);
+        }
+        return connectToNode(cfg, address, null).thenApply(r -> null);
+    }
+
+    CompletableFuture<RedisClient> setupAndValidateMasterEntry(MasterSlaveEntry entry, RedisURI address) {
+        CompletableFuture<RedisClient> setupFuture =
+                entry.setupMasterEntry(address, configEndpointHostName);
+        MasterSlaveServersConfig config = entry.getConfig();
+        boolean subscriptionConnectionInitialized = config.getSubscriptionMode() == SubscriptionMode.MASTER
+                && config.getSubscriptionConnectionMinimumIdleSize() > 0;
+        if (configEndpointHostName == null
+                || config.getMasterConnectionMinimumIdleSize() > 0
+                || subscriptionConnectionInitialized) {
+            return setupFuture;
+        }
+
+        if (config.getMasterConnectionPoolSize() == 0) {
+            return setupFuture.thenCompose(client ->
+                    client.connectAsync().thenApply(connection -> {
+                        connection.closeAsync();
+                        return client;
+                    }).toCompletableFuture());
+        }
+
+        // initConnections(0) doesn't open a socket. Acquire one command connection to preserve
+        // startup validation without retaining another topology connection.
+        return setupFuture.thenCompose(client ->
+                entry.connectionWriteOp(RedisCommands.PING).thenApply(connection -> {
+                    entry.releaseWrite(connection);
+                    return client;
+                }));
     }
 
     private void registerMasterEntry(MasterSlaveEntry entry, ClusterPartition partition) {
@@ -1170,4 +1208,3 @@ public class ClusterConnectionManager extends MasterSlaveConnectionManager {
     }
     
 }
-

--- a/redisson/src/test/java/org/redisson/connection/ClusterConnectionManagerTest.java
+++ b/redisson/src/test/java/org/redisson/connection/ClusterConnectionManagerTest.java
@@ -1,0 +1,182 @@
+/**
+ * Copyright (c) 2013-2026 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redisson.connection;
+
+import mockit.Expectations;
+import mockit.Injectable;
+import mockit.Verifications;
+import org.assertj.core.api.Assertions;
+import org.joor.Reflect;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.redisson.api.NodeType;
+import org.redisson.client.RedisClient;
+import org.redisson.client.RedisConnection;
+import org.redisson.client.protocol.RedisCommands;
+import org.redisson.config.ClusterServersConfig;
+import org.redisson.config.Config;
+import org.redisson.config.MasterSlaveServersConfig;
+import org.redisson.config.SubscriptionMode;
+import org.redisson.misc.CompletableFutureWrapper;
+import org.redisson.misc.RedisURI;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class ClusterConnectionManagerTest {
+
+    private ClusterConnectionManager manager;
+
+    @BeforeEach
+    void beforeEach() {
+        Config config = new Config();
+        ClusterServersConfig clusterConfig = config.useClusterServers()
+                .addNodeAddress("redis://config-endpoint.example:6379");
+        manager = new ClusterConnectionManager(clusterConfig, config);
+        Reflect.on(manager).set("configEndpointHostName", "config-endpoint.example");
+    }
+
+    @AfterEach
+    void afterEach() {
+        manager.shutdown(0, 0, TimeUnit.SECONDS);
+    }
+
+    @Test
+    void testConfigurationEndpointSkipsDiscoveredMasterManagementConnection() {
+        CompletionStage<Void> connectionFuture = manager.ensureMasterNodeConnection(
+                new ClusterServersConfig(), new RedisURI("redis://10.0.0.1:6379"));
+
+        Assertions.assertThat(connectionFuture.toCompletableFuture())
+                .isCompletedWithValue(null);
+    }
+
+    @Test
+    void testConfigurationEndpointValidatesZeroIdleMasterThroughCommandPool(
+            @Injectable MasterSlaveEntry entry, @Injectable RedisClient client,
+            @Injectable RedisConnection connection) {
+        MasterSlaveServersConfig masterConfig = new MasterSlaveServersConfig()
+                .setMasterConnectionMinimumIdleSize(0)
+                .setMasterConnectionPoolSize(64)
+                .setSubscriptionMode(SubscriptionMode.SLAVE);
+        RedisURI masterAddress = new RedisURI("redis://10.0.0.1:6379");
+
+        new Expectations() {{
+            entry.setupMasterEntry(masterAddress, "config-endpoint.example");
+            result = CompletableFuture.completedFuture(client);
+            entry.getConfig(); result = masterConfig;
+            entry.connectionWriteOp(RedisCommands.PING);
+            result = CompletableFuture.completedFuture(connection);
+        }};
+
+        RedisClient result = manager.setupAndValidateMasterEntry(entry, masterAddress).join();
+
+        Assertions.assertThat(result).isSameAs(client);
+        new Verifications() {{
+            entry.releaseWrite(connection); times = 1;
+        }};
+    }
+
+    @Test
+    void testConfigurationEndpointValidatesZeroSizedMasterPoolWithTransientConnection(
+            @Injectable MasterSlaveEntry entry, @Injectable RedisClient client,
+            @Injectable RedisConnection connection) {
+        MasterSlaveServersConfig masterConfig = new MasterSlaveServersConfig()
+                .setMasterConnectionMinimumIdleSize(0)
+                .setMasterConnectionPoolSize(0)
+                .setSubscriptionMode(SubscriptionMode.SLAVE);
+        RedisURI masterAddress = new RedisURI("redis://10.0.0.1:6379");
+
+        new Expectations() {{
+            entry.setupMasterEntry(masterAddress, "config-endpoint.example");
+            result = CompletableFuture.completedFuture(client);
+            entry.getConfig(); result = masterConfig;
+            client.connectAsync();
+            result = new CompletableFutureWrapper<>(connection);
+        }};
+
+        RedisClient result = manager.setupAndValidateMasterEntry(entry, masterAddress).join();
+
+        Assertions.assertThat(result).isSameAs(client);
+        new Verifications() {{
+            connection.closeAsync(); times = 1;
+            entry.connectionWriteOp(RedisCommands.PING); times = 0;
+        }};
+    }
+
+    @Test
+    void testConfigurationEndpointUsesInitializedSubscriptionConnection(
+            @Injectable MasterSlaveEntry entry, @Injectable RedisClient client) {
+        MasterSlaveServersConfig masterConfig = new MasterSlaveServersConfig()
+                .setMasterConnectionMinimumIdleSize(0)
+                .setMasterConnectionPoolSize(64)
+                .setSubscriptionMode(SubscriptionMode.MASTER)
+                .setSubscriptionConnectionMinimumIdleSize(1);
+        RedisURI masterAddress = new RedisURI("redis://10.0.0.1:6379");
+
+        new Expectations() {{
+            entry.setupMasterEntry(masterAddress, "config-endpoint.example");
+            result = CompletableFuture.completedFuture(client);
+            entry.getConfig(); result = masterConfig;
+        }};
+
+        RedisClient result = manager.setupAndValidateMasterEntry(entry, masterAddress).join();
+
+        Assertions.assertThat(result).isSameAs(client);
+        new Verifications() {{
+            entry.connectionWriteOp(RedisCommands.PING); times = 0;
+            client.connectAsync(); times = 0;
+        }};
+    }
+
+    @Test
+    void testDirectNodeConnectsToDiscoveredMaster(
+            @Injectable RedisClient client, @Injectable RedisConnection connection) {
+        Config config = new Config();
+        ClusterServersConfig clusterConfig = config.useClusterServers()
+                .addNodeAddress("redis://10.0.0.1:6379");
+        AtomicReference<RedisURI> connectedAddress = new AtomicReference<>();
+        AtomicReference<String> sslHostname = new AtomicReference<>();
+        ClusterConnectionManager directManager = new ClusterConnectionManager(clusterConfig, config) {
+            @Override
+            protected RedisClient createClient(NodeType type, RedisURI address, int timeout,
+                    int commandTimeout, String hostname) {
+                connectedAddress.set(address);
+                sslHostname.set(hostname);
+                return client;
+            }
+        };
+        RedisURI masterAddress = new RedisURI("redis://10.0.0.2:6379");
+
+        try {
+            new Expectations() {{
+                client.connectAsync(); result = new CompletableFutureWrapper<>(connection);
+                connection.isActive(); result = true;
+            }};
+
+            directManager.ensureMasterNodeConnection(clusterConfig, masterAddress)
+                    .toCompletableFuture().join();
+
+            Assertions.assertThat(connectedAddress.get()).isEqualTo(masterAddress);
+            Assertions.assertThat(sslHostname.get()).isNull();
+        } finally {
+            directManager.disconnectNode(masterAddress);
+            directManager.shutdown(0, 0, TimeUnit.SECONDS);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- avoid retaining a separate management connection for every discovered cluster master when a single hostname configuration endpoint is configured
- keep using the configuration endpoint connection for topology scans while the normal command pools own data connections
- preserve startup connectivity validation when the master minimum idle size is zero, including zero-sized master pools
- preserve the existing management-connection behavior for direct IP seeds

The configuration endpoint is resolved again for each cluster scan, so endpoint DNS rotation continues to be discovered without retaining management connections to individual masters.

## Test plan

```text
mise x java@corretto-25.0.4.7.1 maven@3.9.16 -- mvn \
  -Dmaven.repo.local=/tmp/redisson-m2 \
  -Punit-test -pl redisson \
  -Dtest=ClusterConnectionManagerTest,MasterSlaveConnectionManagerTest \
  test checkstyle:check
```

13 tests passed with no failures and no Checkstyle violations.
