### PR TITLE
Add option to skip replica synchronization for lock operations

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -203,6 +203,12 @@ Default value: `true`
 
 Defines whether to check the synchronized slaves amount with the actual slaves amount after lock acquisition.
 
+**skipLockSyncedSlaves**
+
+Default value: `false`
+
+Defines whether to skip replica synchronization for lock operations. When enabled, lock operations don't send `WAIT` or wait for replicas to acknowledge the operation.
+
 **slavesSyncTimeout**
 
 Default value: `1000`

--- a/docs/data-and-services/locks-and-synchronizers.md
+++ b/docs/data-and-services/locks-and-synchronizers.md
@@ -49,11 +49,13 @@ Redisson closes this window by default, as the next subsection describes, so `RL
 Redisson can verify after each acquisition that the lock has propagated to the connected replicas. Two `Config` settings control this:
 
 * `checkLockSyncedSlaves` — whether to confirm, after acquisition, that the lock reached the connected replicas. Enabled by default.
+* `skipLockSyncedSlaves` — whether to skip replica synchronization for lock operations. Disabled by default.
 * `slavesSyncTimeout` — how long to wait for that synchronization, in milliseconds (default `1000`). The same timeout applies to `RLock`, `RSemaphore`, and `RPermitExpirableSemaphore`.
 
 ```java
 Config config = new Config();
 config.setCheckLockSyncedSlaves(true)   // default
