### PR TITLE
Fix - RSetCache entry added without TTL may become invisible

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonSetCache.java
+++ b/redisson/src/main/java/org/redisson/RedissonSetCache.java
@@ -253,9 +253,10 @@ public class RedissonSetCache<V> extends RedissonExpirable implements RSetCache<
             throw new NullPointerException("TimeUnit param can't be null");
         }
 
-        ByteBuf objectState = encode(value);
+        return addAsync(value, System.currentTimeMillis() + unit.toMillis(ttl), encode(value));
+    }
 
-        long timeoutDate = System.currentTimeMillis() + unit.toMillis(ttl);
+    private RFuture<Boolean> addAsync(V value, long timeoutDate, ByteBuf objectState) {
         String name = getRawName(value);
         return commandExecutor.evalWriteAsync(name, codec, RedisCommands.EVAL_BOOLEAN,
                 "local expireDateScore = redis.call('zscore', KEYS[1], ARGV[3]); " +
@@ -274,7 +275,7 @@ public class RedissonSetCache<V> extends RedissonExpirable implements RSetCache<
 
     @Override
     public RFuture<Boolean> tryAddAsync(V... values) {
-        return tryAddAsync(92233720368547758L - System.currentTimeMillis(), TimeUnit.MILLISECONDS, values);
+        return tryAddAsync(92233720368547758L - System.currentTimeMillis(), values);
     }
 
     @Override
@@ -288,7 +289,10 @@ public class RedissonSetCache<V> extends RedissonExpirable implements RSetCache<
         if (ttl == 0) {
             timeoutDate = 92233720368547758L - System.currentTimeMillis();
         }
+        return tryAddAsync(timeoutDate, values);
+    }
 
+    private RFuture<Boolean> tryAddAsync(long timeoutDate, V... values) {
         List<Object> params = new ArrayList<>();
         params.add(System.currentTimeMillis());
         params.add(timeoutDate);
@@ -311,7 +315,7 @@ public class RedissonSetCache<V> extends RedissonExpirable implements RSetCache<
 
     @Override
     public RFuture<Boolean> addAsync(V value) {
-        return addAsync(value, 92233720368547758L - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
+        return addAsync(value, 92233720368547758L - System.currentTimeMillis(), encode(value));
     }
 
     @Override

--- a/redisson/src/test/java/org/redisson/RedissonSetCacheTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonSetCacheTest.java
@@ -188,7 +188,21 @@ public class RedissonSetCacheTest extends RedisDockerTest {
         set.iterator().next();
         set.destroy();
     }
-    
+
+    @Test
+    public void testAddSlowEncodingValue() {
+        Map<Integer, String> map = new HashMap<>();
+        for (int i = 0; i < 80000; i++) {
+            map.put(i, "value" + i);
+        }
+        RSetCache<Map<Integer, String>> set = redisson.getSetCache("simple");
+        assertThat(set.add(map)).isTrue();
+        assertThat(set.contains(map)).isTrue();
+        assertThat(set.size()).isEqualTo(1);
+        assertThat(set.readAll()).containsExactly(map);
+        set.destroy();
+    }
+
     @Test
     public void testAddBean() throws InterruptedException, ExecutionException {
         SimpleBean sb = new SimpleBean();


### PR DESCRIPTION
## What

`addAsync(V)` and `tryAddAsync(V...)` now compute the no-TTL expiration score from a single clock sample, stored as `92233720368547758L - now` (absolute score), instead of deriving a TTL and re-sampling the clock.

## Why

An entry added to `RSetCache` without a TTL can become invisible to `size()`, `readAll()`, `iterator()` and the sort/union reads, while `contains()` still returns `true` for it. `RedissonTransactionalSetCacheTest.testAdd` fails on current master because of this (`expected: 3 but was: 2`: the first no-TTL add is the one that disappears).

The old path sampled the clock twice with the value encoding in between: `now2 + (92233720368547758L - now1) = 92233720368547758L + (now2 - now1)`. When encoding took more than ~20ms (first add through a cold codec, or a value that is slow to encode), the score exceeded the `92233720368547758L` constant used as the upper score bound by all range-based reads, and after double rounding the entry fell outside the range:

```
zcard = 3, size = 2
entries: 3 -> 92233720368547760, 4 -> 92233720368547760, 1 -> 92233720368547790
                                                                ^ above the read bound
```

## How

`92233720368547758L - now` is stored as an absolute score computed once, before encoding. This matches what `addAllAsync()`, `retainAllAsync()` and the zero-ttl branches of `addIfAbsentAsync()`/`addIfGreaterAsync()` already write, and it is strictly below the read bound.

## Root cause

Two clock samples straddling `encode(value)` made the manufactured "infinite" score drift above the fixed read bound; the sibling methods that write the score directly never had this drift.

## Testing

- New regression test `RedissonSetCacheTest#testAddSlowEncodingValue`: the value takes tens of milliseconds to encode on every run, so the window is deterministic. Fails on master (`expected: 1 but was: 0`), passes with the fix.
- `RedissonTransactionalSetCacheTest` (8/8), `RedissonTransactionalSetTest` (8/8), `RedissonSetCacheReactiveTest` (20/20) pass; the failing `testAdd` scenario of the transactional suite passes here and fails on master. `RedissonSetCacheTest#testDiff` also turns from red on master to green with this change.
- Note: `RedissonSetCacheTest#testDestroy` and `#testIntersection` fail on unmodified master as well and are unrelated to this change (left as is).


Note: entries already stored with an out-of-bound score by a previous version remain invisible until re-added; this change prevents new occurrences.


Alternative direction: raising the read-side upper score bound (the fixed constant used by size()/readAll()/iterator and the sort/union reads) would make already-affected entries visible again; happy to do that as a follow-up if preferred.
