### PR TITLE
Copy the Config level TCP settings in the copy constructor

### DIFF
--- a/redisson/src/main/java/org/redisson/config/Config.java
+++ b/redisson/src/main/java/org/redisson/config/Config.java
@@ -209,6 +209,12 @@ public class Config {
         setSslKeyManagerFactory(oldConf.getSslKeyManagerFactory());
         setSslTrustManagerFactory(oldConf.getSslTrustManagerFactory());
         setSslVerificationMode(oldConf.getSslVerificationMode());
+        setTcpKeepAlive(oldConf.isTcpKeepAlive());
+        setTcpKeepAliveCount(oldConf.getTcpKeepAliveCount());
+        setTcpKeepAliveIdle(oldConf.getTcpKeepAliveIdle());
+        setTcpKeepAliveInterval(oldConf.getTcpKeepAliveInterval());
+        setTcpUserTimeout(oldConf.getTcpUserTimeout());
+        setTcpNoDelay(oldConf.isTcpNoDelay());
         setStorageMemoryUsageListener(oldConf.storageMemoryUsageListener);
         setStorageStatisticsInterval(oldConf.storageStatisticsInterval);
 

--- a/redisson/src/test/java/org/redisson/config/ConfigTest.java
+++ b/redisson/src/test/java/org/redisson/config/ConfigTest.java
@@ -1,0 +1,37 @@
+package org.redisson.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConfigTest {
+
+    @Test
+    public void testCopyConstructorKeepsTcpSettings() {
+        Config config = new Config();
+        config.useSingleServer().setAddress("redis://127.0.0.1:6379");
+        config.setTcpKeepAlive(false)
+                .setTcpKeepAliveCount(7)
+                .setTcpKeepAliveIdle(11)
+                .setTcpKeepAliveInterval(13)
+                .setTcpUserTimeout(17000)
+                .setTcpNoDelay(false);
+
+        Config copy = new Config(config);
+
+        assertThat(copy.isTcpKeepAlive()).isFalse();
+        assertThat(copy.getTcpKeepAliveCount()).isEqualTo(7);
+        assertThat(copy.getTcpKeepAliveIdle()).isEqualTo(11);
+        assertThat(copy.getTcpKeepAliveInterval()).isEqualTo(13);
+        assertThat(copy.getTcpUserTimeout()).isEqualTo(17000);
+        assertThat(copy.isTcpNoDelay()).isFalse();
+    }
+
+    @Test
+    public void testCopyConstructorKeepsTcpDefaults() {
+        Config copy = new Config(new Config());
+
+        assertThat(copy.isTcpKeepAlive()).isTrue();
+        assertThat(copy.isTcpNoDelay()).isTrue();
+    }
+}


### PR DESCRIPTION
The six TCP settings on `Config` are never copied by `Config(Config oldConf)`. Every
`Redisson.create(config)` runs it and hands the copy to the connection layer, and `MasterSlaveConnectionManager.createRedisConfig` reads `tcpKeepAlive`, `tcpNoDelay` and the
four keepalive tuning values off that copy. So `setTcpNoDelay(false)` and friends are accepted,
survive a YAML round trip, and are dropped before a socket is opened, in all five deployment
modes. The per-server equivalents are deprecated in favour of these, so the documented place to
set them is the one that does not work.

The gap came in with #6854, which moved the settings to `Config` without extending the copy
constructor; the sibling moves for auth, mappers and ssl did extend it.

A new unit test asserts the round trip and the defaults, and fails on master.
