### PR TITLE
fix: publish local cache transaction invalidation events via sharded topic in cluster

### DIFF
--- a/redisson/src/main/java/org/redisson/transaction/RedissonTransaction.java
+++ b/redisson/src/main/java/org/redisson/transaction/RedissonTransaction.java
@@ -342,7 +342,7 @@ public class RedissonTransaction implements RTransaction {
         RedissonBatch publishBatch = createBatch();
         for (Entry<HashKey, HashValue> entry : hashes.entrySet()) {
             String name = RedissonObject.suffixName(entry.getKey().getName(), RedissonLocalCachedMap.TOPIC_SUFFIX);
-            RTopicAsync topic = publishBatch.getTopic(name, LocalCachedMessageCodec.INSTANCE);
+            RTopicAsync topic = getLocalCacheInvalidationTopic(publishBatch, name);
             LocalCachedMapEnable msg = new LocalCachedMapEnable(requestId, entry.getValue().getKeyIds().toArray(new byte[entry.getValue().getKeyIds().size()][]), entry.getValue().isAllKeys());
             topic.publishAsync(msg);
         }
@@ -358,7 +358,7 @@ public class RedissonTransaction implements RTransaction {
         RedissonBatch publishBatch = createBatch();
         for (Entry<HashKey, HashValue> entry : hashes.entrySet()) {
             String name = RedissonObject.suffixName(entry.getKey().getName(), RedissonLocalCachedMap.TOPIC_SUFFIX);
-            RTopicAsync topic = publishBatch.getTopic(name, LocalCachedMessageCodec.INSTANCE);
+            RTopicAsync topic = getLocalCacheInvalidationTopic(publishBatch, name);
             LocalCachedMapEnable msg = new LocalCachedMapEnable(requestId, entry.getValue().getKeyIds().toArray(new byte[entry.getValue().getKeyIds().size()][]), entry.getValue().isAllKeys());
             topic.publishAsync(msg);
         }
@@ -368,6 +368,14 @@ public class RedissonTransaction implements RTransaction {
         } catch (Exception e) {
             // skip it. Disabled local cache entries are enabled once reach timeout.
         }
+    }
+
+    // LocalCacheListener subscribes to the invalidation topic with sharded topic if sharding is supported
+    private RTopicAsync getLocalCacheInvalidationTopic(RedissonBatch publishBatch, String name) {
+        if (commandExecutor.getConnectionManager().getSubscribeService().isShardingSupported()) {
+            return publishBatch.getShardedTopic(name, LocalCachedMessageCodec.INSTANCE);
+        }
+        return publishBatch.getTopic(name, LocalCachedMessageCodec.INSTANCE);
     }
 
     private boolean isKeyOperate(TransactionalOperation transactionalOperation) {
@@ -450,7 +458,7 @@ public class RedissonTransaction implements RTransaction {
                 setCache.removeAsync(localCacheKey);
             }
 
-            RTopicAsync topic = publishBatch.getTopic(RedissonObject.suffixName(entry.getKey().getName(), RedissonLocalCachedMap.TOPIC_SUFFIX), LocalCachedMessageCodec.INSTANCE);
+            RTopicAsync topic = getLocalCacheInvalidationTopic(publishBatch, RedissonObject.suffixName(entry.getKey().getName(), RedissonLocalCachedMap.TOPIC_SUFFIX));
             RFuture<Long> future = topic.publishAsync(new LocalCachedMapDisable(requestId,
                     entry.getValue().getKeyIds().toArray(new byte[entry.getValue().getKeyIds().size()][]), options.getResponseTimeout(), entry.getValue().isAllKeys()));
             future.thenAccept(res -> {
@@ -565,8 +573,8 @@ public class RedissonTransaction implements RTransaction {
                         setCache.removeAsync(localCacheKey);
                     }
 
-                    RTopicAsync topic = publishBatch.getTopic(RedissonObject.suffixName(entry.getKey().getName(),
-                            RedissonLocalCachedMap.TOPIC_SUFFIX), LocalCachedMessageCodec.INSTANCE);
+                    RTopicAsync topic = getLocalCacheInvalidationTopic(publishBatch, RedissonObject.suffixName(entry.getKey().getName(),
+                            RedissonLocalCachedMap.TOPIC_SUFFIX));
                     RFuture<Long> publishFuture = topic.publishAsync(new LocalCachedMapDisable(requestId,
                             entry.getValue().getKeyIds().toArray(new byte[entry.getValue().getKeyIds().size()][]),
                             options.getResponseTimeout(), entry.getValue().isAllKeys()));


### PR DESCRIPTION
AI disclosure: this change was prepared with AI coding agents, reviewed and revised line by line by me.

## What
`RTransaction` now publishes the `LocalCachedMapDisable`/`LocalCachedMapEnable` invalidation events through a sharded topic (`SPUBLISH`) when sharded pub/sub is supported, instead of always using a regular `PUBLISH`.

## Why
In Redis Cluster with Redis 7+, `LocalCacheListener` subscribes to the `{name}:topic` invalidation channel with `SSUBSCRIBE` (see `LocalCacheListener#createTopic`, gated on `PublishSubscribeService#isShardingSupported`). A regular `PUBLISH` is not delivered to sharded subscribers, so during a transaction commit over an `RLocalCachedMap`:

- the `Disable` event never reached any listener and local caches kept the stale entries,
- the `Enable` event was lost the same way,
- every `RLocalCachedMap` instance kept returning the pre-transaction value after `commit()`.

On current master this is visible as 4 deterministically failing tests in `RedissonTransactionalLocalCachedMapTest` (`testPutWithUpdateInCluster`, `testPutWithUpdateWithPatternTopicInCluster`, `testPutAsyncWithUpdateInCluster`, `testPutAsyncWithUpdateWithPatternTopicInCluster`), all failing with `expected: 2 but was: 1` after `transaction.commit()`. Single-server, replicated and sentinel modes are unaffected: `shardingSupported` stays false there and both sides use regular pub/sub (the 13 non-cluster tests of the same class pass on master).

## How
`disableLocalCache`/`disableLocalCacheAsync`/`enableLocalCache`/`enableLocalCacheAsync` in `RedissonTransaction` obtained the invalidation topic as a plain `RTopicAsync`. They now go through one helper that returns `RedissonBatch#getShardedTopic` when `isShardingSupported()` is true, mirroring the publish command selection already used by the Lua-based publishers (locks, semaphores, latches, `RMapCache`, `RSetCache`, `RLocalCachedMap`) through `PublishSubscribeService#getPublishCommand`.

When sharding is supported every `LocalCacheListener` holds a sharded subscription on `{name}:topic` (`useTopicPattern` only adds a second, regular pattern subscription), so `SPUBLISH` reaches all listeners including pattern-topic instances; the two `WithPatternTopic` tests cover this.

## Root cause
Publisher/subscriber command mismatch: the transaction published with `PUBLISH` while listeners subscribe with `SSUBSCRIBE` in cluster mode.

## Testing
- `RedissonTransactionalLocalCachedMapTest`: on master the 4 `*InCluster` tests fail (4/4, `expected: 2 but was: 1`); with this change 17/17 pass, verified twice. The 2 `commitAsync` tests cover the async publish path.
- `RedissonTransactionalMapTest`: 16/16.
- `RedissonLocalCachedMapTest`: 123 tests green in a full-class run. Note this class has a pre-existing order-dependent flakiness on master unrelated to this change: a clean-master full-class run failed 3 invalidation-order tests (`testSyncOnUpdate`, `testInvalidationOnRemoveValue`, `testInvalidationOnPut`); the same tests pass in isolation and in other full runs.
- During debugging, `PUBLISH` of the `Disable` event on master returned 0 receivers in a 6-node cluster; with `SPUBLISH` the events are delivered and both map instances read the committed value.
