### PR TITLE
Fix ByteBuf leak in BaseTransactionalMap.isEqual()

### DIFF
--- a/redisson/src/main/java/org/redisson/transaction/BaseTransactionalMap.java
+++ b/redisson/src/main/java/org/redisson/transaction/BaseTransactionalMap.java
@@ -703,8 +703,8 @@ public class BaseTransactionalMap<K, V> extends BaseTransactionalObject {
         try {
             return valueBuf.equals(oldValueBuf);
         } finally {
-            valueBuf.readableBytes();
-            oldValueBuf.readableBytes();
+            valueBuf.release();
+            oldValueBuf.release();
         }
     }
 

--- a/redisson/src/test/java/org/redisson/transaction/RedissonTransactionalMapTest.java
+++ b/redisson/src/test/java/org/redisson/transaction/RedissonTransactionalMapTest.java
@@ -1,7 +1,17 @@
 package org.redisson.transaction;
 
+import io.netty.buffer.ByteBuf;
+import org.junit.jupiter.api.Test;
 import org.redisson.api.RMap;
 import org.redisson.api.RTransaction;
+import org.redisson.api.TransactionOptions;
+import org.redisson.client.codec.StringCodec;
+import org.redisson.client.protocol.Encoder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class RedissonTransactionalMapTest extends RedissonBaseTransactionalMapTest {
 
@@ -15,5 +25,35 @@ public class RedissonTransactionalMapTest extends RedissonBaseTransactionalMapTe
         return transaction.getMap("test");
     }
 
-    
+    @Test
+    public void testContainsValueReleasesEncodedBuffers() {
+        TrackingStringCodec codec = new TrackingStringCodec();
+        RTransaction transaction = redisson.createTransaction(TransactionOptions.defaults());
+        RMap<String, String> map = transaction.getMap("isequal-leak", codec);
+
+        map.put("k", "v");
+        codec.allocated.clear();
+
+        assertThat(map.containsValue("v")).isTrue();
+        assertThat(codec.allocated).hasSize(2);
+        assertThat(codec.allocated).allSatisfy(buf -> assertThat(buf.refCnt()).isZero());
+
+        transaction.commit();
+    }
+
+    static final class TrackingStringCodec extends StringCodec {
+
+        final List<ByteBuf> allocated = new ArrayList<ByteBuf>();
+
+        @Override
+        public Encoder getValueEncoder() {
+            Encoder delegate = super.getValueEncoder();
+            return in -> {
+                ByteBuf buf = delegate.encode(in);
+                allocated.add(buf);
+                return buf;
+            };
+        }
+    }
+
 }


### PR DESCRIPTION
## Problem

`BaseTransactionalMap.isEqual()` encodes both arguments into `ByteBuf` objects, but its `finally` block calls `readableBytes()` on them instead of `release()`:

```java
private boolean isEqual(Object value, Object oldValue) {
    ByteBuf valueBuf = ((RedissonObject) map).encodeMapValue(value);
    ByteBuf oldValueBuf = ((RedissonObject) map).encodeMapValue(oldValue);
    try {
        return valueBuf.equals(oldValueBuf);
    } finally {
        valueBuf.readableBytes();
        oldValueBuf.readableBytes();
    }
}
```

`readableBytes()` only queries the buffer; it does not free it. So both encoded buffers leak on every `isEqual()` call. The sibling `RedissonTransactionalBucket.isEquals()` was already fixed in #7216, and `BaseTransactionalSet.isEqual()` already calls `release()`.

## Fix

Release both buffers in the `finally` block.

## Test

Adds `RedissonTransactionalMapTest#testContainsValueReleasesEncodedBuffers`. It tracks `ByteBuf` instances allocated by a custom map-value encoder during transactional `containsValue()` (the path that calls `isEqual()` on local state) and asserts both buffers are released.

Executed:

- `mvn -pl redisson -Punit-test -Dtest=RedissonTransactionalMapTest#testContainsValueReleasesEncodedBuffers test` RED on master (`refCnt` 1), GREEN after the fix
- `mvn -pl redisson -Punit-test -Dtest=RedissonTransactionalMapTest test` 16/16
- `mvn -pl redisson -Punit-test -Dtest=RedissonTransactionalMapCacheTest,RedissonTransactionalSetTest test` 25/25

Fixes #7302