### PR TITLE
fix: addAndGet throws NumberFormatException when integer delta updates decimal value

### DIFF
--- a/redisson/src/main/java/org/redisson/client/protocol/convertor/NumberConvertor.java
+++ b/redisson/src/main/java/org/redisson/client/protocol/convertor/NumberConvertor.java
@@ -34,6 +34,12 @@ public class NumberConvertor implements Convertor<Object> {
     @Override
     public Object convert(Object result) {
         String res = (String) result;
+        // decimal result can't be represented by an integer type
+        if ((resultClass.isAssignableFrom(Long.class) || resultClass.isAssignableFrom(Integer.class))
+                && (res.indexOf('.') >= 0 || res.indexOf('E') >= 0 || res.indexOf('e') >= 0)) {
+            Object obj = Double.parseDouble(res);
+            return obj;
+        }
         if (resultClass.isAssignableFrom(Long.class)) {
             Object obj = Long.parseLong(res);
             return obj;

--- a/redisson/src/test/java/org/redisson/RedissonMapCacheTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonMapCacheTest.java
@@ -1544,7 +1544,17 @@ public class RedissonMapCacheTest extends BaseMapTest {
         mapCache1.destroy();
     }
 
-    
+    @Test
+    public void testAddAndGetMixedNumberTypes() {
+        RMapCache<String, Object> mapCache = redisson.getMapCache("test_addandget_mixed", StringCodec.INSTANCE);
+        mapCache.put("key1", 10.1, 10000L, TimeUnit.SECONDS);
+        assertThat(mapCache.addAndGet("key1", 1)).isEqualTo(11.1);
+        mapCache.put("key2", 20.1, 10000L, TimeUnit.SECONDS);
+        assertThat(mapCache.addAndGet("key2", -10L)).isEqualTo(10.1);
+        mapCache.destroy();
+    }
+
+
     @Test
     public void testFastPutIfAbsentWithTTL() throws Exception {
         RMapCache<SimpleKey, SimpleValue> map = redisson.getMapCache("simpleTTL");

--- a/redisson/src/test/java/org/redisson/RedissonMapTest.java
+++ b/redisson/src/test/java/org/redisson/RedissonMapTest.java
@@ -17,6 +17,8 @@ import org.redisson.api.listener.MapRemoveListener;
 import org.redisson.client.codec.Codec;
 import org.redisson.client.codec.LongCodec;
 import org.redisson.client.codec.StringCodec;
+import org.redisson.codec.CompositeCodec;
+import org.redisson.codec.JsonJacksonCodec;
 import org.redisson.config.Config;
 import org.testcontainers.containers.GenericContainer;
 
@@ -33,6 +35,46 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.AbstractMap;
 
 public class RedissonMapTest extends BaseMapTest {
+
+    @Test
+    public void testAddAndGetMixedNumberTypes() {
+        RMap<String, Object> map = redisson.getMap("testAddAndGetMixedNumberTypes", StringCodec.INSTANCE);
+
+        map.put("key1", 10);
+        assertThat(map.addAndGet("key1", 1)).isEqualTo(11);
+
+        map.put("key2", 10.1);
+        assertThat(map.addAndGet("key2", 1)).isEqualTo(11.1);
+
+        map.put("key3", 20.1);
+        assertThat(map.addAndGet("key3", -10L)).isEqualTo(10.1);
+
+        map.put("key4", 20L);
+        assertThat(map.addAndGet("key4", -10L)).isEqualTo(10L);
+
+        map.put("key5", 10.5f);
+        assertThat(map.addAndGet("key5", 1)).isEqualTo(11.5);
+
+        assertThat(map.addAndGet("key6", 1)).isEqualTo(1);
+    }
+
+    @Test
+    public void testAddAndGetJsonCodec() {
+        CompositeCodec codec = new CompositeCodec(StringCodec.INSTANCE, JsonJacksonCodec.INSTANCE, JsonJacksonCodec.INSTANCE);
+        RMap<String, Object> map = redisson.getMap("testAddAndGetJsonCodec", codec);
+
+        map.put("key1", 10);
+        assertThat(map.addAndGet("key1", 1)).isEqualTo(11);
+
+        map.put("key2", 10.1);
+        assertThat(map.addAndGet("key2", 1)).isEqualTo(11.1);
+
+        map.put("key3", 10.1);
+        assertThat(map.addAndGet("key3", -10)).isEqualTo(0.1);
+
+        map.put("key4", 20.1);
+        assertThat(map.addAndGet("key4", -10L)).isEqualTo(10.1);
+    }
 
     @Test
     public void testAddAndGetMapWriter() {

--- a/redisson/src/test/java/org/redisson/transaction/RedissonTransactionalMapTest.java
+++ b/redisson/src/test/java/org/redisson/transaction/RedissonTransactionalMapTest.java
@@ -41,6 +41,17 @@ public class RedissonTransactionalMapTest extends RedissonBaseTransactionalMapTe
         transaction.commit();
     }
 
+    @Test
+    public void testAddAndGetMixedNumberTypes() {
+        RMap<String, Object> map = redisson.getMap("test_addandget_mixed", StringCodec.INSTANCE);
+        map.put("key1", 10.1);
+
+        RTransaction transaction = redisson.createTransaction(TransactionOptions.defaults());
+        RMap<String, Object> tmap = transaction.getMap("test_addandget_mixed", StringCodec.INSTANCE);
+        assertThat(tmap.addAndGet("key1", 1)).isEqualTo(11.1);
+        transaction.commit();
+    }
+
     static final class TrackingStringCodec extends StringCodec {
 
         final List<ByteBuf> allocated = new ArrayList<ByteBuf>();


### PR DESCRIPTION
AI disclosure: this change was prepared with AI coding agents, reviewed and revised line by line by me.

## What

`addAndGet` with an integer delta on a decimal stored value throws `NumberFormatException`:

```java
map.put("key", 10.1);
map.addAndGet("key", 1); // NumberFormatException: For input string: "11.1"
```

## Root cause

`NumberConvertor` parses the `HINCRBYFLOAT` response with the **delta type** (`new NumberConvertor(value.getClass())`). All 7 call sites follow this pattern (RMap, RMapCache, local cached map, transactional map, JSON bucket). When the delta is `Integer`/`Long` but the updated value is decimal (`"11.1"`), `Integer.parseInt` throws.

#5431 reports it with a Jackson codec, but the codec is not the trigger: with `StringCodec` the same call fails the same way.

## How

In `NumberConvertor.convert()`: when the target type is `Long`/`Integer` and the response has decimal form (`.`/`e`/`E`), parse it as `Double`. A decimal result cannot be represented by an integer type, the correct value matters more than the exact type. Same narrowing approach as `LongNumberConvertor`. All other branches unchanged, the sibling paths (`RMapCache`, transaction, local cached map) get the same fix through the shared convertor.

## Testing

- `RedissonMapTest#testAddAndGetMixedNumberTypes` and `#testAddAndGetJsonCodec`: fail on master with `NumberFormatException: For input string: "11.1"`, pass with this change.
- Sibling paths, same red/green states: `RedissonMapCacheTest#testAddAndGetMixedNumberTypes`, `RedissonTransactionalMapTest#testAddAndGetMixedNumberTypes`.
- Guard against unconditional `Double` return: integer/long/float deltas on same-type values keep returning the delta type, a mutant returning `Double` unconditionally fails on `expected: 11 but was: 11.0`.
- Local run: `RedissonMapTest, RedissonTransactionalMapTest, RedissonJsonBucketTest` 166/166 passed, `RedissonLocalCachedMapTest` 123/123 passed. `RedissonMapCacheTest` has 3 failures unrelated to this change (testRemovedListener/testDestroy/testExpirationWithMaxSize, reproduced identically on a clean master checkout).

## Limitation

The return type keeps following the delta type: a `Long` stored value with an `Integer` delta returns `Integer` (numerically correct). The stored raw form (`"10"`) carries no `Long` marker, the declared type cannot be restored from the Redis side.

Fixes #5431
