### PR TITLE
Fix connection bootstrap ordering around AUTH

### DIFF
--- a/redisson/src/main/java/org/redisson/client/handler/BaseConnectionHandler.java
+++ b/redisson/src/main/java/org/redisson/client/handler/BaseConnectionHandler.java
@@ -63,12 +63,33 @@ public abstract class BaseConnectionHandler<C extends RedisConnection> extends C
 
     @Override
     public void channelActive(ChannelHandlerContext ctx) {
-        List<CompletableFuture<?>> futures = new ArrayList<>(5);
-
-        CompletableFuture<Void> f = authWithCredential();
-        futures.add(f);
-
         RedisClientConfig config = redisClient.getConfig();
+        CompletableFuture<Void> future = authWithCredential()
+                .thenCompose(ignored -> initializeConnection(config));
+
+        future.whenComplete((res, e) -> {
+            if (e != null) {
+                Throwable cause = cause(future);
+                if (cause instanceof RedisRetryException) {
+                    ctx.executor().schedule(() -> {
+                        channelActive(ctx);
+                    }, 1, TimeUnit.SECONDS);
+                    return;
+                }
+                connection.closeAsync();
+                connectionPromise.completeExceptionally(cause);
+                return;
+            }
+
+            startRenewal(ctx, config);
+
+            ctx.fireChannelActive();
+            connectionPromise.complete(connection);
+        });
+    }
+
+    private CompletableFuture<Void> initializeConnection(RedisClientConfig config) {
+        List<CompletableFuture<?>> futures = new ArrayList<>(5);
 
         if (config.getProtocol() == Protocol.RESP3) {
             CompletionStage<Object> f1 = connection.async(RedisCommands.HELLO, "3");
@@ -96,25 +117,7 @@ public abstract class BaseConnectionHandler<C extends RedisConnection> extends C
             futures.add(future.toCompletableFuture());
         }
 
-        CompletableFuture<Void> future = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
-        future.whenComplete((res, e) -> {
-            if (e != null) {
-                if (e instanceof RedisRetryException) {
-                    ctx.executor().schedule(() -> {
-                        channelActive(ctx);
-                    }, 1, TimeUnit.SECONDS);
-                    return;
-                }
-                connection.closeAsync();
-                connectionPromise.completeExceptionally(e);
-                return;
-            }
-
-            startRenewal(ctx, config);
-
-            ctx.fireChannelActive();
-            connectionPromise.complete(connection);
-        });
+        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
     }
 
     private CompletionStage<Void> startRenewal(ChannelHandlerContext ctx, RedisClientConfig config) {

--- a/redisson/src/test/java/org/redisson/RedisClientTest.java
+++ b/redisson/src/test/java/org/redisson/RedisClientTest.java
@@ -15,7 +15,9 @@ import org.redisson.client.protocol.RedisCommands;
 import org.redisson.client.protocol.RedisStrictCommand;
 import org.redisson.client.protocol.pubsub.PubSubType;
 import org.redisson.config.Config;
+import org.redisson.config.Credentials;
 import org.redisson.config.Protocol;
+import org.testcontainers.containers.GenericContainer;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -169,6 +171,40 @@ public class RedisClientTest  {
             return null;
         });
         assertThat(l.await(10, TimeUnit.SECONDS)).isTrue();
+    }
+
+    @Test
+    public void testCredentialsResolveBeforeConnectionInitialization() throws Exception {
+        GenericContainer<?> redis = RedisDockerTest.createContainer("--requirepass", "1234");
+        redis.start();
+
+        CompletableFuture<Credentials> credentialsFuture = new CompletableFuture<>();
+        CountDownLatch resolverCalled = new CountDownLatch(1);
+        RedisClientConfig config = new RedisClientConfig()
+                .setAddress("redis://127.0.0.1:" + redis.getFirstMappedPort())
+                .setProtocol(Protocol.RESP3)
+                .setDatabase(1)
+                .setClientName("redisson-7295")
+                .setCredentialsResolver(address -> {
+                    resolverCalled.countDown();
+                    return credentialsFuture;
+                });
+        RedisClient client = RedisClient.create(config);
+
+        try {
+            CompletionStage<RedisConnection> connectionFuture = client.connectAsync();
+
+            assertThat(resolverCalled.await(10, TimeUnit.SECONDS)).isTrue();
+            assertThat(connectionFuture.toCompletableFuture().isDone()).isFalse();
+
+            credentialsFuture.complete(new Credentials(null, "1234"));
+
+            RedisConnection connection = connectionFuture.toCompletableFuture().get(10, TimeUnit.SECONDS);
+            assertThat(connection.sync(RedisCommands.PING)).isEqualTo("PONG");
+        } finally {
+            client.shutdown();
+            redis.stop();
+        }
     }
 
     @Test


### PR DESCRIPTION
Fixes #7295

## Summary
- wait for asynchronous credentials and a successful AUTH response before sending connection bootstrap commands
- preserve existing retry, shutdown, and connection-promise behavior
- add a regression test covering delayed credentials with RESP3, SELECT, and CLIENT SETNAME

## Validation
- `mvn -pl redisson -Punit-test -Dtest=RedisClientTest#testCredentialsResolveBeforeConnectionInitialization test`
- `mvn -pl redisson -Punit-test -DskipTests checkstyle:check`

The isolated regression test passes. A full `RedisClientTest` run is currently affected by the existing `testSubscribe` 2-second latch timeout in this environment.