### PR TITLE
Reuse RxIteratorConsumer in RedissonKeysRx instead of duplicating the SCAN-cursor loop

### DIFF
--- a/redisson/src/main/java/org/redisson/rx/RedissonKeysRx.java
+++ b/redisson/src/main/java/org/redisson/rx/RedissonKeysRx.java
@@ -17,10 +17,11 @@ package org.redisson.rx;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
 
 import org.reactivestreams.Publisher;
 import org.redisson.RedissonKeys;
+import org.redisson.ScanResult;
+import org.redisson.api.RFuture;
 import org.redisson.api.RType;
 import org.redisson.api.options.KeysScanOptions;
 import org.redisson.api.options.KeysScanParams;
@@ -28,7 +29,6 @@ import org.redisson.client.RedisClient;
 import org.redisson.connection.MasterSlaveEntry;
 
 import io.reactivex.rxjava3.core.Flowable;
-import io.reactivex.rxjava3.functions.LongConsumer;
 import io.reactivex.rxjava3.processors.ReplayProcessor;
 
 /**
@@ -73,42 +73,15 @@ public class RedissonKeysRx {
 
     private Publisher<String> createKeysIterator(MasterSlaveEntry entry, String pattern, int count, RType type) {
         ReplayProcessor<String> p = ReplayProcessor.create();
-        return p.doOnRequest(new LongConsumer() {
-
-            private RedisClient client;
-            private String nextIterPos = "0";
-            private final AtomicLong requested = new AtomicLong();
+        return p.doOnRequest(new RxIteratorConsumer<String>(p) {
+            @Override
+            protected boolean tryAgain() {
+                return false;
+            }
 
             @Override
-            public void accept(long value) {
-                if (requested.addAndGet(value) == value) {
-                    nextValues();
-                }
-            }
-            
-            private void nextValues() {
-                instance.scanIteratorAsync(client, entry, nextIterPos, pattern, count, type)
-                        .whenComplete((res, e) -> {
-                            if (e != null) {
-                                p.onError(e);
-                                return;
-                            }
-
-                            client = res.getRedisClient();
-                            nextIterPos = res.getPos();
-
-                            for (Object val : res.getValues()) {
-                                p.onNext((String) val);
-                                requested.decrementAndGet();
-                            }
-
-                            if ("0".equals(nextIterPos)) {
-                                p.onComplete();
-                                return;
-                            }
-
-                            nextValues();
-                        });
+            protected RFuture<ScanResult<Object>> scanIterator(RedisClient client, String nextIterPos) {
+                return instance.scanIteratorAsync(client, entry, nextIterPos, pattern, count, type);
             }
         });
     }

--- a/redisson/src/test/java/org/redisson/rx/RedissonKeysRxTest.java
+++ b/redisson/src/test/java/org/redisson/rx/RedissonKeysRxTest.java
@@ -144,4 +144,34 @@ public class RedissonKeysRxTest extends BaseRxTest {
         assertThat(bucketMap).hasSize(expected);
     }
 
+    @Test
+    public void testGetKeysEmptyDatabase() {
+        List<String> result = redisson.getKeys().getKeys().toList().blockingGet();
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void testGetKeysPartialRequestReturnsExactCount() {
+        int total = 50;
+        for (int i = 0; i < total; i++) {
+            redisson.getBucket("partial-test:" + i, StringCodec.INSTANCE)
+                    .set(Integer.toString(i)).blockingAwait();
+        }
+
+        // Requests fewer items than exist (via take(5)) while the chunk size (10)
+        // forces multiple SCAN round-trips underneath. Exercises the RxIteratorConsumer's
+        // request-counting path with partial downstream demand instead of unbounded demand.
+        List<String> firstFive = redisson.getKeys()
+                .getKeys(KeysScanOptions.defaults().pattern("partial-test:*").chunkSize(10))
+                .take(5)
+                .toList()
+                .blockingGet();
+
+        assertThat(firstFive).hasSize(5);
+        assertThat(firstFive).doesNotHaveDuplicates();
+        for (String key : firstFive) {
+            assertThat(key).startsWith("partial-test:");
+        }
+    }
+
 }


### PR DESCRIPTION
Closes #7311

`RedissonKeysRx.createKeysIterator()` re-implemented the backpressure-aware SCAN cursor loop (request counting, cursor advancement, completion signaling) locally instead of extending `RxIteratorConsumer`, which already provides the same loop and is used by `SetRxIterator`, `RedissonMapRxIterator`, and `RedissonArrayRx`.

The Reactor-based equivalent, `RedissonKeysReactive`, already delegates to its shared abstraction (`IteratorConsumer`) with the same two extension points this change now uses (`tryAgain()`, `scanIterator(client, nextIterPos)`), so this brings `RedissonKeysRx` in line with the existing pattern rather than introducing a new one.

This isn't purely cosmetic: the duplicated loop was the site of a real bug before (#5425, fixed in `0fae241aa`), and that fix was applied only inside this file rather than in the shared consumer. Keeping a second copy means any future fix to `RxIteratorConsumer` won't reach this class automatically.

## Changes

- `RedissonKeysRx.createKeysIterator()`: replaced the hand-rolled `LongConsumer` (35 lines) with an anonymous `RxIteratorConsumer<String>` subclass (8 lines). No behavioral change intended.
- `RedissonKeysRxTest`: added two tests exercising code paths the existing suite didn't cover:
  - `testGetKeysEmptyDatabase`: empty keyspace completes without hanging or erroring.
  - `testGetKeysPartialRequestReturnsExactCount`: requesting fewer items than exist via `take(5)` while the chunk size forces multiple SCAN round-trips still returns the exact count, no duplicates, matching the requested pattern.

## Testing

Ran the full `RedissonKeysRxTest` suite (10 tests, including the two new ones) against a real Redis instance:

```
Test set: org.redisson.rx.RedissonKeysRxTest
Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 21.58 s -- in org.redisson.rx.RedissonKeysRxTest
```

Also ran all 18 test classes under `org.redisson.rx` to check for second-order effects, since `RxIteratorConsumer` is shared by three other classes. 

A handful of unrelated failures showed up (a TTL-timing assertion, a batch write-timeout threshold, a connection-leak timeout, and a classpath error that only appeared when running a single test class in isolation). 
None of them touch `getKeys()`/`RKeysRx`, and re-running them in isolation showed the timing-sensitive ones are flaky rather than consistently broken. 

I did not verify these same failures occur on unmodified `master`, but the affected classes (`RedissonMapCacheRx`, `RedissonBatchRx`'s cluster/timeout paths) don't reference `RxIteratorConsumer` or `RedissonKeysRx` at all, so they're outside this change's blast radius.
