### PR TITLE
Fix BinaryStream input stream position after partial reads

### DIFF
--- a/redisson/src/main/java/org/redisson/RedissonBinaryStream.java
+++ b/redisson/src/main/java/org/redisson/RedissonBinaryStream.java
@@ -129,7 +129,7 @@ public class RedissonBinaryStream extends RedissonBucket<byte[]> implements RBin
             if (data.length == 0) {
                 return -1;
             }
-            index += len;
+            index += data.length;
             System.arraycopy(data, 0, b, off, data.length);
             return data.length;
         }

--- a/redisson/src/test/java/org/redisson/RedissonBinaryStreamTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonBinaryStreamTest.java
@@ -243,6 +243,18 @@ public class RedissonBinaryStreamTest extends RedisDockerTest {
         
         assertThat(b).isEqualTo(value);
     }
+
+    @Test
+    public void testAvailableAfterPartialRead() throws IOException {
+        RBinaryStream stream = redisson.getBinaryStream("test");
+        byte[] value = {1, 2, 3, 4, 5, 6};
+        stream.set(value);
+
+        InputStream s = stream.getInputStream();
+        byte[] b = new byte[10];
+        assertThat(s.read(b)).isEqualTo(value.length);
+        assertThat(s.available()).isZero();
+    }
     
     @Test
     public void testReadArrayWithOffset() throws IOException {


### PR DESCRIPTION

## What problem does this PR solve?

`RedissonBinaryStream.RedissonInputStream#read(byte[], int, int)` advances its internal position by the requested length even when Redis returns fewer bytes near the end of the stream.

For example, if 6 bytes remain and the caller provides a 10-byte buffer, the method correctly returns `6`, but the internal position is advanced by `10`. As a result, `available()` can return a negative value.

## Root cause

The input stream position was updated using the requested read length:

```java
index += len;
```

instead of the number of bytes actually returned by `GETRANGE`.

## Fix

Advance the input stream position by `data.length`.

This is consistent with the existing synchronous and asynchronous byte channel implementations, which already advance their positions by the actual number of bytes read.

## Tests

Added `RedissonBinaryStreamTest#testAvailableAfterPartialRead`, which verifies that:

- reading into a buffer larger than the remaining value returns the actual value length;
- `available()` returns `0` after the partial read.

Verification:

- Main sources compile successfully.
- Test sources compile successfully.
- The runtime test requires Docker and was not run locally because the Docker daemon was unavailable.
