### PR TITLE
Fix RReliableTopic polling after listener exception

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonReliableTopic.java
+++ b/redisson/src/main/java/org/redisson/RedissonReliableTopic.java
@@ -204,9 +204,9 @@ public final class RedissonReliableTopic extends RedissonExpirable implements RR
                 return;
             }
 
-            CompletableFuture<Void> done = new CompletableFuture<>();
+            CompletableFuture<Void> done = CompletableFuture.completedFuture(null);
             if (!listeners.isEmpty()) {
-                getServiceManager().getExecutor().execute(() -> {
+                done = CompletableFuture.runAsync(() -> {
                     for (Map.Entry<StreamMessageId, Map<String, Object>> entry : res.entrySet()) {
                         Object m = entry.getValue().get("m");
                         listeners.values().forEach(e -> {
@@ -216,13 +216,27 @@ public final class RedissonReliableTopic extends RedissonExpirable implements RR
                             }
                         });
                     }
-                    done.complete(null);
-                });
-            } else {
-                done.complete(null);
+                }, getServiceManager().getExecutor());
             }
 
-            done.thenAccept(r -> {
+            done.whenComplete((r, listenerException) -> {
+                if (listenerException != null) {
+                    if (getServiceManager().isShuttingDown(listenerException)) {
+                        return;
+                    }
+
+                    log.error("Unable to process a message. Subscriber id: {}", id, listenerException);
+
+                    getServiceManager().newTimeout(task -> {
+                        if (getServiceManager().isShuttingDown()) {
+                            return;
+                        }
+
+                        poll(id);
+                    }, 1, TimeUnit.SECONDS);
+                    return;
+                }
+
                 long time = System.currentTimeMillis();
                 RFuture<Boolean> updateFuture = commandExecutor.evalWriteAsync(getRawName(), StringCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
                                 "local expired = redis.call('zrangebyscore', KEYS[2], 0, tonumber(ARGV[2]) - 1); "

--- a/redisson/src/test/java/org/redisson/RedissonReliableTopicTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonReliableTopicTest.java
@@ -190,6 +190,29 @@ public class RedissonReliableTopicTest extends RedisDockerTest {
     }
 
     @Test
+    public void testListenerFailureDoesNotStopPolling() {
+        RReliableTopic topic = redisson.getReliableTopic("testListenerFailure");
+        AtomicInteger attempts = new AtomicInteger();
+        Queue<String> messages = new ConcurrentLinkedQueue<>();
+        topic.addListener(String.class, (channel, message) -> {
+            if (attempts.getAndIncrement() == 0) {
+                throw new IllegalStateException("listener failure");
+            }
+            messages.add(message);
+        });
+
+        topic.publish("first");
+        Awaitility.await().atMost(Duration.ofSeconds(5))
+                .untilAsserted(() -> assertThat(messages).containsExactly("first"));
+
+        assertThat(topic.countSubscribers()).isOne();
+        assertThat(topic.publish("second")).isOne();
+        Awaitility.await().atMost(Duration.ofSeconds(5))
+                .untilAsserted(() -> assertThat(messages).containsExactly("first", "second"));
+        assertThat(attempts).hasValue(3);
+    }
+
+    @Test
     public void test() throws InterruptedException {
         RReliableTopic rt = redisson.getReliableTopic("test3");
         CountDownLatch a = new CountDownLatch(1);


### PR DESCRIPTION
Fixes #7299

## Problem

An exception thrown by an `RReliableTopic` listener permanently stops the subscriber's polling loop while its watchdog continues to report the subscriber as active. Publishers therefore still see a subscriber, but no more messages are delivered.

## Root cause

Listener dispatch used a manually created `CompletableFuture` that was completed only after every listener returned normally. If a listener threw, the executor task exited before `done.complete(null)`, leaving the future incomplete. The continuation responsible for scheduling the next poll never ran.

## Fix

Run listener dispatch with `CompletableFuture.runAsync(...)` on the existing executor and handle completion with `whenComplete(...)`.

On listener failure, the exception is logged and `poll(id)` is retried after the same one-second delay already used by this polling loop's Redis error path. ACK placement, pending-first delivery, and the successful polling path are unchanged.

Retry limits, DLQ handling, and message discard behavior are unchanged.

## Tests

- Added a regression test verifying that polling resumes after a listener exception and subsequent messages are processed.
- `RedissonReliableTopicTest`: 9 tests passed.
- Full Maven verification completed successfully for all 78 modules.