+      .setSkipLockSyncedSlaves(false)    // default
       .setSlavesSyncTimeout(1000);       // milliseconds, default
 ```
 

--- a/redisson/src/main/java/org/redisson/RedissonBaseLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonBaseLock.java
@@ -78,7 +78,25 @@ public abstract class RedissonBaseLock extends RedissonExpirable implements RLoc
     }
 
     protected final <T> RFuture<T> evalWriteSyncedNoRetryAsync(String key, Codec codec, RedisCommand<T> evalCommandType, String script, List<Object> keys, Object... params) {
-        return commandExecutor.syncedEvalNoRetry(key, codec, evalCommandType, script, keys, params);
+        return commandExecutor.syncedEvalNoRetry(getServiceManager().getCfg().isSkipLockSyncedSlaves(),
+                key, codec, evalCommandType, script, keys, params);
+    }
+
+    protected final <T> RFuture<T> syncedEvalNoRetry(String key, Codec codec, RedisCommand<T> evalCommandType, String script, List<Object> keys, Object... params) {
+        return commandExecutor.syncedEvalNoRetry(getServiceManager().getCfg().isSkipLockSyncedSlaves(),
+                key, codec, evalCommandType, script, keys, params);
+    }
+
+    protected final <T> RFuture<T> syncedEvalWithRetry(String key, Codec codec, RedisCommand<T> evalCommandType, String script, List<Object> keys, Object... params) {
+        return commandExecutor.syncedEvalWithRetry(getServiceManager().getCfg().isSkipLockSyncedSlaves(),
+                key, codec, evalCommandType, script, keys, params);
+    }
+
+    protected final <T> RFuture<T> syncedEval(String key, Codec codec, RedisCommand<T> evalCommandType, String script, List<Object> keys, Object... params) {
+        if (getServiceManager().getCfg().isSkipLockSyncedSlaves()) {
+            return commandExecutor.evalWriteAsync(key, codec, evalCommandType, script, keys, params);
+        }
+        return commandExecutor.syncedEval(key, codec, evalCommandType, script, keys, params);
     }
 
     protected void acquireFailed(long waitTime, TimeUnit unit, long threadId) {

--- a/redisson/src/main/java/org/redisson/RedissonFairLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonFairLock.java
@@ -73,7 +73,7 @@ public class RedissonFairLock extends RedissonLock implements RLock {
             wait = unit.toMillis(waitTime);
         }
 
-        RFuture<Void> f = commandExecutor.syncedEvalWithRetry(getRawName(), LongCodec.INSTANCE, RedisCommands.EVAL_VOID,
+        RFuture<Void> f = syncedEvalWithRetry(getRawName(), LongCodec.INSTANCE, RedisCommands.EVAL_VOID,
                 // get the existing timeout for the thread to remove
                 "local queue = redis.call('lrange', KEYS[1], 0, -1);" +
                         // find the location in the queue where the thread is
@@ -105,7 +105,7 @@ public class RedissonFairLock extends RedissonLock implements RLock {
 
         long currentTime = System.currentTimeMillis();
         if (command == RedisCommands.EVAL_NULL_BOOLEAN) {
-            return commandExecutor.syncedEvalNoRetry(getRawName(), LongCodec.INSTANCE, command,
+            return syncedEvalNoRetry(getRawName(), LongCodec.INSTANCE, command,
                     // remove stale threads
                     "while true do " +
                         "local firstThreadId2 = redis.call('lindex', KEYS[2], 0);" +
@@ -150,7 +150,7 @@ public class RedissonFairLock extends RedissonLock implements RLock {
         }
 
         if (command == RedisCommands.EVAL_LONG) {
-            return commandExecutor.syncedEvalNoRetry(getRawName(), LongCodec.INSTANCE, command,
+            return syncedEvalNoRetry(getRawName(), LongCodec.INSTANCE, command,
                     // remove stale threads
                     "while true do " +
                         "local firstThreadId2 = redis.call('lindex', KEYS[2], 0);" +
@@ -319,7 +319,7 @@ public class RedissonFairLock extends RedissonLock implements RLock {
     @Override
     public RFuture<Boolean> forceUnlockAsync() {
         cancelExpirationRenewal(null, null);
-        return commandExecutor.syncedEvalWithRetry(getRawName(), LongCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
+        return syncedEvalWithRetry(getRawName(), LongCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
                 // remove stale threads
                 "while true do "
                 + "local firstThreadId2 = redis.call('lindex', KEYS[2], 0);"

--- a/redisson/src/main/java/org/redisson/RedissonFasterMultiLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonFasterMultiLock.java
@@ -331,7 +331,7 @@ public class RedissonFasterMultiLock extends RedissonBaseLock {
         params.add(String.valueOf(unit.toMillis(leaseTime)));
         params.add(getLockName(threadId));
         params.addAll(fields);
-        return commandExecutor.syncedEval(key, StringCodec.INSTANCE, command,
+        return syncedEval(key, StringCodec.INSTANCE, command,
                 "local currentTime = tonumber(ARGV[1]);" +
                         "local leaseTime = tonumber(ARGV[2]);" +
                         "local currentThread = ARGV[3];" +
@@ -379,7 +379,7 @@ public class RedissonFasterMultiLock extends RedissonBaseLock {
         params.add(String.valueOf(System.currentTimeMillis()));
         params.add(getLockName(threadId));
         params.addAll(fields);
-        return commandExecutor.syncedEval(key, StringCodec.INSTANCE, RedisCommands.EVAL_LONG,
+        return syncedEval(key, StringCodec.INSTANCE, RedisCommands.EVAL_LONG,
                         "local leaseTime = tonumber(ARGV[1]);" +
                                 "local currentTime = tonumber(ARGV[2]);" +
                                 "local currentThread = ARGV[3];" +
@@ -477,7 +477,7 @@ public class RedissonFasterMultiLock extends RedissonBaseLock {
         params.add(timeout);
         params.add(System.currentTimeMillis());
         params.addAll(fields);
-        return commandExecutor.syncedEval(getRawName(), StringCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
+        return syncedEval(getRawName(), StringCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
                 "local val = redis.call('get', KEYS[3]); " +
                         "if val ~= false then " +
                         "   return tonumber(val);" +
@@ -553,7 +553,7 @@ public class RedissonFasterMultiLock extends RedissonBaseLock {
         params.add(LockPubSub.UNLOCK_MESSAGE);
         params.add(getSubscribeService().getPublishCommand());
         params.addAll(fields);
-        return commandExecutor.syncedEvalWithRetry(getRawName(), LongCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
+        return syncedEvalWithRetry(getRawName(), LongCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
                 "local removeCount = 0;" +
                         "for i=3, #ARGV, 1 do " +
                         "    local lockName = redis.call('hget', KEYS[1], ARGV[i]); " +
@@ -725,7 +725,7 @@ public class RedissonFasterMultiLock extends RedissonBaseLock {
         params.add(String.valueOf(System.currentTimeMillis()));
         params.add(getLockName(threadId));
         params.addAll(fields);
-        return commandExecutor.syncedEval(getRawName(), StringCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
+        return syncedEval(getRawName(), StringCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
                 "local currentTime = tonumber(ARGV[1]);" +
                         "local currentThread = ARGV[2];" +
                         "if (redis.call('exists',KEYS[1]) > 0) then" +
@@ -756,7 +756,7 @@ public class RedissonFasterMultiLock extends RedissonBaseLock {
         List<String> params = new ArrayList<>();
         params.add(String.valueOf(System.currentTimeMillis()));
         params.addAll(fields);
-        return commandExecutor.syncedEval(getRawName(), StringCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
+        return syncedEval(getRawName(), StringCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
                 "local currentTime = tonumber(ARGV[1]);" +
                         "for i = 2,#ARGV,1 do" +
                         "   local localThread = redis.call('hget', KEYS[1], ARGV[i]);" +

--- a/redisson/src/main/java/org/redisson/RedissonFencedLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonFencedLock.java
@@ -104,7 +104,7 @@ public class RedissonFencedLock extends RedissonLock implements RFencedLock {
     }
 
     RFuture<List<Long>> tryLockInnerAsync(long leaseTime, TimeUnit unit, long threadId) {
-        return commandExecutor.syncedEvalNoRetry(getRawName(), LongCodec.INSTANCE, RedisCommands.EVAL_LONG_LIST,
+        return syncedEvalNoRetry(getRawName(), LongCodec.INSTANCE, RedisCommands.EVAL_LONG_LIST,
                 "if (redis.call('exists', KEYS[1]) == 0 " +
                         "or (redis.call('hexists', KEYS[1], ARGV[2]) == 1)) then " +
                             "local token = redis.call('incr', KEYS[2]);" +
@@ -294,7 +294,7 @@ public class RedissonFencedLock extends RedissonLock implements RFencedLock {
 
     @Override
     <T> RFuture<T> tryLockInnerAsync(long waitTime, long leaseTime, TimeUnit unit, long threadId, RedisStrictCommand<T> command) {
-        return commandExecutor.syncedEvalNoRetry(getRawName(), LongCodec.INSTANCE, command,
+        return syncedEvalNoRetry(getRawName(), LongCodec.INSTANCE, command,
                 "if ((redis.call('exists', KEYS[1]) == 0) " +
                         "or (redis.call('hexists', KEYS[1], ARGV[2]) == 1)) then " +
                             "redis.call('incr', KEYS[2]);" +

--- a/redisson/src/main/java/org/redisson/RedissonLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonLock.java
@@ -334,7 +334,7 @@ public class RedissonLock extends RedissonBaseLock {
     @Override
     public RFuture<Boolean> forceUnlockAsync() {
         cancelExpirationRenewal(null, null);
-        return commandExecutor.syncedEvalWithRetry(getRawName(), LongCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
+        return syncedEvalWithRetry(getRawName(), LongCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
                 "if (redis.call('del', KEYS[1]) == 1) then "
                         + "redis.call(ARGV[2], KEYS[2], ARGV[1]); "
                         + "return 1 "

--- a/redisson/src/main/java/org/redisson/RedissonReadLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonReadLock.java
@@ -54,7 +54,7 @@ public class RedissonReadLock extends RedissonLock implements RLock {
     
     @Override
     <T> RFuture<T> tryLockInnerAsync(long waitTime, long leaseTime, TimeUnit unit, long threadId, RedisStrictCommand<T> command) {
-        return commandExecutor.syncedEvalNoRetry(getRawName(), LongCodec.INSTANCE, command,
+        return syncedEvalNoRetry(getRawName(), LongCodec.INSTANCE, command,
                                 "local mode = redis.call('hget', KEYS[1], 'mode'); " +
                                 "if (mode == false) then " +
                                   "redis.call('hset', KEYS[1], 'mode', 'read'); " +
@@ -164,7 +164,7 @@ public class RedissonReadLock extends RedissonLock implements RLock {
     @Override
     public RFuture<Boolean> forceUnlockAsync() {
         cancelExpirationRenewal(null, null);
-        return commandExecutor.syncedEvalWithRetry(getRawName(), LongCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
+        return syncedEvalWithRetry(getRawName(), LongCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
                 "if (redis.call('hget', KEYS[1], 'mode') == 'read') then " +
                     "redis.call('del', KEYS[1]); " +
                     "redis.call(ARGV[2], KEYS[2], ARGV[1]); " +

--- a/redisson/src/main/java/org/redisson/RedissonSpinLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonSpinLock.java
@@ -128,7 +128,7 @@ public final class RedissonSpinLock extends RedissonBaseLock {
     <T> RFuture<T> tryLockInnerAsync(long leaseTime, TimeUnit unit, long threadId, RedisStrictCommand<T> command) {
         internalLockLeaseTime = unit.toMillis(leaseTime);
 
-        return commandExecutor.syncedEvalNoRetry(getRawName(), LongCodec.INSTANCE, command,
+        return syncedEvalNoRetry(getRawName(), LongCodec.INSTANCE, command,
                 "if (redis.call('exists', KEYS[1]) == 0) then " +
                         "redis.call('hincrby', KEYS[1], ARGV[2], 1); " +
                         "redis.call('pexpire', KEYS[1], ARGV[1]); " +
@@ -189,7 +189,7 @@ public final class RedissonSpinLock extends RedissonBaseLock {
     @Override
     public RFuture<Boolean> forceUnlockAsync() {
         cancelExpirationRenewal(null, null);
-        return commandExecutor.syncedEvalWithRetry(getRawName(), LongCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
+        return syncedEvalWithRetry(getRawName(), LongCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
                 "if (redis.call('del', KEYS[1]) == 1) then "
                         + "return 1 "
                         + "else "

--- a/redisson/src/main/java/org/redisson/RedissonWriteLock.java
+++ b/redisson/src/main/java/org/redisson/RedissonWriteLock.java
@@ -52,7 +52,7 @@ public class RedissonWriteLock extends RedissonLock implements RLock {
     
     @Override
     <T> RFuture<T> tryLockInnerAsync(long waitTime, long leaseTime, TimeUnit unit, long threadId, RedisStrictCommand<T> command) {
-        return commandExecutor.syncedEvalNoRetry(getRawName(), LongCodec.INSTANCE, command,
+        return syncedEvalNoRetry(getRawName(), LongCodec.INSTANCE, command,
                             "local mode = redis.call('hget', KEYS[1], 'mode'); " +
                             "if (mode == false) then " +
                                   "redis.call('hset', KEYS[1], 'mode', 'write'); " +
@@ -124,7 +124,7 @@ public class RedissonWriteLock extends RedissonLock implements RLock {
     @Override
     public RFuture<Boolean> forceUnlockAsync() {
         cancelExpirationRenewal(null, null);
-        return commandExecutor.syncedEvalWithRetry(getRawName(), LongCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
+        return syncedEvalWithRetry(getRawName(), LongCodec.INSTANCE, RedisCommands.EVAL_BOOLEAN,
               "if (redis.call('hget', KEYS[1], 'mode') == 'write') then " +
                   "redis.call('del', KEYS[1]); " +
                   "redis.call(ARGV[2], KEYS[2], ARGV[1]); " +

--- a/redisson/src/main/java/org/redisson/command/CommandAsyncExecutor.java
+++ b/redisson/src/main/java/org/redisson/command/CommandAsyncExecutor.java
@@ -163,7 +163,11 @@ public interface CommandAsyncExecutor {
 
     <T> RFuture<T> syncedEvalWithRetry(String key, Codec codec, RedisCommand<T> evalCommandType, String script, List<Object> keys, Object... params);
 
+    <T> RFuture<T> syncedEvalWithRetry(boolean skipSync, String key, Codec codec, RedisCommand<T> evalCommandType, String script, List<Object> keys, Object... params);
+
     <T> RFuture<T> syncedEvalNoRetry(String key, Codec codec, RedisCommand<T> evalCommandType, String script, List<Object> keys, Object... params);
+
+    <T> RFuture<T> syncedEvalNoRetry(boolean skipSync, String key, Codec codec, RedisCommand<T> evalCommandType, String script, List<Object> keys, Object... params);
 
     <T> RFuture<T> syncedEvalNoRetry(long timeout, SyncMode syncMode, String key, Codec codec, RedisCommand<T> evalCommandType, String script, List<Object> keys, Object... params);
 

--- a/redisson/src/main/java/org/redisson/command/CommandAsyncService.java
+++ b/redisson/src/main/java/org/redisson/command/CommandAsyncService.java
@@ -1067,11 +1067,27 @@ public class CommandAsyncService implements CommandAsyncExecutor {
 
     @Override
     public <T> RFuture<T> syncedEvalWithRetry(String key, Codec codec, RedisCommand<T> evalCommandType, String script, List<Object> keys, Object... params) {
+        return syncedEvalWithRetry(false, key, codec, evalCommandType, script, keys, params);
+    }
+
+    @Override
+    public <T> RFuture<T> syncedEvalWithRetry(boolean skipSync, String key, Codec codec, RedisCommand<T> evalCommandType, String script, List<Object> keys, Object... params) {
+        if (skipSync) {
+            return getServiceManager().execute(() -> evalWriteAsync(key, codec, evalCommandType, script, keys, params));
+        }
         return getServiceManager().execute(() -> syncedEval(key, codec, evalCommandType, script, keys, params));
     }
 
     @Override
     public <T> RFuture<T> syncedEvalNoRetry(String key, Codec codec, RedisCommand<T> evalCommandType, String script, List<Object> keys, Object... params) {
+        return syncedEvalNoRetry(false, key, codec, evalCommandType, script, keys, params);
+    }
+
+    @Override
+    public <T> RFuture<T> syncedEvalNoRetry(boolean skipSync, String key, Codec codec, RedisCommand<T> evalCommandType, String script, List<Object> keys, Object... params) {
+        if (skipSync) {
+            return evalWriteNoRetryAsync(key, codec, evalCommandType, script, keys, params);
+        }
         return syncedEval(getServiceManager().getCfg().getSlavesSyncTimeout(),
                             SyncMode.WAIT, false, key, codec, evalCommandType, script, keys, params);
     }

--- a/redisson/src/main/java/org/redisson/config/Config.java
+++ b/redisson/src/main/java/org/redisson/config/Config.java
@@ -86,6 +86,8 @@ public class Config {
 
     private boolean checkLockSyncedSlaves = true;
 
+    private boolean skipLockSyncedSlaves;
+
     private long slavesSyncTimeout = 1000;
 
     private long reliableTopicWatchdogTimeout = TimeUnit.MINUTES.toMillis(10);
@@ -176,6 +178,7 @@ public class Config {
         setLockWatchdogBatchSize(oldConf.getLockWatchdogBatchSize());
         setFairLockWaitTimeout(oldConf.getFairLockWaitTimeout());
         setCheckLockSyncedSlaves(oldConf.isCheckLockSyncedSlaves());
+        setSkipLockSyncedSlaves(oldConf.isSkipLockSyncedSlaves());
         setSlavesSyncTimeout(oldConf.getSlavesSyncTimeout());
         setNettyThreads(oldConf.getNettyThreads());
         setThreads(oldConf.getThreads());
@@ -714,6 +717,24 @@ public class Config {
 
     public boolean isCheckLockSyncedSlaves() {
         return checkLockSyncedSlaves;
+    }
+
+    /**
+     * Defines whether to skip replica synchronization for lock operations.
+     * <p>
+     * Default is <code>false</code>.
+     *
+     * @param skipLockSyncedSlaves <code>true</code> to skip replica synchronization,
+     *                             <code>false</code> otherwise.
+     * @return config
+     */
+    public Config setSkipLockSyncedSlaves(boolean skipLockSyncedSlaves) {
+        this.skipLockSyncedSlaves = skipLockSyncedSlaves;
+        return this;
+    }
+
+    public boolean isSkipLockSyncedSlaves() {
+        return skipLockSyncedSlaves;
     }
 
     /**

--- a/redisson/src/test/java/org/redisson/RedisDockerTest.java
+++ b/redisson/src/test/java/org/redisson/RedisDockerTest.java
@@ -434,6 +434,10 @@ public class RedisDockerTest {
     record ReplicatedData(Startable container, RedissonClient redisson, List<ContainerState> nodes) {}
 
     private static ReplicatedData createReplicated() {
+        return createReplicated(new Config());
+    }
+
+    private static ReplicatedData createReplicated(Config config) {
         DockerComposeContainer environment =
                 new DockerComposeContainer(new File("src/test/resources/docker-compose-redis-replicated.yml"))
                         .withOptions("--compatibility")
@@ -459,7 +463,6 @@ public class RedisDockerTest {
         Ports.Binding[] replicaPort = replica.get().getContainerInfo().getNetworkSettings()
                 .getPorts().getBindings().get(new ExposedPort(replica.get().getExposedPorts().get(0)));
 
-        Config config = new Config();
         config.setProtocol(protocol);
         config.useReplicatedServers()
                 .setNatMapper(new NatMapper() {
@@ -496,6 +499,16 @@ public class RedisDockerTest {
     protected void withNewReplicated(BiConsumer<List<ContainerState>, RedissonClient> callback) {
         ReplicatedData data = createReplicated();
 
+        try {
+            callback.accept(data.nodes, data.redisson);
+        } finally {
+            data.redisson.shutdown();
+            data.container.stop();
+        }
+    }
+
+    protected void withNewReplicated(Config config, BiConsumer<List<ContainerState>, RedissonClient> callback) {
+        ReplicatedData data = createReplicated(config);
         try {
             callback.accept(data.nodes, data.redisson);
         } finally {

--- a/redisson/src/test/java/org/redisson/RedissonLockTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonLockTest.java
@@ -24,6 +24,43 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
 public class RedissonLockTest extends BaseConcurrentTest {
+
+    @Test
+    public void testSkipLockSyncedSlaves() {
+        Config config = new Config().setSkipLockSyncedSlaves(true);
+        withNewReplicated(config, (nodes, client) -> {
+            String before = execute(nodes.get(0), "redis-cli", "info", "commandstats");
+            RLock lock = client.getLock("skip-lock-sync");
+            lock.lock();
+            lock.unlock();
+            String after = execute(nodes.get(0), "redis-cli", "info", "commandstats");
+
+            assertThat(commandCalls(before, "wait")).isEqualTo(commandCalls(after, "wait"));
+        });
+    }
+
+    @Test
+    public void testLockSyncedSlavesByDefault() {
+        withNewReplicated((nodes, client) -> {
+            String before = execute(nodes.get(0), "redis-cli", "info", "commandstats");
+            RLock lock = client.getLock("lock-sync-default");
+            lock.lock();
+            lock.unlock();
+            String after = execute(nodes.get(0), "redis-cli", "info", "commandstats");
+
+            assertThat(commandCalls(after, "wait")).isGreaterThan(commandCalls(before, "wait"));
+        });
+    }
+
+    private long commandCalls(String info, String command) {
+        return java.util.Arrays.stream(info.split("\\r?\\n"))
+                .filter(line -> line.startsWith("cmdstat_" + command + ":"))
+                .map(line -> line.substring(line.indexOf("calls=") + 6))
+                .map(value -> value.substring(0, value.indexOf(',')))
+                .mapToLong(Long::parseLong)
+                .findFirst()
+                .orElse(0);
+    }
     static class LockWithoutBoolean extends Thread {
         private CountDownLatch latch;
         private RedissonClient redisson;

--- a/redisson/src/test/java/org/redisson/config/ConfigSupportTest.java
+++ b/redisson/src/test/java/org/redisson/config/ConfigSupportTest.java
@@ -25,6 +25,16 @@ public class ConfigSupportTest {
         
         assertEquals("redis://127.0.0.1", config.getAddress());
     }
+
+    @Test
+    public void testSkipLockSyncedSlaves() throws IOException {
+        String yaml = "skipLockSyncedSlaves: true\n"
+                + "singleServerConfig:\n  address: redis://127.0.0.1";
+        Config config = new ConfigSupport().fromYAML(yaml, Config.class);
+
+        assertThat(config.isSkipLockSyncedSlaves()).isTrue();
+        assertThat(new Config(config).isSkipLockSyncedSlaves()).isTrue();
+    }
     
     @Test
     public void testParsingEnv() throws IOException {


### PR DESCRIPTION
## What is the problem?

`checkLockSyncedSlaves(false)` only suppresses `NoSyncedSlavesException`. Redisson still sends WAIT and incurs replica synchronization latency.

## What does this change do?

Add `Config.skipLockSyncedSlaves`, disabled by default.

When enabled, lock operations use the normal eval write path and skip WAIT/WAITAOF replica synchronization.

The existing `checkLockSyncedSlaves` behavior remains unchanged.

## Tests

- Verify yaml parsing and config copy behavior
- Verify default lock operations send WAIT
- Verify `skipLockSyncedSlaves(true)` skips WAIT

Fixes #7321