### PR TITLE
Fix cancelled pool acquisitions triggering failed node detection

### DIFF
--- a/redisson/src/main/java/org/redisson/connection/pool/ConnectionPool.java
+++ b/redisson/src/main/java/org/redisson/connection/pool/ConnectionPool.java
@@ -33,6 +33,7 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -133,7 +134,8 @@ abstract class ConnectionPool<T extends RedisConnection> {
         });
         result.whenComplete((r, e) -> {
             if (e != null) {
-                if (entry.getNodeType() == NodeType.SLAVE) {
+                if (entry.getNodeType() == NodeType.SLAVE
+                        && !(e instanceof CancellationException)) {
                     FailedNodeDetector detector = entry.getClient().getConfig().getFailedNodeDetector();
                     detector.onConnectFailed(e);
                     if (detector.isNodeFailed()) {

--- a/redisson/src/test/java/org/redisson/connection/pool/ConnectionPoolTest.java
+++ b/redisson/src/test/java/org/redisson/connection/pool/ConnectionPoolTest.java
@@ -21,6 +21,7 @@ import mockit.Verifications;
 import org.junit.jupiter.api.Test;
 import org.redisson.api.NodeType;
 import org.redisson.client.FailedCommandsDetector;
+import org.redisson.client.FailedConnectionDetector;
 import org.redisson.client.RedisClient;
 import org.redisson.client.RedisClientConfig;
 import org.redisson.client.RedisConnection;
@@ -29,11 +30,14 @@ import org.redisson.client.protocol.RedisCommands;
 import org.redisson.config.MasterSlaveServersConfig;
 import org.redisson.connection.ClientConnectionsEntry;
 import org.redisson.connection.ConnectionManager;
+import org.redisson.connection.ConnectionsHolder;
 import org.redisson.connection.MasterSlaveEntry;
 import org.redisson.misc.Tuple;
 
 import java.net.InetSocketAddress;
 import java.util.Collections;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -72,7 +76,7 @@ class ConnectionPoolTest {
         SlaveConnectionPool pool = new SlaveConnectionPool(
                 new MasterSlaveServersConfig(), connectionManager, masterSlaveEntry);
 
-        Tuple<java.util.concurrent.CompletableFuture<RedisConnection>, Throwable> result =
+        Tuple<CompletableFuture<RedisConnection>, Throwable> result =
                 pool.getTuple(RedisCommands.GET, false);
 
         assertThat(result.getT1()).isNull();
@@ -82,4 +86,85 @@ class ConnectionPoolTest {
             times = 1;
         }};
     }
+
+    @Test
+    void cancelledPoolAcquisitionDoesNotTripFailedConnectionDetector(
+            @Mocked ConnectionManager connectionManager,
+            @Mocked MasterSlaveEntry masterSlaveEntry,
+            @Mocked ClientConnectionsEntry entry,
+            @Mocked ConnectionsHolder<RedisConnection> holder,
+            @Mocked RedisClient client,
+            @Mocked RedisClientConfig clientConfig) throws Exception {
+        CompletableFuture<RedisConnection> pending = new CompletableFuture<>();
+        FailedConnectionDetector detector = new FailedConnectionDetector(1);
+
+        new Expectations() {{
+            entry.getConnectionsHolder();
+            result = holder;
+            holder.acquireConnection(RedisCommands.GET);
+            result = pending;
+            entry.getNodeType();
+            result = NodeType.SLAVE;
+            entry.getClient();
+            result = client;
+            minTimes = 0;
+            client.getConfig();
+            result = clientConfig;
+            minTimes = 0;
+            clientConfig.getFailedNodeDetector();
+            result = detector;
+            minTimes = 0;
+        }};
+
+        SlaveConnectionPool pool = new SlaveConnectionPool(
+                new MasterSlaveServersConfig(), connectionManager, masterSlaveEntry);
+        CompletableFuture<RedisConnection> acquisition =
+                pool.get(RedisCommands.GET, entry, false);
+
+        // RedisExecutor uses this form when a pool acquisition times out.
+        assertThat(acquisition.completeExceptionally(
+                new CancellationException("pool acquisition cancelled"))).isTrue();
+        Thread.sleep(10);
+
+        assertThat(detector.isNodeFailed()).isFalse();
+    }
+
+    @Test
+    void connectionFailureStillTripsFailedConnectionDetector(
+            @Mocked ConnectionManager connectionManager,
+            @Mocked MasterSlaveEntry masterSlaveEntry,
+            @Mocked ClientConnectionsEntry entry,
+            @Mocked ConnectionsHolder<RedisConnection> holder,
+            @Mocked RedisClient client,
+            @Mocked RedisClientConfig clientConfig) throws Exception {
+        CompletableFuture<RedisConnection> failed = new CompletableFuture<>();
+        FailedConnectionDetector detector = new FailedConnectionDetector(1);
+
+        new Expectations() {{
+            entry.getConnectionsHolder();
+            result = holder;
+            holder.acquireConnection(RedisCommands.GET);
+            result = failed;
+            entry.getNodeType();
+            result = NodeType.SLAVE;
+            entry.getClient();
+            result = client;
+            client.getConfig();
+            result = clientConfig;
+            clientConfig.getFailedNodeDetector();
+            result = detector;
+        }};
+
+        SlaveConnectionPool pool = new SlaveConnectionPool(
+                new MasterSlaveServersConfig(), connectionManager, masterSlaveEntry);
+        CompletableFuture<RedisConnection> acquisition =
+                pool.get(RedisCommands.GET, entry, false);
+
+        failed.completeExceptionally(new RedisConnectionException("connection failed"));
+        assertThat(acquisition).isCompletedExceptionally();
+        Thread.sleep(10);
+
+        assertThat(detector.isNodeFailed()).isTrue();
+    }
+
 }


### PR DESCRIPTION
Fixes https://github.com/redisson/redisson/issues/7323

`RedisExecutor` uses `CancellationException` to stop connection acquisition when an operation is cancelled or a retry/acquisition timeout ends. `ConnectionPool.acquireConnection()` currently treats every exceptional pool completion for a replica as a failed connection and forwards it to `FailedNodeDetector`.

## Root cause

`FailedConnectionDetector` records the first failure and, after its check interval, marks the replica as failed. Because cancellation is not a Redis connection failure, repeated pool cancellations can make a healthy replica appear failed, remove it from selection, and trigger unnecessary shutdown/reconnect health checks.

## Changes

- Do not report `CancellationException` from replica pool acquisition to `FailedNodeDetector`.
- Preserve failed-node detection for genuine connection failures.
- Add regression coverage for cancelled acquisitions and genuine `RedisConnectionException` failures.

## Testing

Ran the focused unit-test suite with Temurin 25:

```
mvn -q -pl redisson -Punit-test -Dtest=ConnectionPoolTest,ConnectionsHolderTest,FailedNodeDetectorCopyTest -DfailIfNoTests=false test
```

All selected tests pass.