### PR TITLE
fix: clean up RReliableTopic subscriber and retry transient failures

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonReliableTopic.java
+++ b/redisson/src/main/java/org/redisson/RedissonReliableTopic.java
@@ -189,6 +189,12 @@ public final class RedissonReliableTopic extends RedissonExpirable implements RR
 
                 if (ex.getCause() != null
                         && ex.getCause().getMessage().contains("NOGROUP")) {
+                    if (!subscribed.get()) {
+                        // group has been destroyed by removeListener() call
+                        return;
+                    }
+
+                    checkGroupAsync(id, ex.getCause());
                     return;
                 }
 
@@ -270,6 +276,7 @@ public final class RedissonReliableTopic extends RedissonExpirable implements RR
                             return;
                         }
                         log.error("Unable to update subscriber status", exc);
+                        schedulePoll(id);
                         return;
                     }
 
@@ -282,6 +289,56 @@ public final class RedissonReliableTopic extends RedissonExpirable implements RR
             });
 
         });
+    }
+
+    private void checkGroupAsync(String id, Throwable cause) {
+        RFuture<Long> future = commandExecutor.evalWriteAsync(getRawName(), StringCodec.INSTANCE, RedisCommands.EVAL_LONG,
+                "if redis.call('exists', KEYS[1]) == 0 then return -1; end; "
+                    + "local groups = redis.call('xinfo', 'groups', KEYS[1]); "
+                    + "for i, v in ipairs(groups) do "
+                        + "if v[2] == ARGV[1] then return 1; end; "
+                    + "end; "
+                    + "return 0;",
+                Arrays.asList(getRawName()), id);
+        future.whenComplete((res, exc) -> {
+            if (exc != null) {
+                if (getServiceManager().isShuttingDown(exc)) {
+                    return;
+                }
+
+                log.error("Unable to check consumer group state. Subscriber id: {}", id, exc);
+
+                schedulePoll(id);
+                return;
+            }
+
+            if (res != null && res == 1) {
+                // group still exists on the master, NOGROUP was received
+                // due to reading from an outdated replica
+                log.error("Unable to poll a new element. Subscriber id: {}", id, cause);
+
+                schedulePoll(id);
+                return;
+            }
+
+            log.error("Consumer group of subscriber {} has been removed", id, cause);
+
+            removeSubscriber().whenComplete((r, e) -> {
+                if (e != null && !getServiceManager().isShuttingDown(e)) {
+                    log.error("Unable to remove subscriber {}", id, e);
+                }
+            });
+        });
+    }
+
+    private void schedulePoll(String id) {
+        getServiceManager().newTimeout(task -> {
+            if (getServiceManager().isShuttingDown() || !subscribed.get()) {
+                return;
+            }
+
+            poll(id);
+        }, 1, TimeUnit.SECONDS);
     }
 
     @Override
@@ -342,8 +399,10 @@ public final class RedissonReliableTopic extends RedissonExpirable implements RR
         }
 
         return commandExecutor.evalWriteAsync(getRawName(), StringCodec.INSTANCE, RedisCommands.EVAL_VOID,
-                "redis.call('xgroup', 'destroy', KEYS[1], ARGV[1]); "
-                      + "redis.call('zrem', KEYS[2], ARGV[1]); ",
+                "if redis.call('exists', KEYS[1]) == 1 then "
+                      + "redis.call('xgroup', 'destroy', KEYS[1], ARGV[1]); "
+                + "end; "
+                + "redis.call('zrem', KEYS[2], ARGV[1]); ",
                 Arrays.asList(getRawName(), timeoutName),
                 subscriberId);
     }
