### PR TITLE
Fix typos in comments/javadoc

### DIFF
--- a/redisson/src/main/java/org/redisson/cache/LocalCacheListener.java
+++ b/redisson/src/main/java/org/redisson/cache/LocalCacheListener.java
@@ -484,7 +484,7 @@ public abstract class LocalCacheListener {
 
         object.isExistsAsync().whenComplete((res, e) -> {
             if (e != null) {
-                log.error("Can't check existance", e);
+                log.error("Can't check existence", e);
                 return;
             }
 

--- a/redisson/src/main/java/org/redisson/config/BaseConfig.java
+++ b/redisson/src/main/java/org/redisson/config/BaseConfig.java
@@ -51,7 +51,7 @@ public class BaseConfig<T extends BaseConfig<T>> {
     private int connectTimeout = 10000;
 
     /**
-     * Redis server response timeout. Starts to countdown when Redis command was succesfully sent.
+     * Redis server response timeout. Starts to countdown when Redis command was successfully sent.
      * Value in milliseconds.
      *
      */


### PR DESCRIPTION
Fix minor typos in comments/javadoc/log messages. No functional change.