### PR TITLE
Fixed - offline slaves and sentinels shouldn't be connected during Sentinel startup. #7286

### DIFF
--- a/redisson/src/main/java/org/redisson/connection/SentinelConnectionManager.java
+++ b/redisson/src/main/java/org/redisson/connection/SentinelConnectionManager.java
@@ -127,6 +127,11 @@ public class SentinelConnectionManager extends MasterSlaveConnectionManager {
                         String flags = map.getOrDefault("flags", "");
                         String masterLinkStatus = map.getOrDefault("master-link-status", "");
 
+                        if (isDown(flags, masterLinkStatus)) {
+                            log.warn("slave: {}:{} is down", host, port);
+                            continue;
+                        }
+
                         InetSocketAddress slaveAddr = resolveIP(host, port).join();
                         RedisURI uri = toURI(slaveAddr);
                         if (isHostname(host)) {
@@ -135,18 +140,20 @@ public class SentinelConnectionManager extends MasterSlaveConnectionManager {
 
                         log.debug("slave {} state: {}", slaveAddr, map);
 
-                        if (isDown(flags, masterLinkStatus)) {
-                            log.warn("slave: {} is down", slaveAddr);
-                        } else {
-                            this.config.addSlaveAddress(uri.toURIString());
-                            log.info("slave: {} added", slaveAddr);
-                        }
+                        this.config.addSlaveAddress(uri.toURIString());
+                        log.info("slave: {} added", slaveAddr);
                     }
 
                     if (cfg.isSentinelsDiscovery()) {
                         List<Map<String, String>> sentinelSentinels = connection.sync(StringCodec.INSTANCE, RedisCommands.SENTINEL_SENTINELS, cfg.getMasterName());
                         for (Map<String, String> map : sentinelSentinels) {
                             if (map.isEmpty()) {
+                                continue;
+                            }
+
+                            String flags = map.getOrDefault("flags", "");
+                            String masterLinkStatus = map.getOrDefault("master-link-status", "");
+                            if (isDown(flags, masterLinkStatus)) {
                                 continue;
                             }
 


### PR DESCRIPTION
Fixes #7286.

The Sentinel startup path in `SentinelConnectionManager` still used the pre-#7004 ordering, unlike the periodic checks that were corrected in #7004:

- **Slaves:** `resolveIP(host, port).join()` ran before the `isDown(...)` check, so an offline replica whose hostname no longer resolves (e.g. a scaled-down k8s pod) threw during startup.
- **Sentinels:** every entry returned by `SENTINEL SENTINELS` was resolved and connected unconditionally, so stale entries pointing at dead addresses each cost a full connect timeout.

Mirror the periodic-check behavior (`checkSlavesChange` / `checkSentinelsChange`) in the startup loops: check `isDown(...)` first and skip offline slaves and sentinels before resolving and connecting.