@@ -378,6 +437,12 @@ public final class RedissonReliableTopic extends RedissonExpirable implements RR
             future.whenComplete((res, e) -> {
                 if (e != null) {
                     log.error("Can't update reliable topic {} expiration time", getRawName(), e);
+                    getServiceManager().newTimeout(task -> {
+                        if (getServiceManager().isShuttingDown()) {
+                            return;
+                        }
+                        renewExpiration();
+                    }, 1, TimeUnit.SECONDS);
                     return;
                 }
 

--- a/redisson/src/test/java/org/redisson/RedissonReliableTopicTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonReliableTopicTest.java
@@ -3,8 +3,12 @@ package org.redisson;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.redisson.api.RReliableTopic;
+import org.redisson.api.RScoredSortedSet;
+import org.redisson.api.RStream;
 import org.redisson.api.RedissonClient;
 import org.redisson.api.listener.MessageListener;
+import org.redisson.api.stream.StreamGroup;
+import org.redisson.client.codec.StringCodec;
 import org.redisson.config.Config;
 
 import java.time.Duration;
@@ -210,6 +214,111 @@ public class RedissonReliableTopicTest extends RedisDockerTest {
         Awaitility.await().atMost(Duration.ofSeconds(5))
                 .untilAsserted(() -> assertThat(messages).containsExactly("first", "second"));
         assertThat(attempts).hasValue(3);
+    }
+
+    @Test
+    public void testTopicRemovalWhileSubscribed() throws InterruptedException {
+        RReliableTopic rt = redisson.getReliableTopic("testTopicRemovalWhileSubscribed");
+        Queue<Integer> messages = new ConcurrentLinkedQueue<>();
+        rt.addListener(Integer.class, (channel, msg) -> messages.add(msg));
+
+        assertThat(rt.publish(1)).isEqualTo(1);
+        Awaitility.waitAtMost(Duration.ofSeconds(2)).until(() -> messages.size() == 1);
+
+        // topic key is removed while the subscriber is live, e.g. expired by TTL
+        redisson.getKeys().delete("testTopicRemovalWhileSubscribed");
+        // no group exists on the recreated stream, so the message is undeliverable
+        assertThat(rt.publish(9)).isEqualTo(0);
+
+        // the dead subscriber is cleaned up: its timeout ZSET entry is removed
+        RScoredSortedSet<String> timeout = redisson.getScoredSortedSet("{testTopicRemovalWhileSubscribed}:timeout");
+        Awaitility.waitAtMost(Duration.ofSeconds(5)).until(() -> timeout.size() == 0);
+
+        // a new listener can subscribe through the same topic object and receives new messages
+        rt.addListener(Integer.class, (channel, msg) -> messages.add(msg));
+
+        assertThat(rt.publish(2)).isEqualTo(1);
+        Awaitility.waitAtMost(Duration.ofSeconds(2)).until(() -> messages.contains(2));
+    }
+
+    @Test
+    public void testGroupRemovalWhileSubscribed() throws InterruptedException {
+        RReliableTopic rt = redisson.getReliableTopic("testGroupRemovalWhileSubscribed");
+        Queue<Integer> messages = new ConcurrentLinkedQueue<>();
+        rt.addListener(Integer.class, (channel, msg) -> messages.add(msg));
+
+        assertThat(rt.publish(1)).isEqualTo(1);
+        Awaitility.waitAtMost(Duration.ofSeconds(2)).until(() -> messages.size() == 1);
+
+        // the consumer group is removed while the subscriber is live,
+        // e.g. by the expired-subscriber sweep of another instance
+        RStream<String, Integer> stream = redisson.getStream("testGroupRemovalWhileSubscribed");
+        String groupName = stream.listGroups().get(0).getName();
+        stream.removeGroup(groupName);
+        assertThat(rt.publish(9)).isEqualTo(0);
+
+        RScoredSortedSet<String> timeout = redisson.getScoredSortedSet("{testGroupRemovalWhileSubscribed}:timeout");
+        Awaitility.waitAtMost(Duration.ofSeconds(5)).until(() -> timeout.size() == 0);
+
+        rt.addListener(Integer.class, (channel, msg) -> messages.add(msg));
+
+        assertThat(rt.publish(2)).isEqualTo(1);
+        Awaitility.waitAtMost(Duration.ofSeconds(2)).until(() -> messages.contains(2));
+    }
+
+    @Test
+    public void testTransientUpdateFailureDoesNotStopPolling() throws InterruptedException {
+        RReliableTopic rt = redisson.getReliableTopic("testTransientUpdateFailure");
+        Queue<Integer> received = new ConcurrentLinkedQueue<>();
+        rt.addListener(Integer.class, (channel, msg) -> received.add(msg));
+
+        // capture the registration entry, then break the status update once
+        RScoredSortedSet<String> timeout = redisson.getScoredSortedSet("{testTransientUpdateFailure}:timeout", StringCodec.INSTANCE);
+        Awaitility.waitAtMost(Duration.ofSeconds(2)).until(() -> timeout.size() == 1);
+        String member = timeout.readAll().iterator().next();
+        double score = timeout.getScore(member);
+
+        redisson.getKeys().delete("{testTransientUpdateFailure}:timeout");
+        redisson.getBucket("{testTransientUpdateFailure}:timeout", StringCodec.INSTANCE).set("x");
+
+        assertThat(rt.publish(1)).isEqualTo(1);
+        Awaitility.waitAtMost(Duration.ofSeconds(2)).until(() -> received.size() == 1);
+
+        // registration restored, so a retrying subscriber would continue
+        redisson.getKeys().delete("{testTransientUpdateFailure}:timeout");
+        timeout.add(score, member);
+
+        assertThat(rt.publish(2)).isEqualTo(1);
+        Awaitility.waitAtMost(Duration.ofSeconds(5)).until(() -> received.contains(2));
+    }
+
+    @Test
+    public void testRenewalFailureDoesNotStopWatchdog() throws InterruptedException {
+        Config config = createConfig();
+        config.setReliableTopicWatchdogTimeout(1000);
+        RedissonClient secondInstance = Redisson.create(config);
+        try {
+            RReliableTopic rt = secondInstance.getReliableTopic("testRenewalFailure");
+            rt.addListener(Integer.class, (channel, msg) -> { });
+
+            RScoredSortedSet<String> timeout = secondInstance.getScoredSortedSet("{testRenewalFailure}:timeout", StringCodec.INSTANCE);
+            Awaitility.waitAtMost(Duration.ofSeconds(2)).until(() -> timeout.size() == 1);
+            String member = timeout.readAll().iterator().next();
+            double score = timeout.getScore(member);
+
+            // renewal fails for at least one tick: wrong-type key
+            secondInstance.getKeys().delete("{testRenewalFailure}:timeout");
+            secondInstance.getBucket("{testRenewalFailure}:timeout", StringCodec.INSTANCE).set("x");
+            Thread.sleep(1000);
+
+            // registration restored, so a retrying watchdog renews it again
+            secondInstance.getKeys().delete("{testRenewalFailure}:timeout");
+            timeout.add(score, member);
+
+            Awaitility.waitAtMost(Duration.ofSeconds(5)).until(() -> timeout.getScore(member) > score);
+            } finally {
+                secondInstance.shutdown();
+            }
     }
 
     @Test


### PR DESCRIPTION
AI disclosure: this change was prepared with AI coding agents, reviewed and revised line by line by me.

## What

`poll()` treats every `NOGROUP` error as a normal unsubscribe and stops polling silently. This PR handles `NOGROUP` received while the subscriber is still subscribed (fixes 2 and 3 of #7262; fix 1, the replica-routing part, is covered by #7263), and stops two more error paths from ending the poll loop permanently after a single transient write failure (modes 5 and 6 in the failure mode overview: https://github.com/redisson/redisson/issues/7262#issuecomment-5382465164).

## Why

The consumer group can disappear while the subscriber is live: the topic key expires or is deleted, or another instance's expired-subscriber sweep removes the group. In that case the current code leaves a phantom subscriber (#7262):

- no `XREADGROUP` is ever sent and no error is logged;
- `subscribed` stays set, so a later `addListener()` on the same topic object returns immediately and never re-subscribes;
- the timeout ZSET entry is kept and renewed by the watchdog forever;
- `publishAsync()` counts the dead subscriber via `xinfo groups` while it cannot receive.

Also, the status update after message processing and the watchdog renewal only log and return on a write failure, so one transient error (connection drop, failover) stops the loop or the watchdog for good while the subscriber stays counted.

## How

- `NOGROUP` while `subscribed` is still set is no longer terminal: the group is verified on the master (routed through `evalWriteAsync`, same approach as the poll read in #7263).
- Group still exists -> the reply came from an outdated replica; the error is logged and polling is retried after 1s, same as every other poll error.
- Group gone -> the condition is logged and the subscriber is removed (timeout ZSET entry, watchdog task, `subscribed` flag), so a new `addListener()` re-subscribes. The removal script now tolerates a missing stream key, since `xgroup destroy` errors on it.
- `NOGROUP` after `removeListener()` (group destroyed by the unsubscribe itself) still stops silently.
- The status-update error path now schedules a retry through `schedulePoll`, and the renewal error path reschedules `renewExpiration()` after 1s: same pattern as the generic poll error path. Unacknowledged messages are redelivered on retry.

Surfacing the condition through a listener callback would be an API change, left out here; it can be added separately if there is interest.

## Root cause

`NOGROUP` was unconditionally interpreted as "unsubscribed by removeListener()", with no distinction from "group vanished while subscribed"; the update and renewal error branches terminated their loops without retrying or cleaning up.

## Testing

- `#testTopicRemovalWhileSubscribed` (topic key deleted while subscribed, e.g. TTL expiry) and `#testGroupRemovalWhileSubscribed` (group removed while the timeout ZSET entry stays): both fail on master and pass with this change.
- `#testTransientUpdateFailureDoesNotStopPolling`: breaks the status update once (wrong-type key), restores the registration, publishes again; on master 66863978b the second message is never consumed while `publish()` returns 1 (repro in the overview comment), with this change it is delivered.
- `#testRenewalFailureDoesNotStopWatchdog`: breaks the renewal once, restores the entry; on master the score never advances again, with this change the watchdog renews after the 1s retry.
- `mvn -pl redisson test -Punit-test -Dtest=RedissonReliableTopicTest`: 12/12 passed.
- Limitation: the retry branch (group exists on master, `NOGROUP` from a lagging replica) has no deterministic single-node test; it needs a replica setup as in #7263.

#7262 (fixes 2 and 3)
