### PR TITLE
fix: clean up the local-cache disabled marker after transaction commit

### DIFF
--- a/redisson/src/main/java/org/redisson/cache/LocalCacheListener.java
+++ b/redisson/src/main/java/org/redisson/cache/LocalCacheListener.java
@@ -143,7 +143,7 @@ public abstract class LocalCacheListener {
 
             String disabledCachesName = RedissonObject.suffixName(name, RedissonLocalCachedMap.DISABLED_CACHES_SUFFIX);
             CompositeCodec localCacheCodec = new CompositeCodec(LocalCachedMessageCodec.INSTANCE, StringCodec.INSTANCE, StringCodec.INSTANCE);
-            RSetCache<LocalCachedMapDisabledKey> setCache = new RedissonSetCache<>(localCacheCodec, null, commandExecutor, disabledCachesName, null);
+            RSetCache<LocalCachedMapDisabledKey> setCache = new RedissonSetCache<>(LocalCachedMessageCodec.INSTANCE, null, commandExecutor, disabledCachesName, null);
             for (LocalCachedMapDisabledKey key : setCache.readAll()) {
                 disableCache(key.getRequestId(), key.getTimeout());
             }

--- a/redisson/src/main/java/org/redisson/transaction/RedissonTransaction.java
+++ b/redisson/src/main/java/org/redisson/transaction/RedissonTransaction.java
@@ -407,7 +407,7 @@ public class RedissonTransaction implements RTransaction {
             if (isKeyOperate(transactionalOperation) && !value.isAllKeys()) {
                 value.setAllKeys(true);
                 String disabledCachesName = RedissonObject.suffixName(transactionalOperation.getName(), RedissonLocalCachedMap.DISABLED_CACHES_SUFFIX);
-                RSetCacheAsync<LocalCachedMapDisabledKey> setCache = batch.getSetCache(disabledCachesName, localCacheCodec);
+                RSetCacheAsync<LocalCachedMapDisabledKey> setCache = batch.getSetCache(disabledCachesName, LocalCachedMessageCodec.INSTANCE);
                 LocalCachedMapDisabledKey localCacheKey = new LocalCachedMapDisabledKey(requestId, options.getResponseTimeout());
                 setCache.addAsync(localCacheKey, options.getResponseTimeout(), TimeUnit.MILLISECONDS);
             } else if (transactionalOperation instanceof MapOperation) {
@@ -454,7 +454,7 @@ public class RedissonTransaction implements RTransaction {
             }
             if (entry.getValue().isAllKeys()) {
                 String disabledCachesName = RedissonObject.suffixName(entry.getKey().getName(), RedissonLocalCachedMap.DISABLED_CACHES_SUFFIX);
-                RSetCacheAsync<LocalCachedMapDisabledKey> setCache = batch.getSetCache(disabledCachesName, localCacheCodec);
+                RSetCacheAsync<LocalCachedMapDisabledKey> setCache = publishBatch.getSetCache(disabledCachesName, LocalCachedMessageCodec.INSTANCE);
                 setCache.removeAsync(localCacheKey);
             }
 
@@ -476,16 +476,17 @@ public class RedissonTransaction implements RTransaction {
         } catch (Exception e) {
             throw new TransactionException("Unable to execute transaction over local cached map objects: " + localCaches, e);
         }
-        
-        for (RTopic topic : topics) {
-            topic.removeAllListeners();
-        }
-        
+
         try {
             latch.await(options.getResponseTimeout(), TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
+
+        for (RTopic topic : topics) {
+            topic.removeAllListeners();
+        }
+
         return hashes;
     }
 
@@ -510,7 +511,7 @@ public class RedissonTransaction implements RTransaction {
             if (isKeyOperate(transactionalOperation) && !value.isAllKeys()) {
                 value.setAllKeys(true);
                 String disabledCachesName = RedissonObject.suffixName(transactionalOperation.getName(), RedissonLocalCachedMap.DISABLED_CACHES_SUFFIX);
-                RSetCacheAsync<LocalCachedMapDisabledKey> setCache = batch.getSetCache(disabledCachesName, localCacheCodec);
+                RSetCacheAsync<LocalCachedMapDisabledKey> setCache = batch.getSetCache(disabledCachesName, LocalCachedMessageCodec.INSTANCE);
                 LocalCachedMapDisabledKey localCacheKey = new LocalCachedMapDisabledKey(requestId, options.getResponseTimeout());
                 setCache.addAsync(localCacheKey, options.getResponseTimeout(), TimeUnit.MILLISECONDS);
 
@@ -569,7 +570,7 @@ public class RedissonTransaction implements RTransaction {
                     }
                     if (entry.getValue().isAllKeys()) {
                         String disabledCachesName = RedissonObject.suffixName(entry.getKey().getName(), RedissonLocalCachedMap.DISABLED_CACHES_SUFFIX);
-                        RSetCacheAsync<LocalCachedMapDisabledKey> setCache = batch.getSetCache(disabledCachesName, localCacheCodec);
+                        RSetCacheAsync<LocalCachedMapDisabledKey> setCache = publishBatch.getSetCache(disabledCachesName, LocalCachedMessageCodec.INSTANCE);
                         setCache.removeAsync(localCacheKey);
                     }
 

--- a/redisson/src/test/java/org/redisson/transaction/RedissonTransactionalLocalCachedMapTest.java
+++ b/redisson/src/test/java/org/redisson/transaction/RedissonTransactionalLocalCachedMapTest.java
@@ -6,12 +6,18 @@ import mockit.MockUp;
 import org.junit.jupiter.api.Test;
 import org.redisson.RedisDockerTest;
 import org.redisson.RedissonListMultimapCache;
+import org.redisson.RedissonLocalCachedMap;
+import org.redisson.RedissonObject;
+import org.redisson.api.RListMultimapCache;
 import org.redisson.api.RLocalCachedMap;
 import org.redisson.api.RMap;
+import org.redisson.api.RSetCache;
 import org.redisson.api.RTransaction;
 import org.redisson.api.TransactionOptions;
 import org.redisson.api.map.MapLoader;
 import org.redisson.api.options.LocalCachedMapOptions;
+import org.redisson.cache.LocalCachedMapDisabledKey;
+import org.redisson.cache.LocalCachedMessageCodec;
 import org.redisson.client.codec.StringCodec;
 import org.redisson.codec.CompositeCodec;
 import org.redisson.codec.SnappyCodecV2;
@@ -20,6 +26,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -75,6 +82,70 @@ public class RedissonTransactionalLocalCachedMapTest extends RedisDockerTest {
 
         RLocalCachedMap < Object, Object > localCachedMap2 = redisson.getLocalCachedMap(
                 org.redisson.api.options.LocalCachedMapOptions.name("test1").codec(CODEC));
+    }
+
+    @Test
+    public void testDisabledCachesClearedAfterCommit() {
+        RLocalCachedMap<String, String> m1 = redisson.getLocalCachedMap(LocalCachedMapOptions.name("test"));
+
+        // a response timeout above the transaction timeout makes the blocking
+        // visible: commit() stalls on it instead of the stall being cut off by
+        // the transaction timeout
+        RTransaction transaction = redisson.createTransaction(TransactionOptions.defaults()
+                .responseTimeout(10, TimeUnit.SECONDS));
+        RLocalCachedMap<String, String> txMap = transaction.getLocalCachedMap(m1);
+        txMap.expire(Duration.ofSeconds(100));
+        transaction.commit();
+
+        // the disabled-caches marker must not survive the commit: it would keep
+        // disabling instances connecting during its TTL window
+        assertThat(disabledCachesSet("test").size()).isZero();
+    }
+
+    @Test
+    public void testDisabledCachesClearedAfterCommitAsync() throws InterruptedException, ExecutionException {
+        RLocalCachedMap<String, String> m1 = redisson.getLocalCachedMap(LocalCachedMapOptions.name("test"));
+
+        RTransaction transaction = redisson.createTransaction(TransactionOptions.defaults());
+        RLocalCachedMap<String, String> txMap = transaction.getLocalCachedMap(m1);
+        txMap.expire(Duration.ofSeconds(100));
+        transaction.commitAsync().get();
+
+        assertThat(disabledCachesSet("test").size()).isZero();
+    }
+
+    @Test
+    public void testInstanceStartsWithDisabledCachesMarker() {
+        // a marker written with the message codec must disable a freshly started
+        // instance on startup instead of failing to decode
+        RSetCache<LocalCachedMapDisabledKey> setCache = disabledCachesSet("test");
+        setCache.add(new LocalCachedMapDisabledKey("request-1", 2000), 2000, TimeUnit.MILLISECONDS);
+
+        RLocalCachedMap<String, String> m2 = redisson.getLocalCachedMap(LocalCachedMapOptions.name("test"));
+        m2.put("1", "0");
+        assertThat(m2.get("1")).isEqualTo("0");
+    }
+
+    @Test
+    public void testDisabledKeysClearedAfterCommit() {
+        RLocalCachedMap<String, String> m1 = redisson.getLocalCachedMap(LocalCachedMapOptions.name("test"));
+
+        RTransaction transaction = redisson.createTransaction(TransactionOptions.defaults());
+        RLocalCachedMap<String, String> txMap = transaction.getLocalCachedMap(m1);
+        txMap.put("1", "1");
+        transaction.commit();
+
+        // the disabled-keys entries must not survive the commit either
+        CompositeCodec localCacheCodec = new CompositeCodec(LocalCachedMessageCodec.INSTANCE,
+                StringCodec.INSTANCE, StringCodec.INSTANCE);
+        RListMultimapCache<LocalCachedMapDisabledKey, String> multimap = redisson.getListMultimapCache(
+                RedissonObject.suffixName("test", RedissonLocalCachedMap.DISABLED_KEYS_SUFFIX), localCacheCodec);
+        assertThat(multimap.readAllKeySet()).isEmpty();
+    }
+
+    private RSetCache<LocalCachedMapDisabledKey> disabledCachesSet(String name) {
+        return redisson.getSetCache(RedissonObject.suffixName(name, RedissonLocalCachedMap.DISABLED_CACHES_SUFFIX),
+                LocalCachedMessageCodec.INSTANCE);
     }
 
     @Test


### PR DESCRIPTION
AI disclosure: this change was prepared with AI coding agents, reviewed and revised line by line by me.

## What

Three defects in the local cache disable phase of `RedissonTransaction`, all introduced with the recent rewrite of that phase:

1. The `disabled-caches` marker remove went into the first batch, which was already executed at that point, so the remove never ran and the marker lingered in Redis for its TTL (`responseTimeout`).
2. The marker could not have matched anyway: the marker set was accessed through `localCacheCodec`, whose value slot is `StringCodec`. `StringCodec.encode` stringifies objects, so the ZADD on commit and the ZREM after publish encoded the same `LocalCachedMapDisabledKey` differently (identity hash). A freshly started instance then failed with `ClassCastException` in `LocalCacheListener` when reading the leftover marker back.
3. `disableLocalCache` (sync) removed the ack listeners before awaiting the latch, so the latch always ran into the full `responseTimeout` and every synchronous commit over a local cached map blocked for it (measured 3021 ms with defaults). The async variant already awaits first.

## How

- The remove now goes into `publishBatch`, the batch that is executed for the publish phase (sync and async variants).
- The marker set is accessed with `LocalCachedMessageCodec.INSTANCE`, which encodes and decodes `LocalCachedMapDisabledKey` symmetrically (type 0x6); the `disabled-keys` multimap keeps `localCacheCodec` because its EVAL responses decode string values through the value slot.
- The listener removal moved after `latch.await`, matching the async variant.

## Testing

`RedissonTransactionalLocalCachedMapTest`: 21 passed locally (4 new).

The new tests fail on unpatched master, each anchored to one defect:
- `testDisabledCachesClearedAfterCommit`: `TransactionTimeoutException` after blocking 10 s (defect 3)
- `testDisabledCachesClearedAfterCommitAsync`: marker survives, `expected: 0 but was: 1` (defects 1+2)
- `testInstanceStartsWithDisabledCachesMarker`: `ClassCastException` on startup with a leftover marker (defect 2)
- `testDisabledKeysClearedAfterCommit`: guard for the sibling `disabled-keys` cleanup; verified red under a mutant that misfiles the `removeAllAsync` into the executed batch
