### PR TITLE
Feature - eagerConnectionRelease setting added

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -116,6 +116,18 @@ Default value: `null`
 
 The connection listener, which is triggered when Redisson is connected/disconnected to a Valkey or Redis server.
 
+**eagerConnectionRelease**
+
+Default value: `false`
+
+Defines whether to return the connection to the pool right after a command has been written to the channel regardless of the connection pool size. Allows a single connection to be shared by multiple commands.
+
+Eager release is always used if `masterConnectionPoolSize` is less than `10`. Blocking commands, ASK redirects, and batch executors are always released after the response.
+
+`true` - enables eager release regardless of the connection pool size
+
+`false` - preserves behavior based on the connection pool size
+
 **lazyInitialization**
 
 Default value: `false`

--- a/redisson/src/main/java/org/redisson/command/RedisExecutor.java
+++ b/redisson/src/main/java/org/redisson/command/RedisExecutor.java
@@ -737,7 +737,7 @@ public class RedisExecutor<V, R> {
             }
             writeFuture = connection.send(new CommandData<>(attemptPromise, codec, command, params));
 
-            if (connectionManager.getServiceManager().getConfig().getMasterConnectionPoolSize() < 10
+            if (isEagerConnectionRelease()
                     && !command.isBlockingCommand()) {
                 release(connection);
             }
@@ -756,7 +756,7 @@ public class RedisExecutor<V, R> {
         }
 
         RedisConnection connection = getNow(connectionFuture);
-        if (connectionManager.getServiceManager().getConfig().getMasterConnectionPoolSize() < 10) {
+        if (isEagerConnectionRelease()) {
             if (source.getRedirect() == Redirect.ASK
                     || getClass() != RedisExecutor.class
                         || (command != null && command.isBlockingCommand())) {
@@ -775,6 +775,11 @@ public class RedisExecutor<V, R> {
             log.debug("connection{}released for {} from slot {} using connection {}",
                     connectionType, LogHelper.toString(command, params), source, connection);
         }
+    }
+
+    protected boolean isEagerConnectionRelease() {
+        return connectionManager.getServiceManager().getCfg().isEagerConnectionRelease()
+                || connectionManager.getServiceManager().getConfig().getMasterConnectionPoolSize() < 10;
     }
 
     private void release(RedisConnection connection) {

--- a/redisson/src/main/java/org/redisson/config/Config.java
+++ b/redisson/src/main/java/org/redisson/config/Config.java
@@ -110,6 +110,8 @@ public class Config {
 
     private boolean lazyInitialization;
 
+    private boolean eagerConnectionRelease;
+
     private Protocol protocol = Protocol.RESP2;
 
     private Set<ValkeyCapability> valkeyCapabilities = Collections.emptySet();
@@ -189,6 +191,7 @@ public class Config {
         setAddressResolverGroupFactory(oldConf.getAddressResolverGroupFactory());
         setReliableTopicWatchdogTimeout(oldConf.getReliableTopicWatchdogTimeout());
         setLazyInitialization(oldConf.isLazyInitialization());
+        setEagerConnectionRelease(oldConf.isEagerConnectionRelease());
         setProtocol(oldConf.getProtocol());
         setValkeyCapabilities(oldConf.getValkeyCapabilities());
         setNameMapper(oldConf.getNameMapper());
@@ -991,6 +994,29 @@ public class Config {
      */
     public Config setLazyInitialization(boolean lazyInitialization) {
         this.lazyInitialization = lazyInitialization;
+        return this;
+    }
+
+    public boolean isEagerConnectionRelease() {
+        return eagerConnectionRelease;
+    }
+
+    /**
+     * Defines whether to return the connection to the pool right after a command has been
+     * written to the channel regardless of the connection pool size. Allows a single connection
+     * to be shared by multiple commands.
+     * <p>
+     * Eager release is always used if master connection pool size is less than <code>10</code>.
+     * Blocking commands, ASK redirects, and batch executors are always released after the response.
+     * <p>
+     * Default value is <code>false</code>
+     *
+     * @param eagerConnectionRelease <code>true</code> enables eager release regardless of the connection pool size,
+     *                               <code>false</code> preserves behavior based on the connection pool size.
+     * @return config
+     */
+    public Config setEagerConnectionRelease(boolean eagerConnectionRelease) {
+        this.eagerConnectionRelease = eagerConnectionRelease;
         return this;
     }
 

--- a/redisson/src/test/java/org/redisson/command/RedisExecutorTest.java
+++ b/redisson/src/test/java/org/redisson/command/RedisExecutorTest.java
@@ -1,0 +1,66 @@
+package org.redisson.command;
+
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.jupiter.api.Test;
+import org.redisson.config.Config;
+import org.redisson.config.MasterSlaveServersConfig;
+import org.redisson.config.ReadMode;
+import org.redisson.connection.ConnectionManager;
+import org.redisson.connection.ServiceManager;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RedisExecutorTest {
+
+    @Test
+    void largePoolDoesNotUseEagerReleaseByDefault(@Mocked ConnectionManager connectionManager,
+                                                  @Mocked ServiceManager serviceManager) {
+        assertThat(isEagerConnectionRelease(connectionManager, serviceManager, 24, false)).isFalse();
+    }
+
+    @Test
+    void settingEnablesEagerReleaseForLargePool(@Mocked ConnectionManager connectionManager,
+                                                @Mocked ServiceManager serviceManager) {
+        assertThat(isEagerConnectionRelease(connectionManager, serviceManager, 24, true)).isTrue();
+    }
+
+    @Test
+    void smallPoolUsesEagerReleaseByDefault(@Mocked ConnectionManager connectionManager,
+                                            @Mocked ServiceManager serviceManager) {
+        assertThat(isEagerConnectionRelease(connectionManager, serviceManager, 5, false)).isTrue();
+    }
+
+    @Test
+    void poolSizeAtThresholdDoesNotUseEagerReleaseByDefault(@Mocked ConnectionManager connectionManager,
+                                                            @Mocked ServiceManager serviceManager) {
+        assertThat(isEagerConnectionRelease(connectionManager, serviceManager, 10, false)).isFalse();
+    }
+
+    private boolean isEagerConnectionRelease(ConnectionManager connectionManager, ServiceManager serviceManager,
+                                            int masterConnectionPoolSize, boolean eagerConnectionRelease) {
+        Config config = new Config();
+        config.setEagerConnectionRelease(eagerConnectionRelease);
+        MasterSlaveServersConfig serversConfig = new MasterSlaveServersConfig();
+        serversConfig.setMasterConnectionPoolSize(masterConnectionPoolSize);
+
+        new Expectations() {{
+            connectionManager.getServiceManager();
+            result = serviceManager;
+            minTimes = 0;
+            serviceManager.getCfg();
+            result = config;
+            minTimes = 0;
+            serviceManager.getConfig();
+            result = serversConfig;
+            minTimes = 0;
+        }};
+
+        RedisExecutor<Object, Object> executor = new RedisExecutor<>(false, null, null, null, null,
+                new CompletableFuture<>(), false, connectionManager, null, null, false,
+                0, null, 0, false, ReadMode.MASTER);
+        return executor.isEagerConnectionRelease();
+    }
+}


### PR DESCRIPTION
## Summary

A connection is returned to the pool right after a command is written instead of after its response arrives, letting multiple commands share one connection. Today `RedisExecutor` reaches that path only when `masterConnectionPoolSize` is below 10, so a deployment that wants the sharing behavior has to shrink its pool to get it.

During local load testing, enabling eager release reduced connection pressure and improved p99 latency.

This adds an `eagerConnectionRelease` setting on `Config` that enables the same path for any pool size. It defaults to `false` and is combined with the existing pool size condition, so current behavior is unchanged. Blocking commands, ASK redirects and batch executors keep releasing the connection after the response, exactly as they do under the small-pool path.

Both decision sites in `RedisExecutor` (post-write release in `sendCommand`, and the release skip in `releaseConnection`) now read one `isEagerConnectionRelease()` predicate so they cannot disagree.

## Test plan

- New `RedisExecutorTest` covers the three states of the release decision: large pool with the setting off releases after the response, large pool with the setting on releases after the write, small pool still releases after the write with the setting off.
- `mvn -Punit-test test -Dtest=RedisExecutorTest` and `mvn checkstyle:check` pass locally (0 violations).
- Verified the setting survives a YAML round trip through `Config.toYAML()` / `Config.fromYAML()`, and that `Config(Config)` copies it, since `Redisson` builds its manager from a config copy.
