### PR TITLE
Fix reactive getEx() ignoring PERSIST/KEEPTTL/EXAT/PXAT (fixes #7308)

### DIFF
--- a/redisson-spring/redisson-spring-data/redisson-spring-data-26/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStringCommands.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-26/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStringCommands.java
@@ -27,6 +27,7 @@ import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.BitFieldSubCommands;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.*;
 import org.springframework.data.redis.connection.ReactiveStringCommands;
+import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.connection.RedisStringCommands.BitOperation;
 import org.springframework.data.redis.connection.RedisStringCommands.SetOption;
 import org.springframework.util.Assert;
@@ -475,10 +476,23 @@ public class RedissonReactiveStringCommands extends RedissonBaseReactive impleme
         return execute(commands, command -> {
 
             Assert.notNull(command.getKey(), "Key must not be null!");
+            Assert.notNull(command.getExpiration(), "Expiration must not be null!");
 
             byte[] keyBuf = toByteArray(command.getKey());
-            Mono<byte[]> m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf,
-                                    "PX", command.getExpiration().getExpirationTimeInMilliseconds());
+            Expiration expiration = command.getExpiration();
+
+            Mono<byte[]> m;
+            if (expiration.isPersistent()) {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf, "PERSIST");
+            } else if (expiration.isKeepTtl()) {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf);
+            } else if (expiration.isUnixTimestamp()) {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf,
+                        "PXAT", expiration.getExpirationTimeInMilliseconds());
+            } else {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf,
+                        "PX", expiration.getExpirationTimeInMilliseconds());
+            }
             return m.map(v -> new ByteBufferResponse<>(command, ByteBuffer.wrap(v)))
                     .defaultIfEmpty(new AbsentByteBufferResponse<>(command));
         });

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-26/src/test/java/org/redisson/spring/data/connection/RedissonReactiveStringCommandsTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-26/src/test/java/org/redisson/spring/data/connection/RedissonReactiveStringCommandsTest.java
@@ -1,0 +1,112 @@
+package org.redisson.spring.data.connection;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.ReactiveRedisConnection;
+import org.springframework.data.redis.connection.ReactiveStringCommands;
+import org.springframework.data.redis.core.types.Expiration;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Reproduction/regression coverage for RedissonReactiveStringCommands.getEx() ignoring the
+ * PERSIST / KEEPTTL / EXAT / PXAT options carried by GetExCommand.getExpiration() and always
+ * sending "PX &lt;millis&gt;" regardless of what was actually requested. The sync equivalent
+ * (RedissonConnection.getEx()) was fixed for this exact bug in commit 6c393a51f, but the reactive
+ * implementation in this same file was never updated to match.
+ */
+public class RedissonReactiveStringCommandsTest extends BaseConnectionTest {
+
+    private ByteBuffer buf(String s) {
+        return ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private ReactiveStringCommands stringCommands() {
+        RedissonConnectionFactory factory = new RedissonConnectionFactory(redisson);
+        ReactiveRedisConnection conn = factory.getReactiveConnection();
+        return conn.stringCommands();
+    }
+
+    private Long ttlMillis(String key) {
+        RedissonConnectionFactory factory = new RedissonConnectionFactory(redisson);
+        return factory.getReactiveConnection().keyCommands().pTtl(buf(key)).block();
+    }
+
+    // Baseline: plain relative expiration (milliseconds) - this is the ONLY variant the current
+    // (buggy) implementation happens to get right, since it's the one hardcoded case.
+    @Test
+    public void testGetExRelativeMillis() {
+        redisson.getBucket("k1", org.redisson.client.codec.StringCodec.INSTANCE).set("v1");
+
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k1")).withExpiration(Expiration.milliseconds(60_000));
+        ByteBuffer result = stringCommands().getEx(reactor.core.publisher.Mono.just(cmd))
+                .map(r -> r.getOutput()).blockFirst();
+
+        assertThat(StandardCharsets.UTF_8.decode(result).toString()).isEqualTo("v1");
+        Long ttl = ttlMillis("k1");
+        assertThat(ttl).isBetween(55_000L, 60_000L);
+    }
+
+    // PERSIST: should remove the TTL entirely. Currently sends "PX <persistent-sentinel-millis>"
+    // instead of "PERSIST", so the key keeps expiring instead of becoming persistent.
+    @Test
+    public void testGetExPersistRemovesTtl() {
+        redisson.getBucket("k2", org.redisson.client.codec.StringCodec.INSTANCE)
+                .set("v2", Duration.ofSeconds(30));
+        assertThat(ttlMillis("k2")).isGreaterThan(0);
+
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k2")).withExpiration(Expiration.persistent());
+        stringCommands().getEx(reactor.core.publisher.Mono.just(cmd)).blockFirst();
+
+        Long ttl = ttlMillis("k2");
+        assertThat(ttl)
+                .as("PERSIST must remove the TTL entirely (PTTL should be -1)")
+                .isEqualTo(-1L);
+    }
+
+    // KEEPTTL: should leave the existing TTL untouched. Currently overwrites it with a fresh,
+    // unrelated "PX" value derived from Expiration's internal sentinel encoding.
+    @Test
+    public void testGetExKeepTtlPreservesOriginalTtl() {
+        redisson.getBucket("k3", org.redisson.client.codec.StringCodec.INSTANCE)
+                .set("v3", Duration.ofSeconds(100));
+        Long ttlBefore = ttlMillis("k3");
+
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k3")).withExpiration(Expiration.keepTtl());
+        stringCommands().getEx(reactor.core.publisher.Mono.just(cmd)).blockFirst();
+
+        Long ttlAfter = ttlMillis("k3");
+        assertThat(ttlAfter)
+                .as("KEEPTTL must leave the original TTL (~100s) untouched, not overwrite it")
+                .isCloseTo(ttlBefore, org.assertj.core.data.Offset.offset(2000L));
+    }
+
+    // EXAT: absolute expiration in seconds since epoch. Currently the absolute timestamp is sent
+    // as a relative "PX" delay instead, producing a wildly different actual expiration time.
+    @Test
+    public void testGetExAbsoluteSecondsUsesExatSemantics() {
+        redisson.getBucket("k4", org.redisson.client.codec.StringCodec.INSTANCE).set("v4");
+
+        long expireAtEpochSeconds = Instant.now().plusSeconds(120).getEpochSecond();
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k4"))
+                .withExpiration(Expiration.unixTimestamp(expireAtEpochSeconds, java.util.concurrent.TimeUnit.SECONDS));
+        stringCommands().getEx(reactor.core.publisher.Mono.just(cmd)).blockFirst();
+
+        Long ttl = ttlMillis("k4");
+        // Expected: close to 120_000ms (now -> expireAtEpochSeconds). If the bug is present, the
+        // command instead sends "PX <raw epoch seconds value>", producing a TTL of roughly
+        // (epochSeconds * 1000 - now) milliseconds - i.e. decades in the future - or an outright
+        // Redis error depending on how large that number is.
+        assertThat(ttl)
+                .as("EXAT must set the TTL to ~120s from now, not treat the epoch value as a relative PX delay")
+                .isBetween(110_000L, 120_000L);
+    }
+}

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-27/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStringCommands.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-27/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStringCommands.java
@@ -27,6 +27,7 @@ import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.BitFieldSubCommands;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.*;
 import org.springframework.data.redis.connection.ReactiveStringCommands;
+import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.connection.RedisStringCommands.BitOperation;
 import org.springframework.data.redis.connection.RedisStringCommands.SetOption;
 import org.springframework.util.Assert;
@@ -475,10 +476,23 @@ public class RedissonReactiveStringCommands extends RedissonBaseReactive impleme
         return execute(commands, command -> {
 
             Assert.notNull(command.getKey(), "Key must not be null!");
+            Assert.notNull(command.getExpiration(), "Expiration must not be null!");
 
             byte[] keyBuf = toByteArray(command.getKey());
-            Mono<byte[]> m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf,
-                                    "PX", command.getExpiration().getExpirationTimeInMilliseconds());
+            Expiration expiration = command.getExpiration();
+
+            Mono<byte[]> m;
+            if (expiration.isPersistent()) {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf, "PERSIST");
+            } else if (expiration.isKeepTtl()) {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf);
+            } else if (expiration.isUnixTimestamp()) {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf,
+                        "PXAT", expiration.getExpirationTimeInMilliseconds());
+            } else {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf,
+                        "PX", expiration.getExpirationTimeInMilliseconds());
+            }
             return m.map(v -> new ByteBufferResponse<>(command, ByteBuffer.wrap(v)))
                     .defaultIfEmpty(new AbsentByteBufferResponse<>(command));
         });

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-27/src/test/java/org/redisson/spring/data/connection/RedissonReactiveStringCommandsTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-27/src/test/java/org/redisson/spring/data/connection/RedissonReactiveStringCommandsTest.java
@@ -1,0 +1,112 @@
+package org.redisson.spring.data.connection;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.ReactiveRedisConnection;
+import org.springframework.data.redis.connection.ReactiveStringCommands;
+import org.springframework.data.redis.core.types.Expiration;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Reproduction/regression coverage for RedissonReactiveStringCommands.getEx() ignoring the
+ * PERSIST / KEEPTTL / EXAT / PXAT options carried by GetExCommand.getExpiration() and always
+ * sending "PX &lt;millis&gt;" regardless of what was actually requested. The sync equivalent
+ * (RedissonConnection.getEx()) was fixed for this exact bug in commit 6c393a51f, but the reactive
+ * implementation in this same file was never updated to match.
+ */
+public class RedissonReactiveStringCommandsTest extends BaseConnectionTest {
+
+    private ByteBuffer buf(String s) {
+        return ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private ReactiveStringCommands stringCommands() {
+        RedissonConnectionFactory factory = new RedissonConnectionFactory(redisson);
+        ReactiveRedisConnection conn = factory.getReactiveConnection();
+        return conn.stringCommands();
+    }
+
+    private Long ttlMillis(String key) {
+        RedissonConnectionFactory factory = new RedissonConnectionFactory(redisson);
+        return factory.getReactiveConnection().keyCommands().pTtl(buf(key)).block();
+    }
+
+    // Baseline: plain relative expiration (milliseconds) - this is the ONLY variant the current
+    // (buggy) implementation happens to get right, since it's the one hardcoded case.
+    @Test
+    public void testGetExRelativeMillis() {
+        redisson.getBucket("k1", org.redisson.client.codec.StringCodec.INSTANCE).set("v1");
+
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k1")).withExpiration(Expiration.milliseconds(60_000));
+        ByteBuffer result = stringCommands().getEx(reactor.core.publisher.Mono.just(cmd))
+                .map(r -> r.getOutput()).blockFirst();
+
+        assertThat(StandardCharsets.UTF_8.decode(result).toString()).isEqualTo("v1");
+        Long ttl = ttlMillis("k1");
+        assertThat(ttl).isBetween(55_000L, 60_000L);
+    }
+
+    // PERSIST: should remove the TTL entirely. Currently sends "PX <persistent-sentinel-millis>"
+    // instead of "PERSIST", so the key keeps expiring instead of becoming persistent.
+    @Test
+    public void testGetExPersistRemovesTtl() {
+        redisson.getBucket("k2", org.redisson.client.codec.StringCodec.INSTANCE)
+                .set("v2", Duration.ofSeconds(30));
+        assertThat(ttlMillis("k2")).isGreaterThan(0);
+
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k2")).withExpiration(Expiration.persistent());
+        stringCommands().getEx(reactor.core.publisher.Mono.just(cmd)).blockFirst();
+
+        Long ttl = ttlMillis("k2");
+        assertThat(ttl)
+                .as("PERSIST must remove the TTL entirely (PTTL should be -1)")
+                .isEqualTo(-1L);
+    }
+
+    // KEEPTTL: should leave the existing TTL untouched. Currently overwrites it with a fresh,
+    // unrelated "PX" value derived from Expiration's internal sentinel encoding.
+    @Test
+    public void testGetExKeepTtlPreservesOriginalTtl() {
+        redisson.getBucket("k3", org.redisson.client.codec.StringCodec.INSTANCE)
+                .set("v3", Duration.ofSeconds(100));
+        Long ttlBefore = ttlMillis("k3");
+
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k3")).withExpiration(Expiration.keepTtl());
+        stringCommands().getEx(reactor.core.publisher.Mono.just(cmd)).blockFirst();
+
+        Long ttlAfter = ttlMillis("k3");
+        assertThat(ttlAfter)
+                .as("KEEPTTL must leave the original TTL (~100s) untouched, not overwrite it")
+                .isCloseTo(ttlBefore, org.assertj.core.data.Offset.offset(2000L));
+    }
+
+    // EXAT: absolute expiration in seconds since epoch. Currently the absolute timestamp is sent
+    // as a relative "PX" delay instead, producing a wildly different actual expiration time.
+    @Test
+    public void testGetExAbsoluteSecondsUsesExatSemantics() {
+        redisson.getBucket("k4", org.redisson.client.codec.StringCodec.INSTANCE).set("v4");
+
+        long expireAtEpochSeconds = Instant.now().plusSeconds(120).getEpochSecond();
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k4"))
+                .withExpiration(Expiration.unixTimestamp(expireAtEpochSeconds, java.util.concurrent.TimeUnit.SECONDS));
+        stringCommands().getEx(reactor.core.publisher.Mono.just(cmd)).blockFirst();
+
+        Long ttl = ttlMillis("k4");
+        // Expected: close to 120_000ms (now -> expireAtEpochSeconds). If the bug is present, the
+        // command instead sends "PX <raw epoch seconds value>", producing a TTL of roughly
+        // (epochSeconds * 1000 - now) milliseconds - i.e. decades in the future - or an outright
+        // Redis error depending on how large that number is.
+        assertThat(ttl)
+                .as("EXAT must set the TTL to ~120s from now, not treat the epoch value as a relative PX delay")
+                .isBetween(110_000L, 120_000L);
+    }
+}

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-30/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStringCommands.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-30/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStringCommands.java
@@ -27,6 +27,7 @@ import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.BitFieldSubCommands;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.*;
 import org.springframework.data.redis.connection.ReactiveStringCommands;
+import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.connection.RedisStringCommands.BitOperation;
 import org.springframework.data.redis.connection.RedisStringCommands.SetOption;
 import org.springframework.util.Assert;
@@ -475,10 +476,23 @@ public class RedissonReactiveStringCommands extends RedissonBaseReactive impleme
         return execute(commands, command -> {
 
             Assert.notNull(command.getKey(), "Key must not be null!");
+            Assert.notNull(command.getExpiration(), "Expiration must not be null!");
 
             byte[] keyBuf = toByteArray(command.getKey());
-            Mono<byte[]> m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf,
-                                    "PX", command.getExpiration().getExpirationTimeInMilliseconds());
+            Expiration expiration = command.getExpiration();
+
+            Mono<byte[]> m;
+            if (expiration.isPersistent()) {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf, "PERSIST");
+            } else if (expiration.isKeepTtl()) {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf);
+            } else if (expiration.isUnixTimestamp()) {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf,
+                        "PXAT", expiration.getExpirationTimeInMilliseconds());
+            } else {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf,
+                        "PX", expiration.getExpirationTimeInMilliseconds());
+            }
             return m.map(v -> new ByteBufferResponse<>(command, ByteBuffer.wrap(v)))
                     .defaultIfEmpty(new AbsentByteBufferResponse<>(command));
         });

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-30/src/test/java/org/redisson/spring/data/connection/RedissonReactiveStringCommandsTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-30/src/test/java/org/redisson/spring/data/connection/RedissonReactiveStringCommandsTest.java
@@ -1,0 +1,112 @@
+package org.redisson.spring.data.connection;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.ReactiveRedisConnection;
+import org.springframework.data.redis.connection.ReactiveStringCommands;
+import org.springframework.data.redis.core.types.Expiration;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Reproduction/regression coverage for RedissonReactiveStringCommands.getEx() ignoring the
+ * PERSIST / KEEPTTL / EXAT / PXAT options carried by GetExCommand.getExpiration() and always
+ * sending "PX &lt;millis&gt;" regardless of what was actually requested. The sync equivalent
+ * (RedissonConnection.getEx()) was fixed for this exact bug in commit 6c393a51f, but the reactive
+ * implementation in this same file was never updated to match.
+ */
+public class RedissonReactiveStringCommandsTest extends BaseConnectionTest {
+
+    private ByteBuffer buf(String s) {
+        return ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private ReactiveStringCommands stringCommands() {
+        RedissonConnectionFactory factory = new RedissonConnectionFactory(redisson);
+        ReactiveRedisConnection conn = factory.getReactiveConnection();
+        return conn.stringCommands();
+    }
+
+    private Long ttlMillis(String key) {
+        RedissonConnectionFactory factory = new RedissonConnectionFactory(redisson);
+        return factory.getReactiveConnection().keyCommands().pTtl(buf(key)).block();
+    }
+
+    // Baseline: plain relative expiration (milliseconds) - this is the ONLY variant the current
+    // (buggy) implementation happens to get right, since it's the one hardcoded case.
+    @Test
+    public void testGetExRelativeMillis() {
+        redisson.getBucket("k1", org.redisson.client.codec.StringCodec.INSTANCE).set("v1");
+
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k1")).withExpiration(Expiration.milliseconds(60_000));
+        ByteBuffer result = stringCommands().getEx(reactor.core.publisher.Mono.just(cmd))
+                .map(r -> r.getOutput()).blockFirst();
+
+        assertThat(StandardCharsets.UTF_8.decode(result).toString()).isEqualTo("v1");
+        Long ttl = ttlMillis("k1");
+        assertThat(ttl).isBetween(55_000L, 60_000L);
+    }
+
+    // PERSIST: should remove the TTL entirely. Currently sends "PX <persistent-sentinel-millis>"
+    // instead of "PERSIST", so the key keeps expiring instead of becoming persistent.
+    @Test
+    public void testGetExPersistRemovesTtl() {
+        redisson.getBucket("k2", org.redisson.client.codec.StringCodec.INSTANCE)
+                .set("v2", Duration.ofSeconds(30));
+        assertThat(ttlMillis("k2")).isGreaterThan(0);
+
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k2")).withExpiration(Expiration.persistent());
+        stringCommands().getEx(reactor.core.publisher.Mono.just(cmd)).blockFirst();
+
+        Long ttl = ttlMillis("k2");
+        assertThat(ttl)
+                .as("PERSIST must remove the TTL entirely (PTTL should be -1)")
+                .isEqualTo(-1L);
+    }
+
+    // KEEPTTL: should leave the existing TTL untouched. Currently overwrites it with a fresh,
+    // unrelated "PX" value derived from Expiration's internal sentinel encoding.
+    @Test
+    public void testGetExKeepTtlPreservesOriginalTtl() {
+        redisson.getBucket("k3", org.redisson.client.codec.StringCodec.INSTANCE)
+                .set("v3", Duration.ofSeconds(100));
+        Long ttlBefore = ttlMillis("k3");
+
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k3")).withExpiration(Expiration.keepTtl());
+        stringCommands().getEx(reactor.core.publisher.Mono.just(cmd)).blockFirst();
+
+        Long ttlAfter = ttlMillis("k3");
+        assertThat(ttlAfter)
+                .as("KEEPTTL must leave the original TTL (~100s) untouched, not overwrite it")
+                .isCloseTo(ttlBefore, org.assertj.core.data.Offset.offset(2000L));
+    }
+
+    // EXAT: absolute expiration in seconds since epoch. Currently the absolute timestamp is sent
+    // as a relative "PX" delay instead, producing a wildly different actual expiration time.
+    @Test
+    public void testGetExAbsoluteSecondsUsesExatSemantics() {
+        redisson.getBucket("k4", org.redisson.client.codec.StringCodec.INSTANCE).set("v4");
+
+        long expireAtEpochSeconds = Instant.now().plusSeconds(120).getEpochSecond();
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k4"))
+                .withExpiration(Expiration.unixTimestamp(expireAtEpochSeconds, java.util.concurrent.TimeUnit.SECONDS));
+        stringCommands().getEx(reactor.core.publisher.Mono.just(cmd)).blockFirst();
+
+        Long ttl = ttlMillis("k4");
+        // Expected: close to 120_000ms (now -> expireAtEpochSeconds). If the bug is present, the
+        // command instead sends "PX <raw epoch seconds value>", producing a TTL of roughly
+        // (epochSeconds * 1000 - now) milliseconds - i.e. decades in the future - or an outright
+        // Redis error depending on how large that number is.
+        assertThat(ttl)
+                .as("EXAT must set the TTL to ~120s from now, not treat the epoch value as a relative PX delay")
+                .isBetween(110_000L, 120_000L);
+    }
+}

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-31/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStringCommands.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-31/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStringCommands.java
@@ -27,6 +27,7 @@ import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.BitFieldSubCommands;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.*;
 import org.springframework.data.redis.connection.ReactiveStringCommands;
+import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.connection.RedisStringCommands.BitOperation;
 import org.springframework.data.redis.connection.RedisStringCommands.SetOption;
 import org.springframework.util.Assert;
@@ -475,10 +476,23 @@ public class RedissonReactiveStringCommands extends RedissonBaseReactive impleme
         return execute(commands, command -> {
 
             Assert.notNull(command.getKey(), "Key must not be null!");
+            Assert.notNull(command.getExpiration(), "Expiration must not be null!");
 
             byte[] keyBuf = toByteArray(command.getKey());
-            Mono<byte[]> m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf,
-                                    "PX", command.getExpiration().getExpirationTimeInMilliseconds());
+            Expiration expiration = command.getExpiration();
+
+            Mono<byte[]> m;
+            if (expiration.isPersistent()) {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf, "PERSIST");
+            } else if (expiration.isKeepTtl()) {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf);
+            } else if (expiration.isUnixTimestamp()) {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf,
+                        "PXAT", expiration.getExpirationTimeInMilliseconds());
+            } else {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf,
+                        "PX", expiration.getExpirationTimeInMilliseconds());
+            }
             return m.map(v -> new ByteBufferResponse<>(command, ByteBuffer.wrap(v)))
                     .defaultIfEmpty(new AbsentByteBufferResponse<>(command));
         });

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-31/src/test/java/org/redisson/spring/data/connection/RedissonReactiveStringCommandsTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-31/src/test/java/org/redisson/spring/data/connection/RedissonReactiveStringCommandsTest.java
@@ -1,0 +1,112 @@
+package org.redisson.spring.data.connection;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.ReactiveRedisConnection;
+import org.springframework.data.redis.connection.ReactiveStringCommands;
+import org.springframework.data.redis.core.types.Expiration;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Reproduction/regression coverage for RedissonReactiveStringCommands.getEx() ignoring the
+ * PERSIST / KEEPTTL / EXAT / PXAT options carried by GetExCommand.getExpiration() and always
+ * sending "PX &lt;millis&gt;" regardless of what was actually requested. The sync equivalent
+ * (RedissonConnection.getEx()) was fixed for this exact bug in commit 6c393a51f, but the reactive
+ * implementation in this same file was never updated to match.
+ */
+public class RedissonReactiveStringCommandsTest extends BaseConnectionTest {
+
+    private ByteBuffer buf(String s) {
+        return ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private ReactiveStringCommands stringCommands() {
+        RedissonConnectionFactory factory = new RedissonConnectionFactory(redisson);
+        ReactiveRedisConnection conn = factory.getReactiveConnection();
+        return conn.stringCommands();
+    }
+
+    private Long ttlMillis(String key) {
+        RedissonConnectionFactory factory = new RedissonConnectionFactory(redisson);
+        return factory.getReactiveConnection().keyCommands().pTtl(buf(key)).block();
+    }
+
+    // Baseline: plain relative expiration (milliseconds) - this is the ONLY variant the current
+    // (buggy) implementation happens to get right, since it's the one hardcoded case.
+    @Test
+    public void testGetExRelativeMillis() {
+        redisson.getBucket("k1", org.redisson.client.codec.StringCodec.INSTANCE).set("v1");
+
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k1")).withExpiration(Expiration.milliseconds(60_000));
+        ByteBuffer result = stringCommands().getEx(reactor.core.publisher.Mono.just(cmd))
+                .map(r -> r.getOutput()).blockFirst();
+
+        assertThat(StandardCharsets.UTF_8.decode(result).toString()).isEqualTo("v1");
+        Long ttl = ttlMillis("k1");
+        assertThat(ttl).isBetween(55_000L, 60_000L);
+    }
+
+    // PERSIST: should remove the TTL entirely. Currently sends "PX <persistent-sentinel-millis>"
+    // instead of "PERSIST", so the key keeps expiring instead of becoming persistent.
+    @Test
+    public void testGetExPersistRemovesTtl() {
+        redisson.getBucket("k2", org.redisson.client.codec.StringCodec.INSTANCE)
+                .set("v2", Duration.ofSeconds(30));
+        assertThat(ttlMillis("k2")).isGreaterThan(0);
+
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k2")).withExpiration(Expiration.persistent());
+        stringCommands().getEx(reactor.core.publisher.Mono.just(cmd)).blockFirst();
+
+        Long ttl = ttlMillis("k2");
+        assertThat(ttl)
+                .as("PERSIST must remove the TTL entirely (PTTL should be -1)")
+                .isEqualTo(-1L);
+    }
+
+    // KEEPTTL: should leave the existing TTL untouched. Currently overwrites it with a fresh,
+    // unrelated "PX" value derived from Expiration's internal sentinel encoding.
+    @Test
+    public void testGetExKeepTtlPreservesOriginalTtl() {
+        redisson.getBucket("k3", org.redisson.client.codec.StringCodec.INSTANCE)
+                .set("v3", Duration.ofSeconds(100));
+        Long ttlBefore = ttlMillis("k3");
+
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k3")).withExpiration(Expiration.keepTtl());
+        stringCommands().getEx(reactor.core.publisher.Mono.just(cmd)).blockFirst();
+
+        Long ttlAfter = ttlMillis("k3");
+        assertThat(ttlAfter)
+                .as("KEEPTTL must leave the original TTL (~100s) untouched, not overwrite it")
+                .isCloseTo(ttlBefore, org.assertj.core.data.Offset.offset(2000L));
+    }
+
+    // EXAT: absolute expiration in seconds since epoch. Currently the absolute timestamp is sent
+    // as a relative "PX" delay instead, producing a wildly different actual expiration time.
+    @Test
+    public void testGetExAbsoluteSecondsUsesExatSemantics() {
+        redisson.getBucket("k4", org.redisson.client.codec.StringCodec.INSTANCE).set("v4");
+
+        long expireAtEpochSeconds = Instant.now().plusSeconds(120).getEpochSecond();
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k4"))
+                .withExpiration(Expiration.unixTimestamp(expireAtEpochSeconds, java.util.concurrent.TimeUnit.SECONDS));
+        stringCommands().getEx(reactor.core.publisher.Mono.just(cmd)).blockFirst();
+
+        Long ttl = ttlMillis("k4");
+        // Expected: close to 120_000ms (now -> expireAtEpochSeconds). If the bug is present, the
+        // command instead sends "PX <raw epoch seconds value>", producing a TTL of roughly
+        // (epochSeconds * 1000 - now) milliseconds - i.e. decades in the future - or an outright
+        // Redis error depending on how large that number is.
+        assertThat(ttl)
+                .as("EXAT must set the TTL to ~120s from now, not treat the epoch value as a relative PX delay")
+                .isBetween(110_000L, 120_000L);
+    }
+}

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-32/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStringCommands.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-32/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStringCommands.java
@@ -27,6 +27,7 @@ import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.BitFieldSubCommands;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.*;
 import org.springframework.data.redis.connection.ReactiveStringCommands;
+import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.connection.RedisStringCommands.BitOperation;
 import org.springframework.data.redis.connection.RedisStringCommands.SetOption;
 import org.springframework.util.Assert;
@@ -475,10 +476,23 @@ public class RedissonReactiveStringCommands extends RedissonBaseReactive impleme
         return execute(commands, command -> {
 
             Assert.notNull(command.getKey(), "Key must not be null!");
+            Assert.notNull(command.getExpiration(), "Expiration must not be null!");
 
             byte[] keyBuf = toByteArray(command.getKey());
-            Mono<byte[]> m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf,
-                                    "PX", command.getExpiration().getExpirationTimeInMilliseconds());
+            Expiration expiration = command.getExpiration();
+
+            Mono<byte[]> m;
+            if (expiration.isPersistent()) {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf, "PERSIST");
+            } else if (expiration.isKeepTtl()) {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf);
+            } else if (expiration.isUnixTimestamp()) {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf,
+                        "PXAT", expiration.getExpirationTimeInMilliseconds());
+            } else {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf,
+                        "PX", expiration.getExpirationTimeInMilliseconds());
+            }
             return m.map(v -> new ByteBufferResponse<>(command, ByteBuffer.wrap(v)))
                     .defaultIfEmpty(new AbsentByteBufferResponse<>(command));
         });

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-32/src/test/java/org/redisson/spring/data/connection/RedissonReactiveStringCommandsTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-32/src/test/java/org/redisson/spring/data/connection/RedissonReactiveStringCommandsTest.java
@@ -1,0 +1,112 @@
+package org.redisson.spring.data.connection;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.ReactiveRedisConnection;
+import org.springframework.data.redis.connection.ReactiveStringCommands;
+import org.springframework.data.redis.core.types.Expiration;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Reproduction/regression coverage for RedissonReactiveStringCommands.getEx() ignoring the
+ * PERSIST / KEEPTTL / EXAT / PXAT options carried by GetExCommand.getExpiration() and always
+ * sending "PX &lt;millis&gt;" regardless of what was actually requested. The sync equivalent
+ * (RedissonConnection.getEx()) was fixed for this exact bug in commit 6c393a51f, but the reactive
+ * implementation in this same file was never updated to match.
+ */
+public class RedissonReactiveStringCommandsTest extends BaseConnectionTest {
+
+    private ByteBuffer buf(String s) {
+        return ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private ReactiveStringCommands stringCommands() {
+        RedissonConnectionFactory factory = new RedissonConnectionFactory(redisson);
+        ReactiveRedisConnection conn = factory.getReactiveConnection();
+        return conn.stringCommands();
+    }
+
+    private Long ttlMillis(String key) {
+        RedissonConnectionFactory factory = new RedissonConnectionFactory(redisson);
+        return factory.getReactiveConnection().keyCommands().pTtl(buf(key)).block();
+    }
+
+    // Baseline: plain relative expiration (milliseconds) - this is the ONLY variant the current
+    // (buggy) implementation happens to get right, since it's the one hardcoded case.
+    @Test
+    public void testGetExRelativeMillis() {
+        redisson.getBucket("k1", org.redisson.client.codec.StringCodec.INSTANCE).set("v1");
+
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k1")).withExpiration(Expiration.milliseconds(60_000));
+        ByteBuffer result = stringCommands().getEx(reactor.core.publisher.Mono.just(cmd))
+                .map(r -> r.getOutput()).blockFirst();
+
+        assertThat(StandardCharsets.UTF_8.decode(result).toString()).isEqualTo("v1");
+        Long ttl = ttlMillis("k1");
+        assertThat(ttl).isBetween(55_000L, 60_000L);
+    }
+
+    // PERSIST: should remove the TTL entirely. Currently sends "PX <persistent-sentinel-millis>"
+    // instead of "PERSIST", so the key keeps expiring instead of becoming persistent.
+    @Test
+    public void testGetExPersistRemovesTtl() {
+        redisson.getBucket("k2", org.redisson.client.codec.StringCodec.INSTANCE)
+                .set("v2", Duration.ofSeconds(30));
+        assertThat(ttlMillis("k2")).isGreaterThan(0);
+
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k2")).withExpiration(Expiration.persistent());
+        stringCommands().getEx(reactor.core.publisher.Mono.just(cmd)).blockFirst();
+
+        Long ttl = ttlMillis("k2");
+        assertThat(ttl)
+                .as("PERSIST must remove the TTL entirely (PTTL should be -1)")
+                .isEqualTo(-1L);
+    }
+
+    // KEEPTTL: should leave the existing TTL untouched. Currently overwrites it with a fresh,
+    // unrelated "PX" value derived from Expiration's internal sentinel encoding.
+    @Test
+    public void testGetExKeepTtlPreservesOriginalTtl() {
+        redisson.getBucket("k3", org.redisson.client.codec.StringCodec.INSTANCE)
+                .set("v3", Duration.ofSeconds(100));
+        Long ttlBefore = ttlMillis("k3");
+
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k3")).withExpiration(Expiration.keepTtl());
+        stringCommands().getEx(reactor.core.publisher.Mono.just(cmd)).blockFirst();
+
+        Long ttlAfter = ttlMillis("k3");
+        assertThat(ttlAfter)
+                .as("KEEPTTL must leave the original TTL (~100s) untouched, not overwrite it")
+                .isCloseTo(ttlBefore, org.assertj.core.data.Offset.offset(2000L));
+    }
+
+    // EXAT: absolute expiration in seconds since epoch. Currently the absolute timestamp is sent
+    // as a relative "PX" delay instead, producing a wildly different actual expiration time.
+    @Test
+    public void testGetExAbsoluteSecondsUsesExatSemantics() {
+        redisson.getBucket("k4", org.redisson.client.codec.StringCodec.INSTANCE).set("v4");
+
+        long expireAtEpochSeconds = Instant.now().plusSeconds(120).getEpochSecond();
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k4"))
+                .withExpiration(Expiration.unixTimestamp(expireAtEpochSeconds, java.util.concurrent.TimeUnit.SECONDS));
+        stringCommands().getEx(reactor.core.publisher.Mono.just(cmd)).blockFirst();
+
+        Long ttl = ttlMillis("k4");
+        // Expected: close to 120_000ms (now -> expireAtEpochSeconds). If the bug is present, the
+        // command instead sends "PX <raw epoch seconds value>", producing a TTL of roughly
+        // (epochSeconds * 1000 - now) milliseconds - i.e. decades in the future - or an outright
+        // Redis error depending on how large that number is.
+        assertThat(ttl)
+                .as("EXAT must set the TTL to ~120s from now, not treat the epoch value as a relative PX delay")
+                .isBetween(110_000L, 120_000L);
+    }
+}

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-33/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStringCommands.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-33/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStringCommands.java
@@ -27,6 +27,7 @@ import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.BitFieldSubCommands;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.*;
 import org.springframework.data.redis.connection.ReactiveStringCommands;
+import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.connection.RedisStringCommands.BitOperation;
 import org.springframework.data.redis.connection.RedisStringCommands.SetOption;
 import org.springframework.util.Assert;
@@ -475,10 +476,23 @@ public class RedissonReactiveStringCommands extends RedissonBaseReactive impleme
         return execute(commands, command -> {
 
             Assert.notNull(command.getKey(), "Key must not be null!");
+            Assert.notNull(command.getExpiration(), "Expiration must not be null!");
 
             byte[] keyBuf = toByteArray(command.getKey());
-            Mono<byte[]> m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf,
-                                    "PX", command.getExpiration().getExpirationTimeInMilliseconds());
+            Expiration expiration = command.getExpiration();
+
+            Mono<byte[]> m;
+            if (expiration.isPersistent()) {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf, "PERSIST");
+            } else if (expiration.isKeepTtl()) {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf);
+            } else if (expiration.isUnixTimestamp()) {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf,
+                        "PXAT", expiration.getExpirationTimeInMilliseconds());
+            } else {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf,
+                        "PX", expiration.getExpirationTimeInMilliseconds());
+            }
             return m.map(v -> new ByteBufferResponse<>(command, ByteBuffer.wrap(v)))
                     .defaultIfEmpty(new AbsentByteBufferResponse<>(command));
         });

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-33/src/test/java/org/redisson/spring/data/connection/RedissonReactiveStringCommandsTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-33/src/test/java/org/redisson/spring/data/connection/RedissonReactiveStringCommandsTest.java
@@ -1,0 +1,112 @@
+package org.redisson.spring.data.connection;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.ReactiveRedisConnection;
+import org.springframework.data.redis.connection.ReactiveStringCommands;
+import org.springframework.data.redis.core.types.Expiration;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Reproduction/regression coverage for RedissonReactiveStringCommands.getEx() ignoring the
+ * PERSIST / KEEPTTL / EXAT / PXAT options carried by GetExCommand.getExpiration() and always
+ * sending "PX &lt;millis&gt;" regardless of what was actually requested. The sync equivalent
+ * (RedissonConnection.getEx()) was fixed for this exact bug in commit 6c393a51f, but the reactive
+ * implementation in this same file was never updated to match.
+ */
+public class RedissonReactiveStringCommandsTest extends BaseConnectionTest {
+
+    private ByteBuffer buf(String s) {
+        return ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private ReactiveStringCommands stringCommands() {
+        RedissonConnectionFactory factory = new RedissonConnectionFactory(redisson);
+        ReactiveRedisConnection conn = factory.getReactiveConnection();
+        return conn.stringCommands();
+    }
+
+    private Long ttlMillis(String key) {
+        RedissonConnectionFactory factory = new RedissonConnectionFactory(redisson);
+        return factory.getReactiveConnection().keyCommands().pTtl(buf(key)).block();
+    }
+
+    // Baseline: plain relative expiration (milliseconds) - this is the ONLY variant the current
+    // (buggy) implementation happens to get right, since it's the one hardcoded case.
+    @Test
+    public void testGetExRelativeMillis() {
+        redisson.getBucket("k1", org.redisson.client.codec.StringCodec.INSTANCE).set("v1");
+
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k1")).withExpiration(Expiration.milliseconds(60_000));
+        ByteBuffer result = stringCommands().getEx(reactor.core.publisher.Mono.just(cmd))
+                .map(r -> r.getOutput()).blockFirst();
+
+        assertThat(StandardCharsets.UTF_8.decode(result).toString()).isEqualTo("v1");
+        Long ttl = ttlMillis("k1");
+        assertThat(ttl).isBetween(55_000L, 60_000L);
+    }
+
+    // PERSIST: should remove the TTL entirely. Currently sends "PX <persistent-sentinel-millis>"
+    // instead of "PERSIST", so the key keeps expiring instead of becoming persistent.
+    @Test
+    public void testGetExPersistRemovesTtl() {
+        redisson.getBucket("k2", org.redisson.client.codec.StringCodec.INSTANCE)
+                .set("v2", Duration.ofSeconds(30));
+        assertThat(ttlMillis("k2")).isGreaterThan(0);
+
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k2")).withExpiration(Expiration.persistent());
+        stringCommands().getEx(reactor.core.publisher.Mono.just(cmd)).blockFirst();
+
+        Long ttl = ttlMillis("k2");
+        assertThat(ttl)
+                .as("PERSIST must remove the TTL entirely (PTTL should be -1)")
+                .isEqualTo(-1L);
+    }
+
+    // KEEPTTL: should leave the existing TTL untouched. Currently overwrites it with a fresh,
+    // unrelated "PX" value derived from Expiration's internal sentinel encoding.
+    @Test
+    public void testGetExKeepTtlPreservesOriginalTtl() {
+        redisson.getBucket("k3", org.redisson.client.codec.StringCodec.INSTANCE)
+                .set("v3", Duration.ofSeconds(100));
+        Long ttlBefore = ttlMillis("k3");
+
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k3")).withExpiration(Expiration.keepTtl());
+        stringCommands().getEx(reactor.core.publisher.Mono.just(cmd)).blockFirst();
+
+        Long ttlAfter = ttlMillis("k3");
+        assertThat(ttlAfter)
+                .as("KEEPTTL must leave the original TTL (~100s) untouched, not overwrite it")
+                .isCloseTo(ttlBefore, org.assertj.core.data.Offset.offset(2000L));
+    }
+
+    // EXAT: absolute expiration in seconds since epoch. Currently the absolute timestamp is sent
+    // as a relative "PX" delay instead, producing a wildly different actual expiration time.
+    @Test
+    public void testGetExAbsoluteSecondsUsesExatSemantics() {
+        redisson.getBucket("k4", org.redisson.client.codec.StringCodec.INSTANCE).set("v4");
+
+        long expireAtEpochSeconds = Instant.now().plusSeconds(120).getEpochSecond();
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k4"))
+                .withExpiration(Expiration.unixTimestamp(expireAtEpochSeconds, java.util.concurrent.TimeUnit.SECONDS));
+        stringCommands().getEx(reactor.core.publisher.Mono.just(cmd)).blockFirst();
+
+        Long ttl = ttlMillis("k4");
+        // Expected: close to 120_000ms (now -> expireAtEpochSeconds). If the bug is present, the
+        // command instead sends "PX <raw epoch seconds value>", producing a TTL of roughly
+        // (epochSeconds * 1000 - now) milliseconds - i.e. decades in the future - or an outright
+        // Redis error depending on how large that number is.
+        assertThat(ttl)
+                .as("EXAT must set the TTL to ~120s from now, not treat the epoch value as a relative PX delay")
+                .isBetween(110_000L, 120_000L);
+    }
+}

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-34/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStringCommands.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-34/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStringCommands.java
@@ -27,6 +27,7 @@ import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.BitFieldSubCommands;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.*;
 import org.springframework.data.redis.connection.ReactiveStringCommands;
+import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.connection.RedisStringCommands.BitOperation;
 import org.springframework.data.redis.connection.RedisStringCommands.SetOption;
 import org.springframework.util.Assert;
@@ -475,10 +476,23 @@ public class RedissonReactiveStringCommands extends RedissonBaseReactive impleme
         return execute(commands, command -> {
 
             Assert.notNull(command.getKey(), "Key must not be null!");
+            Assert.notNull(command.getExpiration(), "Expiration must not be null!");
 
             byte[] keyBuf = toByteArray(command.getKey());
-            Mono<byte[]> m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf,
-                                    "PX", command.getExpiration().getExpirationTimeInMilliseconds());
+            Expiration expiration = command.getExpiration();
+
+            Mono<byte[]> m;
+            if (expiration.isPersistent()) {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf, "PERSIST");
+            } else if (expiration.isKeepTtl()) {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf);
+            } else if (expiration.isUnixTimestamp()) {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf,
+                        "PXAT", expiration.getExpirationTimeInMilliseconds());
+            } else {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf,
+                        "PX", expiration.getExpirationTimeInMilliseconds());
+            }
             return m.map(v -> new ByteBufferResponse<>(command, ByteBuffer.wrap(v)))
                     .defaultIfEmpty(new AbsentByteBufferResponse<>(command));
         });

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-34/src/test/java/org/redisson/spring/data/connection/RedissonReactiveStringCommandsTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-34/src/test/java/org/redisson/spring/data/connection/RedissonReactiveStringCommandsTest.java
@@ -1,0 +1,112 @@
+package org.redisson.spring.data.connection;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.ReactiveRedisConnection;
+import org.springframework.data.redis.connection.ReactiveStringCommands;
+import org.springframework.data.redis.core.types.Expiration;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Reproduction/regression coverage for RedissonReactiveStringCommands.getEx() ignoring the
+ * PERSIST / KEEPTTL / EXAT / PXAT options carried by GetExCommand.getExpiration() and always
+ * sending "PX &lt;millis&gt;" regardless of what was actually requested. The sync equivalent
+ * (RedissonConnection.getEx()) was fixed for this exact bug in commit 6c393a51f, but the reactive
+ * implementation in this same file was never updated to match.
+ */
+public class RedissonReactiveStringCommandsTest extends BaseConnectionTest {
+
+    private ByteBuffer buf(String s) {
+        return ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private ReactiveStringCommands stringCommands() {
+        RedissonConnectionFactory factory = new RedissonConnectionFactory(redisson);
+        ReactiveRedisConnection conn = factory.getReactiveConnection();
+        return conn.stringCommands();
+    }
+
+    private Long ttlMillis(String key) {
+        RedissonConnectionFactory factory = new RedissonConnectionFactory(redisson);
+        return factory.getReactiveConnection().keyCommands().pTtl(buf(key)).block();
+    }
+
+    // Baseline: plain relative expiration (milliseconds) - this is the ONLY variant the current
+    // (buggy) implementation happens to get right, since it's the one hardcoded case.
+    @Test
+    public void testGetExRelativeMillis() {
+        redisson.getBucket("k1", org.redisson.client.codec.StringCodec.INSTANCE).set("v1");
+
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k1")).withExpiration(Expiration.milliseconds(60_000));
+        ByteBuffer result = stringCommands().getEx(reactor.core.publisher.Mono.just(cmd))
+                .map(r -> r.getOutput()).blockFirst();
+
+        assertThat(StandardCharsets.UTF_8.decode(result).toString()).isEqualTo("v1");
+        Long ttl = ttlMillis("k1");
+        assertThat(ttl).isBetween(55_000L, 60_000L);
+    }
+
+    // PERSIST: should remove the TTL entirely. Currently sends "PX <persistent-sentinel-millis>"
+    // instead of "PERSIST", so the key keeps expiring instead of becoming persistent.
+    @Test
+    public void testGetExPersistRemovesTtl() {
+        redisson.getBucket("k2", org.redisson.client.codec.StringCodec.INSTANCE)
+                .set("v2", Duration.ofSeconds(30));
+        assertThat(ttlMillis("k2")).isGreaterThan(0);
+
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k2")).withExpiration(Expiration.persistent());
+        stringCommands().getEx(reactor.core.publisher.Mono.just(cmd)).blockFirst();
+
+        Long ttl = ttlMillis("k2");
+        assertThat(ttl)
+                .as("PERSIST must remove the TTL entirely (PTTL should be -1)")
+                .isEqualTo(-1L);
+    }
+
+    // KEEPTTL: should leave the existing TTL untouched. Currently overwrites it with a fresh,
+    // unrelated "PX" value derived from Expiration's internal sentinel encoding.
+    @Test
+    public void testGetExKeepTtlPreservesOriginalTtl() {
+        redisson.getBucket("k3", org.redisson.client.codec.StringCodec.INSTANCE)
+                .set("v3", Duration.ofSeconds(100));
+        Long ttlBefore = ttlMillis("k3");
+
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k3")).withExpiration(Expiration.keepTtl());
+        stringCommands().getEx(reactor.core.publisher.Mono.just(cmd)).blockFirst();
+
+        Long ttlAfter = ttlMillis("k3");
+        assertThat(ttlAfter)
+                .as("KEEPTTL must leave the original TTL (~100s) untouched, not overwrite it")
+                .isCloseTo(ttlBefore, org.assertj.core.data.Offset.offset(2000L));
+    }
+
+    // EXAT: absolute expiration in seconds since epoch. Currently the absolute timestamp is sent
+    // as a relative "PX" delay instead, producing a wildly different actual expiration time.
+    @Test
+    public void testGetExAbsoluteSecondsUsesExatSemantics() {
+        redisson.getBucket("k4", org.redisson.client.codec.StringCodec.INSTANCE).set("v4");
+
+        long expireAtEpochSeconds = Instant.now().plusSeconds(120).getEpochSecond();
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k4"))
+                .withExpiration(Expiration.unixTimestamp(expireAtEpochSeconds, java.util.concurrent.TimeUnit.SECONDS));
+        stringCommands().getEx(reactor.core.publisher.Mono.just(cmd)).blockFirst();
+
+        Long ttl = ttlMillis("k4");
+        // Expected: close to 120_000ms (now -> expireAtEpochSeconds). If the bug is present, the
+        // command instead sends "PX <raw epoch seconds value>", producing a TTL of roughly
+        // (epochSeconds * 1000 - now) milliseconds - i.e. decades in the future - or an outright
+        // Redis error depending on how large that number is.
+        assertThat(ttl)
+                .as("EXAT must set the TTL to ~120s from now, not treat the epoch value as a relative PX delay")
+                .isBetween(110_000L, 120_000L);
+    }
+}

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-35/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStringCommands.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-35/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStringCommands.java
@@ -27,6 +27,7 @@ import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.BitFieldSubCommands;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.*;
 import org.springframework.data.redis.connection.ReactiveStringCommands;
+import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.connection.RedisStringCommands.BitOperation;
 import org.springframework.data.redis.connection.RedisStringCommands.SetOption;
 import org.springframework.util.Assert;
@@ -476,10 +477,23 @@ public class RedissonReactiveStringCommands extends RedissonBaseReactive impleme
         return execute(commands, command -> {
 
             Assert.notNull(command.getKey(), "Key must not be null!");
+            Assert.notNull(command.getExpiration(), "Expiration must not be null!");
 
             byte[] keyBuf = toByteArray(command.getKey());
-            Mono<byte[]> m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf,
-                                    "PX", command.getExpiration().getExpirationTimeInMilliseconds());
+            Expiration expiration = command.getExpiration();
+
+            Mono<byte[]> m;
+            if (expiration.isPersistent()) {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf, "PERSIST");
+            } else if (expiration.isKeepTtl()) {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf);
+            } else if (expiration.isUnixTimestamp()) {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf,
+                        "PXAT", expiration.getExpirationTimeInMilliseconds());
+            } else {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf,
+                        "PX", expiration.getExpirationTimeInMilliseconds());
+            }
             return m.map(v -> new ByteBufferResponse<>(command, ByteBuffer.wrap(v)))
                     .defaultIfEmpty(new AbsentByteBufferResponse<>(command));
         });

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-35/src/test/java/org/redisson/spring/data/connection/RedissonReactiveStringCommandsTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-35/src/test/java/org/redisson/spring/data/connection/RedissonReactiveStringCommandsTest.java
@@ -1,0 +1,112 @@
+package org.redisson.spring.data.connection;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.ReactiveRedisConnection;
+import org.springframework.data.redis.connection.ReactiveStringCommands;
+import org.springframework.data.redis.core.types.Expiration;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Reproduction/regression coverage for RedissonReactiveStringCommands.getEx() ignoring the
+ * PERSIST / KEEPTTL / EXAT / PXAT options carried by GetExCommand.getExpiration() and always
+ * sending "PX &lt;millis&gt;" regardless of what was actually requested. The sync equivalent
+ * (RedissonConnection.getEx()) was fixed for this exact bug in commit 6c393a51f, but the reactive
+ * implementation in this same file was never updated to match.
+ */
+public class RedissonReactiveStringCommandsTest extends BaseConnectionTest {
+
+    private ByteBuffer buf(String s) {
+        return ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private ReactiveStringCommands stringCommands() {
+        RedissonConnectionFactory factory = new RedissonConnectionFactory(redisson);
+        ReactiveRedisConnection conn = factory.getReactiveConnection();
+        return conn.stringCommands();
+    }
+
+    private Long ttlMillis(String key) {
+        RedissonConnectionFactory factory = new RedissonConnectionFactory(redisson);
+        return factory.getReactiveConnection().keyCommands().pTtl(buf(key)).block();
+    }
+
+    // Baseline: plain relative expiration (milliseconds) - this is the ONLY variant the current
+    // (buggy) implementation happens to get right, since it's the one hardcoded case.
+    @Test
+    public void testGetExRelativeMillis() {
+        redisson.getBucket("k1", org.redisson.client.codec.StringCodec.INSTANCE).set("v1");
+
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k1")).withExpiration(Expiration.milliseconds(60_000));
+        ByteBuffer result = stringCommands().getEx(reactor.core.publisher.Mono.just(cmd))
+                .map(r -> r.getOutput()).blockFirst();
+
+        assertThat(StandardCharsets.UTF_8.decode(result).toString()).isEqualTo("v1");
+        Long ttl = ttlMillis("k1");
+        assertThat(ttl).isBetween(55_000L, 60_000L);
+    }
+
+    // PERSIST: should remove the TTL entirely. Currently sends "PX <persistent-sentinel-millis>"
+    // instead of "PERSIST", so the key keeps expiring instead of becoming persistent.
+    @Test
+    public void testGetExPersistRemovesTtl() {
+        redisson.getBucket("k2", org.redisson.client.codec.StringCodec.INSTANCE)
+                .set("v2", Duration.ofSeconds(30));
+        assertThat(ttlMillis("k2")).isGreaterThan(0);
+
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k2")).withExpiration(Expiration.persistent());
+        stringCommands().getEx(reactor.core.publisher.Mono.just(cmd)).blockFirst();
+
+        Long ttl = ttlMillis("k2");
+        assertThat(ttl)
+                .as("PERSIST must remove the TTL entirely (PTTL should be -1)")
+                .isEqualTo(-1L);
+    }
+
+    // KEEPTTL: should leave the existing TTL untouched. Currently overwrites it with a fresh,
+    // unrelated "PX" value derived from Expiration's internal sentinel encoding.
+    @Test
+    public void testGetExKeepTtlPreservesOriginalTtl() {
+        redisson.getBucket("k3", org.redisson.client.codec.StringCodec.INSTANCE)
+                .set("v3", Duration.ofSeconds(100));
+        Long ttlBefore = ttlMillis("k3");
+
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k3")).withExpiration(Expiration.keepTtl());
+        stringCommands().getEx(reactor.core.publisher.Mono.just(cmd)).blockFirst();
+
+        Long ttlAfter = ttlMillis("k3");
+        assertThat(ttlAfter)
+                .as("KEEPTTL must leave the original TTL (~100s) untouched, not overwrite it")
+                .isCloseTo(ttlBefore, org.assertj.core.data.Offset.offset(2000L));
+    }
+
+    // EXAT: absolute expiration in seconds since epoch. Currently the absolute timestamp is sent
+    // as a relative "PX" delay instead, producing a wildly different actual expiration time.
+    @Test
+    public void testGetExAbsoluteSecondsUsesExatSemantics() {
+        redisson.getBucket("k4", org.redisson.client.codec.StringCodec.INSTANCE).set("v4");
+
+        long expireAtEpochSeconds = Instant.now().plusSeconds(120).getEpochSecond();
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k4"))
+                .withExpiration(Expiration.unixTimestamp(expireAtEpochSeconds, java.util.concurrent.TimeUnit.SECONDS));
+        stringCommands().getEx(reactor.core.publisher.Mono.just(cmd)).blockFirst();
+
+        Long ttl = ttlMillis("k4");
+        // Expected: close to 120_000ms (now -> expireAtEpochSeconds). If the bug is present, the
+        // command instead sends "PX <raw epoch seconds value>", producing a TTL of roughly
+        // (epochSeconds * 1000 - now) milliseconds - i.e. decades in the future - or an outright
+        // Redis error depending on how large that number is.
+        assertThat(ttl)
+                .as("EXAT must set the TTL to ~120s from now, not treat the epoch value as a relative PX delay")
+                .isBetween(110_000L, 120_000L);
+    }
+}

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-40/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStringCommands.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-40/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStringCommands.java
@@ -27,6 +27,7 @@ import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.BitFieldSubCommands;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.*;
 import org.springframework.data.redis.connection.ReactiveStringCommands;
+import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.connection.RedisStringCommands.BitOperation;
 import org.springframework.data.redis.connection.RedisStringCommands.SetOption;
 import org.springframework.util.Assert;
@@ -476,10 +477,23 @@ public class RedissonReactiveStringCommands extends RedissonBaseReactive impleme
         return execute(commands, command -> {
 
             Assert.notNull(command.getKey(), "Key must not be null!");
+            Assert.notNull(command.getExpiration(), "Expiration must not be null!");
 
             byte[] keyBuf = toByteArray(command.getKey());
-            Mono<byte[]> m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf,
-                                    "PX", command.getExpiration().getExpirationTimeInMilliseconds());
+            Expiration expiration = command.getExpiration();
+
+            Mono<byte[]> m;
+            if (expiration.isPersistent()) {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf, "PERSIST");
+            } else if (expiration.isKeepTtl()) {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf);
+            } else if (expiration.isUnixTimestamp()) {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf,
+                        "PXAT", expiration.getExpirationTimeInMilliseconds());
+            } else {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf,
+                        "PX", expiration.getExpirationTimeInMilliseconds());
+            }
             return m.map(v -> new ByteBufferResponse<>(command, ByteBuffer.wrap(v)))
                     .defaultIfEmpty(new AbsentByteBufferResponse<>(command));
         });

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-40/src/test/java/org/redisson/spring/data/connection/RedissonReactiveStringCommandsTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-40/src/test/java/org/redisson/spring/data/connection/RedissonReactiveStringCommandsTest.java
@@ -1,0 +1,112 @@
+package org.redisson.spring.data.connection;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.ReactiveRedisConnection;
+import org.springframework.data.redis.connection.ReactiveStringCommands;
+import org.springframework.data.redis.core.types.Expiration;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Reproduction/regression coverage for RedissonReactiveStringCommands.getEx() ignoring the
+ * PERSIST / KEEPTTL / EXAT / PXAT options carried by GetExCommand.getExpiration() and always
+ * sending "PX &lt;millis&gt;" regardless of what was actually requested. The sync equivalent
+ * (RedissonConnection.getEx()) was fixed for this exact bug in commit 6c393a51f, but the reactive
+ * implementation in this same file was never updated to match.
+ */
+public class RedissonReactiveStringCommandsTest extends BaseConnectionTest {
+
+    private ByteBuffer buf(String s) {
+        return ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private ReactiveStringCommands stringCommands() {
+        RedissonConnectionFactory factory = new RedissonConnectionFactory(redisson);
+        ReactiveRedisConnection conn = factory.getReactiveConnection();
+        return conn.stringCommands();
+    }
+
+    private Long ttlMillis(String key) {
+        RedissonConnectionFactory factory = new RedissonConnectionFactory(redisson);
+        return factory.getReactiveConnection().keyCommands().pTtl(buf(key)).block();
+    }
+
+    // Baseline: plain relative expiration (milliseconds) - this is the ONLY variant the current
+    // (buggy) implementation happens to get right, since it's the one hardcoded case.
+    @Test
+    public void testGetExRelativeMillis() {
+        redisson.getBucket("k1", org.redisson.client.codec.StringCodec.INSTANCE).set("v1");
+
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k1")).withExpiration(Expiration.milliseconds(60_000));
+        ByteBuffer result = stringCommands().getEx(reactor.core.publisher.Mono.just(cmd))
+                .map(r -> r.getOutput()).blockFirst();
+
+        assertThat(StandardCharsets.UTF_8.decode(result).toString()).isEqualTo("v1");
+        Long ttl = ttlMillis("k1");
+        assertThat(ttl).isBetween(55_000L, 60_000L);
+    }
+
+    // PERSIST: should remove the TTL entirely. Currently sends "PX <persistent-sentinel-millis>"
+    // instead of "PERSIST", so the key keeps expiring instead of becoming persistent.
+    @Test
+    public void testGetExPersistRemovesTtl() {
+        redisson.getBucket("k2", org.redisson.client.codec.StringCodec.INSTANCE)
+                .set("v2", Duration.ofSeconds(30));
+        assertThat(ttlMillis("k2")).isGreaterThan(0);
+
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k2")).withExpiration(Expiration.persistent());
+        stringCommands().getEx(reactor.core.publisher.Mono.just(cmd)).blockFirst();
+
+        Long ttl = ttlMillis("k2");
+        assertThat(ttl)
+                .as("PERSIST must remove the TTL entirely (PTTL should be -1)")
+                .isEqualTo(-1L);
+    }
+
+    // KEEPTTL: should leave the existing TTL untouched. Currently overwrites it with a fresh,
+    // unrelated "PX" value derived from Expiration's internal sentinel encoding.
+    @Test
+    public void testGetExKeepTtlPreservesOriginalTtl() {
+        redisson.getBucket("k3", org.redisson.client.codec.StringCodec.INSTANCE)
+                .set("v3", Duration.ofSeconds(100));
+        Long ttlBefore = ttlMillis("k3");
+
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k3")).withExpiration(Expiration.keepTtl());
+        stringCommands().getEx(reactor.core.publisher.Mono.just(cmd)).blockFirst();
+
+        Long ttlAfter = ttlMillis("k3");
+        assertThat(ttlAfter)
+                .as("KEEPTTL must leave the original TTL (~100s) untouched, not overwrite it")
+                .isCloseTo(ttlBefore, org.assertj.core.data.Offset.offset(2000L));
+    }
+
+    // EXAT: absolute expiration in seconds since epoch. Currently the absolute timestamp is sent
+    // as a relative "PX" delay instead, producing a wildly different actual expiration time.
+    @Test
+    public void testGetExAbsoluteSecondsUsesExatSemantics() {
+        redisson.getBucket("k4", org.redisson.client.codec.StringCodec.INSTANCE).set("v4");
+
+        long expireAtEpochSeconds = Instant.now().plusSeconds(120).getEpochSecond();
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k4"))
+                .withExpiration(Expiration.unixTimestamp(expireAtEpochSeconds, java.util.concurrent.TimeUnit.SECONDS));
+        stringCommands().getEx(reactor.core.publisher.Mono.just(cmd)).blockFirst();
+
+        Long ttl = ttlMillis("k4");
+        // Expected: close to 120_000ms (now -> expireAtEpochSeconds). If the bug is present, the
+        // command instead sends "PX <raw epoch seconds value>", producing a TTL of roughly
+        // (epochSeconds * 1000 - now) milliseconds - i.e. decades in the future - or an outright
+        // Redis error depending on how large that number is.
+        assertThat(ttl)
+                .as("EXAT must set the TTL to ~120s from now, not treat the epoch value as a relative PX delay")
+                .isBetween(110_000L, 120_000L);
+    }
+}

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-41/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStringCommands.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-41/src/main/java/org/redisson/spring/data/connection/RedissonReactiveStringCommands.java
@@ -29,6 +29,7 @@ import org.springframework.data.redis.connection.ReactiveRedisConnection.*;
 import org.springframework.data.redis.connection.ReactiveStringCommands;
 import org.springframework.data.redis.connection.RedisStringCommands.BitOperation;
 import org.springframework.data.redis.connection.RedisStringCommands.SetOption;
+import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.util.Assert;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -476,10 +477,23 @@ public class RedissonReactiveStringCommands extends RedissonBaseReactive impleme
         return execute(commands, command -> {
 
             Assert.notNull(command.getKey(), "Key must not be null!");
+            Assert.notNull(command.getExpiration(), "Expiration must not be null!");
 
             byte[] keyBuf = toByteArray(command.getKey());
-            Mono<byte[]> m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf,
-                                    "PX", command.getExpiration().getExpirationTimeInMilliseconds());
+            Expiration expiration = command.getExpiration();
+
+            Mono<byte[]> m;
+            if (expiration.isPersistent()) {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf, "PERSIST");
+            } else if (expiration.isKeepTtl()) {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf);
+            } else if (expiration.isUnixTimestamp()) {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf,
+                        "PXAT", expiration.getExpirationTimeInMilliseconds());
+            } else {
+                m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf,
+                        "PX", expiration.getExpirationTimeInMilliseconds());
+            }
             return m.map(v -> new ByteBufferResponse<>(command, ByteBuffer.wrap(v)))
                     .defaultIfEmpty(new AbsentByteBufferResponse<>(command));
         });

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-41/src/test/java/org/redisson/spring/data/connection/RedissonReactiveStringCommandsTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-41/src/test/java/org/redisson/spring/data/connection/RedissonReactiveStringCommandsTest.java
@@ -1,0 +1,112 @@
+package org.redisson.spring.data.connection;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.ReactiveRedisConnection;
+import org.springframework.data.redis.connection.ReactiveStringCommands;
+import org.springframework.data.redis.core.types.Expiration;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Reproduction/regression coverage for RedissonReactiveStringCommands.getEx() ignoring the
+ * PERSIST / KEEPTTL / EXAT / PXAT options carried by GetExCommand.getExpiration() and always
+ * sending "PX &lt;millis&gt;" regardless of what was actually requested. The sync equivalent
+ * (RedissonConnection.getEx()) was fixed for this exact bug in commit 6c393a51f, but the reactive
+ * implementation in this same file was never updated to match.
+ */
+public class RedissonReactiveStringCommandsTest extends BaseConnectionTest {
+
+    private ByteBuffer buf(String s) {
+        return ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private ReactiveStringCommands stringCommands() {
+        RedissonConnectionFactory factory = new RedissonConnectionFactory(redisson);
+        ReactiveRedisConnection conn = factory.getReactiveConnection();
+        return conn.stringCommands();
+    }
+
+    private Long ttlMillis(String key) {
+        RedissonConnectionFactory factory = new RedissonConnectionFactory(redisson);
+        return factory.getReactiveConnection().keyCommands().pTtl(buf(key)).block();
+    }
+
+    // Baseline: plain relative expiration (milliseconds) - this is the ONLY variant the current
+    // (buggy) implementation happens to get right, since it's the one hardcoded case.
+    @Test
+    public void testGetExRelativeMillis() {
+        redisson.getBucket("k1", org.redisson.client.codec.StringCodec.INSTANCE).set("v1");
+
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k1")).withExpiration(Expiration.milliseconds(60_000));
+        ByteBuffer result = stringCommands().getEx(reactor.core.publisher.Mono.just(cmd))
+                .map(r -> r.getOutput()).blockFirst();
+
+        assertThat(StandardCharsets.UTF_8.decode(result).toString()).isEqualTo("v1");
+        Long ttl = ttlMillis("k1");
+        assertThat(ttl).isBetween(55_000L, 60_000L);
+    }
+
+    // PERSIST: should remove the TTL entirely. Currently sends "PX <persistent-sentinel-millis>"
+    // instead of "PERSIST", so the key keeps expiring instead of becoming persistent.
+    @Test
+    public void testGetExPersistRemovesTtl() {
+        redisson.getBucket("k2", org.redisson.client.codec.StringCodec.INSTANCE)
+                .set("v2", Duration.ofSeconds(30));
+        assertThat(ttlMillis("k2")).isGreaterThan(0);
+
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k2")).withExpiration(Expiration.persistent());
+        stringCommands().getEx(reactor.core.publisher.Mono.just(cmd)).blockFirst();
+
+        Long ttl = ttlMillis("k2");
+        assertThat(ttl)
+                .as("PERSIST must remove the TTL entirely (PTTL should be -1)")
+                .isEqualTo(-1L);
+    }
+
+    // KEEPTTL: should leave the existing TTL untouched. Currently overwrites it with a fresh,
+    // unrelated "PX" value derived from Expiration's internal sentinel encoding.
+    @Test
+    public void testGetExKeepTtlPreservesOriginalTtl() {
+        redisson.getBucket("k3", org.redisson.client.codec.StringCodec.INSTANCE)
+                .set("v3", Duration.ofSeconds(100));
+        Long ttlBefore = ttlMillis("k3");
+
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k3")).withExpiration(Expiration.keepTtl());
+        stringCommands().getEx(reactor.core.publisher.Mono.just(cmd)).blockFirst();
+
+        Long ttlAfter = ttlMillis("k3");
+        assertThat(ttlAfter)
+                .as("KEEPTTL must leave the original TTL (~100s) untouched, not overwrite it")
+                .isCloseTo(ttlBefore, org.assertj.core.data.Offset.offset(2000L));
+    }
+
+    // EXAT: absolute expiration in seconds since epoch. Currently the absolute timestamp is sent
+    // as a relative "PX" delay instead, producing a wildly different actual expiration time.
+    @Test
+    public void testGetExAbsoluteSecondsUsesExatSemantics() {
+        redisson.getBucket("k4", org.redisson.client.codec.StringCodec.INSTANCE).set("v4");
+
+        long expireAtEpochSeconds = Instant.now().plusSeconds(120).getEpochSecond();
+        ReactiveStringCommands.GetExCommand cmd = ReactiveStringCommands.GetExCommand
+                .key(buf("k4"))
+                .withExpiration(Expiration.unixTimestamp(expireAtEpochSeconds, java.util.concurrent.TimeUnit.SECONDS));
+        stringCommands().getEx(reactor.core.publisher.Mono.just(cmd)).blockFirst();
+
+        Long ttl = ttlMillis("k4");
+        // Expected: close to 120_000ms (now -> expireAtEpochSeconds). If the bug is present, the
+        // command instead sends "PX <raw epoch seconds value>", producing a TTL of roughly
+        // (epochSeconds * 1000 - now) milliseconds - i.e. decades in the future - or an outright
+        // Redis error depending on how large that number is.
+        assertThat(ttl)
+                .as("EXAT must set the TTL to ~120s from now, not treat the epoch value as a relative PX delay")
+                .isBetween(110_000L, 120_000L);
+    }
+}


### PR DESCRIPTION
### What

Fixes `getEx()` in all 10 `RedissonReactiveStringCommands.java` module variants (Spring Data Redis 2.6 through 4.1) to check `Expiration.isPersistent()` / `isKeepTtl()` / `isUnixTimestamp()` and translate to the matching `GETEX` option, instead of always sending the raw expiration value as `PX`.

### Why

See #7308 for the full writeup. Short version: `Expiration` encodes `PERSIST`/`KEEPTTL` as negative sentinel values internally. The current code sends whatever `getExpirationTimeInMilliseconds()` returns as a literal `PX` argument regardless of what was requested, so:

- `Expiration.persistent()` → `GETEX key PX -1000` → Redis rejects it: `ERR invalid expire time in 'getex' command`
- `Expiration.keepTtl()` → `GETEX key PX -2000` → same error
- `Expiration.unixTimestamp(...)` (`EXAT`/`PXAT`) → the absolute epoch value is sent as if it were a relative millisecond delay, landing decades in the future instead of at the intended time

This exact bug was already fixed on the sync side (`RedissonConnection.getEx()`) in commit `6c393a51f`. This PR applies the identical fix to the reactive counterpart in the same files, which that commit didn't touch.

### Changes

- `getEx()` in `RedissonReactiveStringCommands.java`, all 10 module variants that contain this method (`redisson-spring-data-{26,27,30,31,32,33,34,35,40,41}`):

```java
if (expiration.isPersistent()) {
    m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf, "PERSIST");
} else if (expiration.isKeepTtl()) {
    m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf);
} else if (expiration.isUnixTimestamp()) {
    m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf,
            "PXAT", expiration.getExpirationTimeInMilliseconds());
} else {
    m = write(keyBuf, ByteArrayCodec.INSTANCE, GETEX, keyBuf,
            "PX", expiration.getExpirationTimeInMilliseconds());
}
```

Mirrors the sync fix's logic and option choices exactly (including always using `PXAT` with millisecond precision for the absolute-timestamp case, rather than branching between `EXAT`/`PXAT` by original unit).

- New test `RedissonReactiveStringCommandsTest`, added to all 10 module variants, covering all four `Expiration` variants (relative milliseconds, `PERSIST`, `KEEPTTL`, `EXAT`) against a real Redis instance.

### Test plan

Before the fix, against both `master` and the latest release `redisson-4.7.0`:

```
testGetExRelativeMillis                      -> PASS (already worked)
testGetExPersistRemovesTtl                   -> ERROR: RedisSystem ERR invalid expire time in 'getex' command. params: [key, PX, -1000]
testGetExKeepTtlPreservesOriginalTtl         -> ERROR: RedisSystem ERR invalid expire time in 'getex' command. params: [key, PX, -2000]
testGetExAbsoluteSecondsUsesExatSemantics    -> FAIL: expected PTTL ~120000ms, got 1787146328998ms (~56.6 years)
```

After the fix, all four pass in every module (`Tests run: 4, Failures: 0, Errors: 0, Skipped: 0` each).

### Backward compatibility

No API or behavior change for the one case that already worked (plain relative expiration). `PERSIST`/`KEEPTTL`/`EXAT`/`PXAT` go from "throws" or "silently wrong" to "correct", which can only fix previously-broken behavior, not change any working behavior.