### PR TITLE
Use script cache for lock evals when no slaves are available

### DIFF
--- a/redisson/src/main/java/org/redisson/command/CommandAsyncService.java
+++ b/redisson/src/main/java/org/redisson/command/CommandAsyncService.java
@@ -1096,14 +1096,11 @@ public class CommandAsyncService implements CommandAsyncExecutor {
                                       String script, List<Object> keys, Object... params) {
         if (getServiceManager().getCfg().isSingleConfig()
                 || this instanceof CommandBatchService
-                   || (waitSupportedCommands != null && waitSupportedCommands.isEmpty() && syncMode == SyncMode.AUTO)
-                    || (waitSupportedCommands != null && !waitSupportedCommands.contains(RedisCommands.WAIT.getName()) && syncMode == SyncMode.WAIT)
-                        || (waitSupportedCommands != null && !waitSupportedCommands.contains(RedisCommands.WAITAOF.getName()) && syncMode == SyncMode.WAIT_AOF)
+                || (waitSupportedCommands != null && waitSupportedCommands.isEmpty() && syncMode == SyncMode.AUTO)
+                || (waitSupportedCommands != null && !waitSupportedCommands.contains(RedisCommands.WAIT.getName()) && syncMode == SyncMode.WAIT)
+                || (waitSupportedCommands != null && !waitSupportedCommands.contains(RedisCommands.WAITAOF.getName()) && syncMode == SyncMode.WAIT_AOF)
                 ) {
-            if (retry) {
-                return evalWriteAsync(key, codec, evalCommandType, script, keys, params);
-            }
-            return evalWriteNoRetryAsync(key, codec, evalCommandType, script, keys, params);
+            return evalWrite(retry, key, codec, evalCommandType, script, keys, params);
         }
 
         CompletionStage<BatchResult<?>> waitFuture = CompletableFuture.completedFuture(null);
@@ -1195,11 +1192,8 @@ public class CommandAsyncService implements CommandAsyncExecutor {
                 e.setAvailableSlaves(availableSlaves);
                 e.setAofEnabled(aofEnabled);
 
-                if (availableSlaves == 0 && !aofEnabled) {
-                    if (retry) {
-                        return evalWriteAsync(key, codec, evalCommandType, script, keys, params);
-                    }
-                    return evalWriteNoRetryAsync(key, codec, evalCommandType, script, keys, params);
+                if (!isSyncRequired(availableSlaves, aofEnabled)) {
+                    return evalWrite(retry, key, codec, evalCommandType, script, keys, params);
                 }
 
                 CommandBatchService executorService = createCommandBatchService(availableSlaves, aofEnabled, timeout);
@@ -1239,6 +1233,18 @@ public class CommandAsyncService implements CommandAsyncExecutor {
         }).thenCompose(f -> f);
 
         return new CompletableFutureWrapper<>(resFuture);
+    }
+
+    private boolean isSyncRequired(int availableSlaves, boolean aofEnabled) {
+        return availableSlaves > 0 || aofEnabled;
+    }
+
+    private <T> RFuture<T> evalWrite(boolean retry, String key, Codec codec, RedisCommand<T> evalCommandType,
+                                    String script, List<Object> keys, Object... params) {
+        if (retry) {
+            return evalWriteAsync(key, codec, evalCommandType, script, keys, params);
+        }
+        return evalWriteNoRetryAsync(key, codec, evalCommandType, script, keys, params);
     }
 
     protected CommandBatchService createCommandBatchService(int availableSlaves, boolean aofEnabled, long timeout) {

--- a/redisson/src/main/java/org/redisson/command/CommandAsyncService.java
+++ b/redisson/src/main/java/org/redisson/command/CommandAsyncService.java
@@ -1195,6 +1195,13 @@ public class CommandAsyncService implements CommandAsyncExecutor {
                 e.setAvailableSlaves(availableSlaves);
                 e.setAofEnabled(aofEnabled);
 
+                if (availableSlaves == 0 && !aofEnabled) {
+                    if (retry) {
+                        return evalWriteAsync(key, codec, evalCommandType, script, keys, params);
+                    }
+                    return evalWriteNoRetryAsync(key, codec, evalCommandType, script, keys, params);
+                }
+
                 CommandBatchService executorService = createCommandBatchService(availableSlaves, aofEnabled, timeout);
                 RFuture<T> result = executorService.evalWriteAsync(key, codec, evalCommandType, script, keys, params);
                 if (executorService == this) {

--- a/redisson/src/test/java/org/redisson/RedissonLockTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonLockTest.java
@@ -1,12 +1,20 @@
 package org.redisson;
 
+import mockit.Invocation;
+import mockit.Mock;
+import mockit.MockUp;
 import org.joor.Reflect;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.redisson.api.*;
 import org.redisson.client.*;
+import org.redisson.client.codec.Codec;
+import org.redisson.client.protocol.RedisCommand;
 import org.redisson.client.protocol.RedisCommands;
+import org.redisson.command.CommandBatchService;
 import org.redisson.config.Config;
+import org.redisson.connection.ConnectionManager;
+import org.redisson.connection.MasterSlaveEntry;
 import org.redisson.renewal.LockEntry;
 import org.redisson.renewal.LockTask;
 import org.testcontainers.containers.GenericContainer;
@@ -24,6 +32,41 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
 public class RedissonLockTest extends BaseConcurrentTest {
+    @Test
+    public void testLockUsesDirectEvalWhenNoSlavesAvailable() {
+        testInCluster(redisson -> {
+            Config config = redisson.getConfig();
+            config.setUseScriptCache(true);
+
+            RedissonClient instance = Redisson.create(config);
+            try {
+                RLock lock = instance.getLock("testLockUsesDirectEvalWhenNoSlavesAvailable");
+                ConnectionManager connectionManager = Reflect.on(instance).get("connectionManager");
+                MasterSlaveEntry entry = connectionManager.getEntry(lock.getName());
+                entry.setAvailableSlaves(0);
+                entry.setAofEnabled(false);
+
+                AtomicInteger batchEvalCounter = new AtomicInteger();
+                new MockUp<CommandBatchService>() {
+                    @Mock
+                    public <T, R> RFuture<R> evalWriteAsync(Invocation inv, String key, Codec codec,
+                                                            RedisCommand<T> evalCommandType, String script,
+                                                            List<Object> keys, Object... params) {
+                        batchEvalCounter.incrementAndGet();
+                        return inv.proceed(key, codec, evalCommandType, script, keys, params);
+                    }
+                };
+
+                lock.lock();
+                lock.unlock();
+
+                assertThat(batchEvalCounter).hasValue(0);
+            } finally {
+                instance.shutdown();
+            }
+        });
+    }
+
     static class LockWithoutBoolean extends Thread {
         private CountDownLatch latch;
         private RedissonClient redisson;


### PR DESCRIPTION
## What problem does this PR solve?

When useScriptCache(true) is enabled, lock operations can still bypass the script cache in non-single configurations when there are no available slaves and AOF sync is disabled.

In this case, the lock script goes through CommandBatchService, so Redisson sends EVAL instead of using the configured script cache.

Fixes #7238

## Root cause

CommandAsyncService#syncedEval enters the batch execution path for lock evals in non-single configurations.

When there are no connected slaves and AOF sync is disabled, there is nothing to wait for. However, the code still creates a CommandBatchService.

Since CommandBatchService doesn’t use the normal eval script cache path, useScriptCache(true) doesn’t work in this case.

## Fix

Skip the batch execution path when no synchronization is needed.

If there are no available slaves and AOF sync is disabled, syncedEval now goes directly to the normal eval path. The existing batch behavior is kept when slave or AOF synchronization is required.

The retry/no-retry eval selection is also moved into a small helper to make the main flow simpler.

## Tests

Added a regression test for lock operations with script cache enabled when no slaves are available.

Test command:

```bash
mvn -pl redisson -Punit-test -DskipITs -Dtest=org.redisson.RedissonLockTest#testLockUsesDirectEvalWhenNoSlavesAvailable test
```

Result:
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS