### PR TITLE
Fix reactive hash field expiration ignoring expiration type and precision

### DIFF
--- a/redisson-spring/redisson-spring-data/redisson-spring-data-35/src/main/java/org/redisson/spring/data/connection/RedissonReactiveHashCommands.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-35/src/main/java/org/redisson/spring/data/connection/RedissonReactiveHashCommands.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.reactivestreams.Publisher;
@@ -51,6 +52,7 @@ import org.springframework.data.redis.connection.ReactiveRedisConnection.KeyComm
 import org.springframework.data.redis.connection.ReactiveRedisConnection.KeyScanCommand;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.MultiValueResponse;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
+import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.util.Assert;
 
 import reactor.core.publisher.Flux;
@@ -300,6 +302,9 @@ public class RedissonReactiveHashCommands extends RedissonBaseReactive implement
     }
 
     private static final RedisCommand<List<Long>> HEXPIRE = new RedisCommand<>("HEXPIRE", new ObjectListReplayDecoder<>());
+    private static final RedisStrictCommand<List<Long>> HPEXPIRE = new RedisStrictCommand<>("HPEXPIRE", new ObjectListReplayDecoder<>());
+    private static final RedisCommand<List<Long>> HEXPIREAT = new RedisCommand<>("HEXPIREAT", new ObjectListReplayDecoder<>());
+    private static final RedisStrictCommand<List<Long>> HPEXPIREAT = new RedisStrictCommand<>("HPEXPIREAT", new ObjectListReplayDecoder<>());
 
     @Override
     public Flux<NumericResponse<HashExpireCommand, Long>> applyHashFieldExpiration(Publisher<HashExpireCommand> commands) {
@@ -312,18 +317,39 @@ public class RedissonReactiveHashCommands extends RedissonBaseReactive implement
 
             List<Object> args = new ArrayList<>();
             args.add(keyBuf);
-            args.add(command.getExpiration().getExpirationTimeInSeconds());
+            Expiration expiration = command.getExpiration();
+            RedisCommand<List<Long>> cmd;
+            if (expiration.isPersistent()) {
+                cmd = HPERSIST;
+            } else {
+                boolean millis = expiration.getTimeUnit() == TimeUnit.MILLISECONDS;
+                if (expiration.isUnixTimestamp()) {
+                    if (millis) {
+                        cmd = HPEXPIREAT;
+                        args.add(expiration.getExpirationTimeInMilliseconds());
+                    } else {
+                        cmd = HEXPIREAT;
+                        args.add(expiration.getExpirationTimeInSeconds());
+                    }
+                } else if (millis) {
+                    cmd = HPEXPIRE;
+                    args.add(expiration.getExpirationTimeInMilliseconds());
+                } else {
+                    cmd = HEXPIRE;
+                    args.add(expiration.getExpirationTimeInSeconds());
+                }
 
-            if (command.getOptions() != null
-                    && command.getOptions().getCondition() != ExpirationOptions.Condition.ALWAYS) {
-                args.add(command.getOptions().getCondition().name());
+                if (command.getOptions() != null
+                        && command.getOptions().getCondition() != ExpirationOptions.Condition.ALWAYS) {
+                    args.add(command.getOptions().getCondition().name());
+                }
             }
 
             args.add("FIELDS");
             args.add(command.getFields().size());
             args.addAll(command.getFields().stream().map(buf -> toByteArray(buf)).collect(Collectors.toList()));
 
-            Mono<List<Long>> result = write(keyBuf, LongCodec.INSTANCE, HEXPIRE, args.toArray());
+            Mono<List<Long>> result = write(keyBuf, LongCodec.INSTANCE, cmd, args.toArray());
             return result.flatMapMany(Flux::fromIterable)
                     .map(value -> new NumericResponse<>(command, value));
         });

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-35/src/test/java/org/redisson/spring/data/connection/RedissonReactiveHashCommandsTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-35/src/test/java/org/redisson/spring/data/connection/RedissonReactiveHashCommandsTest.java
@@ -1,0 +1,186 @@
+package org.redisson.spring.data.connection;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.ExpirationOptions;
+import org.springframework.data.redis.connection.ReactiveHashCommands;
+import org.springframework.data.redis.core.types.Expiration;
+import reactor.core.publisher.Mono;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RedissonReactiveHashCommandsTest extends BaseConnectionTest {
+
+    private final byte[] key = "hash".getBytes(StandardCharsets.UTF_8);
+    private final byte[] field = "field".getBytes(StandardCharsets.UTF_8);
+    private final byte[] value = "value".getBytes(StandardCharsets.UTF_8);
+
+    private List<Long> applyExpiration(Expiration expiration, ExpirationOptions options) {
+        ReactiveHashCommands.HashExpireCommand command = ReactiveHashCommands.HashExpireCommand
+                .expire(List.of(ByteBuffer.wrap(field)), expiration)
+                .from(ByteBuffer.wrap(key)).withOptions(options);
+        return new RedissonConnectionFactory(redisson).getReactiveConnection().hashCommands()
+                .applyHashFieldExpiration(Mono.just(command))
+                .map(response -> response.getOutput()).collectList().block();
+    }
+
+    private Long ttl(TimeUnit unit) {
+        if (unit == TimeUnit.MILLISECONDS) {
+            return connection.hpTtl(key, field).get(0);
+        }
+        return connection.hTtl(key, unit, field).get(0);
+    }
+
+    @Test
+    public void subSecondMillisDoesNotDeleteField() {
+        connection.hSet(key, field, value);
+
+        assertThat(applyExpiration(Expiration.milliseconds(500), ExpirationOptions.none())).containsExactly(1L);
+
+        assertThat(connection.hGet(key, field)).isEqualTo(value);
+        assertThat(ttl(TimeUnit.MILLISECONDS)).isBetween(1L, 500L);
+    }
+
+    @Test
+    public void persistentRemovesFieldTtl() {
+        connection.hSet(key, field, value);
+        connection.hExpire(key, 100, field);
+
+        assertThat(applyExpiration(Expiration.persistent(), ExpirationOptions.none())).containsExactly(1L);
+
+        assertThat(ttl(TimeUnit.MILLISECONDS)).isEqualTo(-1L);
+        assertThat(connection.hGet(key, field)).isEqualTo(value);
+    }
+
+    @Test
+    public void absoluteSecondsUsesHexpireat() {
+        connection.hSet(key, field, value);
+        Expiration expiration = Expiration.unixTimestamp(Instant.now().plusSeconds(120).getEpochSecond(), TimeUnit.SECONDS);
+
+        assertThat(applyExpiration(expiration, ExpirationOptions.none())).containsExactly(1L);
+
+        assertThat(ttl(TimeUnit.SECONDS)).isBetween(110L, 120L);
+    }
+
+    @Test
+    public void relativeSecondsUsesHexpire() {
+        connection.hSet(key, field, value);
+
+        assertThat(applyExpiration(Expiration.seconds(100), ExpirationOptions.none())).containsExactly(1L);
+
+        assertThat(ttl(TimeUnit.SECONDS)).isBetween(95L, 100L);
+        assertThat(connection.hGet(key, field)).isEqualTo(value);
+    }
+
+    @Test
+    public void millisPrecisionPreservedForNonRoundValue() {
+        connection.hSet(key, field, value);
+
+        assertThat(applyExpiration(Expiration.milliseconds(1500), ExpirationOptions.none())).containsExactly(1L);
+
+        assertThat(ttl(TimeUnit.MILLISECONDS)).isBetween(1001L, 1500L);
+    }
+
+    @Test
+    public void absoluteMillisUsesHpexpireat() {
+        connection.hSet(key, field, value);
+        Expiration expiration = Expiration.unixTimestamp(Instant.now().plusSeconds(120).toEpochMilli(), TimeUnit.MILLISECONDS);
+
+        assertThat(applyExpiration(expiration, ExpirationOptions.none())).containsExactly(1L);
+
+        assertThat(ttl(TimeUnit.MILLISECONDS)).isBetween(110_000L, 120_000L);
+    }
+
+    @Test
+    public void conditionForwardedToExpireCommand() {
+        connection.hSet(key, field, value);
+        connection.hExpire(key, 200, field);
+
+        assertThat(applyExpiration(Expiration.seconds(50), ExpirationOptions.builder().gt().build())).containsExactly(0L);
+        assertThat(ttl(TimeUnit.SECONDS)).isBetween(195L, 200L);
+
+        assertThat(applyExpiration(Expiration.seconds(300), ExpirationOptions.builder().gt().build())).containsExactly(1L);
+        assertThat(ttl(TimeUnit.SECONDS)).isBetween(295L, 300L);
+
+        assertThat(applyExpiration(Expiration.seconds(50), ExpirationOptions.builder().lt().build())).containsExactly(1L);
+        assertThat(ttl(TimeUnit.SECONDS)).isBetween(45L, 50L);
+    }
+
+    @Test
+    public void conditionMatrixDoesNotThrow() {
+        List<String> failures = new ArrayList<>();
+        String[] names = {"HEXPIRE", "HPEXPIRE", "HEXPIREAT", "HPEXPIREAT", "HPERSIST"};
+        ExpirationOptions[] options = {
+                ExpirationOptions.builder().nx().build(),
+                ExpirationOptions.builder().xx().build(),
+                ExpirationOptions.builder().gt().build(),
+                ExpirationOptions.builder().lt().build()
+        };
+
+        for (int i = 0; i < names.length; i++) {
+            for (ExpirationOptions option : options) {
+                connection.hSet(key, field, value);
+                connection.hExpire(key, 200, field);
+                Expiration[] expirations = {
+                        Expiration.seconds(100),
+                        Expiration.milliseconds(100_000),
+                        Expiration.unixTimestamp(Instant.now().plusSeconds(100).getEpochSecond(), TimeUnit.SECONDS),
+                        Expiration.unixTimestamp(Instant.now().plusSeconds(100).toEpochMilli(), TimeUnit.MILLISECONDS),
+                        Expiration.persistent()
+                };
+
+                try {
+                    List<Long> result = applyExpiration(expirations[i], option);
+                    if (expirations[i].isPersistent()) {
+                        assertThat(result).containsExactly(1L);
+                        assertThat(ttl(TimeUnit.MILLISECONDS)).isEqualTo(-1L);
+                    } else if (option.getCondition() == ExpirationOptions.Condition.NX
+                            || option.getCondition() == ExpirationOptions.Condition.GT) {
+                        assertThat(result).containsExactly(0L);
+                        assertThat(ttl(TimeUnit.SECONDS)).isBetween(195L, 200L);
+                    } else {
+                        assertThat(result).containsExactly(1L);
+                        assertThat(ttl(TimeUnit.SECONDS)).isBetween(95L, 100L);
+                    }
+                    assertThat(connection.hGet(key, field)).isEqualTo(value);
+                } catch (Exception | AssertionError e) {
+                    failures.add(names[i] + " / " + option.getCondition() + ": " + e);
+                }
+            }
+        }
+        assertThat(failures).isEmpty();
+    }
+
+    @Test
+    public void persistIgnoresCondition() {
+        connection.hSet(key, field, value);
+        connection.hExpire(key, 100, field);
+
+        assertThat(applyExpiration(Expiration.persistent(), ExpirationOptions.builder().xx().build())).containsExactly(1L);
+
+        assertThat(ttl(TimeUnit.MILLISECONDS)).isEqualTo(-1L);
+        assertThat(connection.hGet(key, field)).isEqualTo(value);
+    }
+
+    @Test
+    public void responsesFollowFieldOrder() {
+        connection.hSet(key, field, value);
+        ReactiveHashCommands.HashExpireCommand command = ReactiveHashCommands.HashExpireCommand
+                .expire(List.of(ByteBuffer.wrap("missing".getBytes(StandardCharsets.UTF_8)), ByteBuffer.wrap(field)),
+                        Expiration.milliseconds(100_000))
+                .from(ByteBuffer.wrap(key));
+
+        List<Long> result = new RedissonConnectionFactory(redisson).getReactiveConnection().hashCommands()
+                .applyHashFieldExpiration(Mono.just(command))
+                .map(response -> response.getOutput()).collectList().block();
+
+        assertThat(result).containsExactly(-2L, 1L);
+        assertThat(ttl(TimeUnit.MILLISECONDS)).isBetween(95_000L, 100_000L);
+    }
+}

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-40/src/main/java/org/redisson/spring/data/connection/RedissonReactiveHashCommands.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-40/src/main/java/org/redisson/spring/data/connection/RedissonReactiveHashCommands.java
@@ -304,6 +304,9 @@ public class RedissonReactiveHashCommands extends RedissonBaseReactive implement
     }
 
     private static final RedisCommand<List<Long>> HEXPIRE = new RedisCommand<>("HEXPIRE", new ObjectListReplayDecoder<>());
+    private static final RedisStrictCommand<List<Long>> HPEXPIRE = new RedisStrictCommand<>("HPEXPIRE", new ObjectListReplayDecoder<>());
+    private static final RedisCommand<List<Long>> HEXPIREAT = new RedisCommand<>("HEXPIREAT", new ObjectListReplayDecoder<>());
+    private static final RedisStrictCommand<List<Long>> HPEXPIREAT = new RedisStrictCommand<>("HPEXPIREAT", new ObjectListReplayDecoder<>());
 
     @Override
     public Flux<NumericResponse<HashExpireCommand, Long>> applyHashFieldExpiration(Publisher<HashExpireCommand> commands) {
@@ -316,18 +319,39 @@ public class RedissonReactiveHashCommands extends RedissonBaseReactive implement
 
             List<Object> args = new ArrayList<>();
             args.add(keyBuf);
-            args.add(command.getExpiration().getExpirationTimeInSeconds());
+            Expiration expiration = command.getExpiration();
+            RedisCommand<List<Long>> cmd;
+            if (expiration.isPersistent()) {
+                cmd = HPERSIST;
+            } else {
+                boolean millis = expiration.getTimeUnit() == TimeUnit.MILLISECONDS;
+                if (expiration.isUnixTimestamp()) {
+                    if (millis) {
+                        cmd = HPEXPIREAT;
+                        args.add(expiration.getExpirationTimeInMilliseconds());
+                    } else {
+                        cmd = HEXPIREAT;
+                        args.add(expiration.getExpirationTimeInSeconds());
+                    }
+                } else if (millis) {
+                    cmd = HPEXPIRE;
+                    args.add(expiration.getExpirationTimeInMilliseconds());
+                } else {
+                    cmd = HEXPIRE;
+                    args.add(expiration.getExpirationTimeInSeconds());
+                }
 
-            if (command.getOptions() != null
-                    && command.getOptions().getCondition() != ExpirationOptions.Condition.ALWAYS) {
-                args.add(command.getOptions().getCondition().name());
+                if (command.getOptions() != null
+                        && command.getOptions().getCondition() != ExpirationOptions.Condition.ALWAYS) {
+                    args.add(command.getOptions().getCondition().name());
+                }
             }
 
             args.add("FIELDS");
             args.add(command.getFields().size());
             args.addAll(command.getFields().stream().map(buf -> toByteArray(buf)).collect(Collectors.toList()));
 
-            Mono<List<Long>> result = write(keyBuf, LongCodec.INSTANCE, HEXPIRE, args.toArray());
+            Mono<List<Long>> result = write(keyBuf, LongCodec.INSTANCE, cmd, args.toArray());
             return result.flatMapMany(Flux::fromIterable)
                     .map(value -> new NumericResponse<>(command, value));
         });

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-40/src/test/java/org/redisson/spring/data/connection/RedissonReactiveHashCommandsTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-40/src/test/java/org/redisson/spring/data/connection/RedissonReactiveHashCommandsTest.java
@@ -1,0 +1,186 @@
+package org.redisson.spring.data.connection;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.ExpirationOptions;
+import org.springframework.data.redis.connection.ReactiveHashCommands;
+import org.springframework.data.redis.core.types.Expiration;
+import reactor.core.publisher.Mono;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RedissonReactiveHashCommandsTest extends BaseConnectionTest {
+
+    private final byte[] key = "hash".getBytes(StandardCharsets.UTF_8);
+    private final byte[] field = "field".getBytes(StandardCharsets.UTF_8);
+    private final byte[] value = "value".getBytes(StandardCharsets.UTF_8);
+
+    private List<Long> applyExpiration(Expiration expiration, ExpirationOptions options) {
+        ReactiveHashCommands.HashExpireCommand command = ReactiveHashCommands.HashExpireCommand
+                .expire(List.of(ByteBuffer.wrap(field)), expiration)
+                .from(ByteBuffer.wrap(key)).withOptions(options);
+        return new RedissonConnectionFactory(redisson).getReactiveConnection().hashCommands()
+                .applyHashFieldExpiration(Mono.just(command))
+                .map(response -> response.getOutput()).collectList().block();
+    }
+
+    private Long ttl(TimeUnit unit) {
+        if (unit == TimeUnit.MILLISECONDS) {
+            return connection.hpTtl(key, field).get(0);
+        }
+        return connection.hTtl(key, unit, field).get(0);
+    }
+
+    @Test
+    public void subSecondMillisDoesNotDeleteField() {
+        connection.hSet(key, field, value);
+
+        assertThat(applyExpiration(Expiration.milliseconds(500), ExpirationOptions.none())).containsExactly(1L);
+
+        assertThat(connection.hGet(key, field)).isEqualTo(value);
+        assertThat(ttl(TimeUnit.MILLISECONDS)).isBetween(1L, 500L);
+    }
+
+    @Test
+    public void persistentRemovesFieldTtl() {
+        connection.hSet(key, field, value);
+        connection.hExpire(key, 100, field);
+
+        assertThat(applyExpiration(Expiration.persistent(), ExpirationOptions.none())).containsExactly(1L);
+
+        assertThat(ttl(TimeUnit.MILLISECONDS)).isEqualTo(-1L);
+        assertThat(connection.hGet(key, field)).isEqualTo(value);
+    }
+
+    @Test
+    public void absoluteSecondsUsesHexpireat() {
+        connection.hSet(key, field, value);
+        Expiration expiration = Expiration.unixTimestamp(Instant.now().plusSeconds(120).getEpochSecond(), TimeUnit.SECONDS);
+
+        assertThat(applyExpiration(expiration, ExpirationOptions.none())).containsExactly(1L);
+
+        assertThat(ttl(TimeUnit.SECONDS)).isBetween(110L, 120L);
+    }
+
+    @Test
+    public void relativeSecondsUsesHexpire() {
+        connection.hSet(key, field, value);
+
+        assertThat(applyExpiration(Expiration.seconds(100), ExpirationOptions.none())).containsExactly(1L);
+
+        assertThat(ttl(TimeUnit.SECONDS)).isBetween(95L, 100L);
+        assertThat(connection.hGet(key, field)).isEqualTo(value);
+    }
+
+    @Test
+    public void millisPrecisionPreservedForNonRoundValue() {
+        connection.hSet(key, field, value);
+
+        assertThat(applyExpiration(Expiration.milliseconds(1500), ExpirationOptions.none())).containsExactly(1L);
+
+        assertThat(ttl(TimeUnit.MILLISECONDS)).isBetween(1001L, 1500L);
+    }
+
+    @Test
+    public void absoluteMillisUsesHpexpireat() {
+        connection.hSet(key, field, value);
+        Expiration expiration = Expiration.unixTimestamp(Instant.now().plusSeconds(120).toEpochMilli(), TimeUnit.MILLISECONDS);
+
+        assertThat(applyExpiration(expiration, ExpirationOptions.none())).containsExactly(1L);
+
+        assertThat(ttl(TimeUnit.MILLISECONDS)).isBetween(110_000L, 120_000L);
+    }
+
+    @Test
+    public void conditionForwardedToExpireCommand() {
+        connection.hSet(key, field, value);
+        connection.hExpire(key, 200, field);
+
+        assertThat(applyExpiration(Expiration.seconds(50), ExpirationOptions.builder().gt().build())).containsExactly(0L);
+        assertThat(ttl(TimeUnit.SECONDS)).isBetween(195L, 200L);
+
+        assertThat(applyExpiration(Expiration.seconds(300), ExpirationOptions.builder().gt().build())).containsExactly(1L);
+        assertThat(ttl(TimeUnit.SECONDS)).isBetween(295L, 300L);
+
+        assertThat(applyExpiration(Expiration.seconds(50), ExpirationOptions.builder().lt().build())).containsExactly(1L);
+        assertThat(ttl(TimeUnit.SECONDS)).isBetween(45L, 50L);
+    }
+
+    @Test
+    public void conditionMatrixDoesNotThrow() {
+        List<String> failures = new ArrayList<>();
+        String[] names = {"HEXPIRE", "HPEXPIRE", "HEXPIREAT", "HPEXPIREAT", "HPERSIST"};
+        ExpirationOptions[] options = {
+                ExpirationOptions.builder().nx().build(),
+                ExpirationOptions.builder().xx().build(),
+                ExpirationOptions.builder().gt().build(),
+                ExpirationOptions.builder().lt().build()
+        };
+
+        for (int i = 0; i < names.length; i++) {
+            for (ExpirationOptions option : options) {
+                connection.hSet(key, field, value);
+                connection.hExpire(key, 200, field);
+                Expiration[] expirations = {
+                        Expiration.seconds(100),
+                        Expiration.milliseconds(100_000),
+                        Expiration.unixTimestamp(Instant.now().plusSeconds(100).getEpochSecond(), TimeUnit.SECONDS),
+                        Expiration.unixTimestamp(Instant.now().plusSeconds(100).toEpochMilli(), TimeUnit.MILLISECONDS),
+                        Expiration.persistent()
+                };
+
+                try {
+                    List<Long> result = applyExpiration(expirations[i], option);
+                    if (expirations[i].isPersistent()) {
+                        assertThat(result).containsExactly(1L);
+                        assertThat(ttl(TimeUnit.MILLISECONDS)).isEqualTo(-1L);
+                    } else if (option.getCondition() == ExpirationOptions.Condition.NX
+                            || option.getCondition() == ExpirationOptions.Condition.GT) {
+                        assertThat(result).containsExactly(0L);
+                        assertThat(ttl(TimeUnit.SECONDS)).isBetween(195L, 200L);
+                    } else {
+                        assertThat(result).containsExactly(1L);
+                        assertThat(ttl(TimeUnit.SECONDS)).isBetween(95L, 100L);
+                    }
+                    assertThat(connection.hGet(key, field)).isEqualTo(value);
+                } catch (Exception | AssertionError e) {
+                    failures.add(names[i] + " / " + option.getCondition() + ": " + e);
+                }
+            }
+        }
+        assertThat(failures).isEmpty();
+    }
+
+    @Test
+    public void persistIgnoresCondition() {
+        connection.hSet(key, field, value);
+        connection.hExpire(key, 100, field);
+
+        assertThat(applyExpiration(Expiration.persistent(), ExpirationOptions.builder().xx().build())).containsExactly(1L);
+
+        assertThat(ttl(TimeUnit.MILLISECONDS)).isEqualTo(-1L);
+        assertThat(connection.hGet(key, field)).isEqualTo(value);
+    }
+
+    @Test
+    public void responsesFollowFieldOrder() {
+        connection.hSet(key, field, value);
+        ReactiveHashCommands.HashExpireCommand command = ReactiveHashCommands.HashExpireCommand
+                .expire(List.of(ByteBuffer.wrap("missing".getBytes(StandardCharsets.UTF_8)), ByteBuffer.wrap(field)),
+                        Expiration.milliseconds(100_000))
+                .from(ByteBuffer.wrap(key));
+
+        List<Long> result = new RedissonConnectionFactory(redisson).getReactiveConnection().hashCommands()
+                .applyHashFieldExpiration(Mono.just(command))
+                .map(response -> response.getOutput()).collectList().block();
+
+        assertThat(result).containsExactly(-2L, 1L);
+        assertThat(ttl(TimeUnit.MILLISECONDS)).isBetween(95_000L, 100_000L);
+    }
+}

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-41/src/main/java/org/redisson/spring/data/connection/RedissonReactiveHashCommands.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-41/src/main/java/org/redisson/spring/data/connection/RedissonReactiveHashCommands.java
@@ -304,6 +304,9 @@ public class RedissonReactiveHashCommands extends RedissonBaseReactive implement
     }
 
     private static final RedisCommand<List<Long>> HEXPIRE = new RedisCommand<>("HEXPIRE", new ObjectListReplayDecoder<>());
+    private static final RedisStrictCommand<List<Long>> HPEXPIRE = new RedisStrictCommand<>("HPEXPIRE", new ObjectListReplayDecoder<>());
+    private static final RedisCommand<List<Long>> HEXPIREAT = new RedisCommand<>("HEXPIREAT", new ObjectListReplayDecoder<>());
+    private static final RedisStrictCommand<List<Long>> HPEXPIREAT = new RedisStrictCommand<>("HPEXPIREAT", new ObjectListReplayDecoder<>());
 
     @Override
     public Flux<NumericResponse<HashExpireCommand, Long>> applyHashFieldExpiration(Publisher<HashExpireCommand> commands) {
@@ -316,18 +319,39 @@ public class RedissonReactiveHashCommands extends RedissonBaseReactive implement
 
             List<Object> args = new ArrayList<>();
             args.add(keyBuf);
-            args.add(command.getExpiration().getExpirationTimeInSeconds());
+            Expiration expiration = command.getExpiration();
+            RedisCommand<List<Long>> cmd;
+            if (expiration.isPersistent()) {
+                cmd = HPERSIST;
+            } else {
+                boolean millis = expiration.getTimeUnit() == TimeUnit.MILLISECONDS;
+                if (expiration.isUnixTimestamp()) {
+                    if (millis) {
+                        cmd = HPEXPIREAT;
+                        args.add(expiration.getExpirationTimeInMilliseconds());
+                    } else {
+                        cmd = HEXPIREAT;
+                        args.add(expiration.getExpirationTimeInSeconds());
+                    }
+                } else if (millis) {
+                    cmd = HPEXPIRE;
+                    args.add(expiration.getExpirationTimeInMilliseconds());
+                } else {
+                    cmd = HEXPIRE;
+                    args.add(expiration.getExpirationTimeInSeconds());
+                }
 
-            if (command.getOptions() != null
-                    && command.getOptions().getCondition() != ExpirationOptions.Condition.ALWAYS) {
-                args.add(command.getOptions().getCondition().name());
+                if (command.getOptions() != null
+                        && command.getOptions().getCondition() != ExpirationOptions.Condition.ALWAYS) {
+                    args.add(command.getOptions().getCondition().name());
+                }
             }
 
             args.add("FIELDS");
             args.add(command.getFields().size());
             args.addAll(command.getFields().stream().map(buf -> toByteArray(buf)).collect(Collectors.toList()));
 
-            Mono<List<Long>> result = write(keyBuf, LongCodec.INSTANCE, HEXPIRE, args.toArray());
+            Mono<List<Long>> result = write(keyBuf, LongCodec.INSTANCE, cmd, args.toArray());
             return result.flatMapMany(Flux::fromIterable)
                     .map(value -> new NumericResponse<>(command, value));
         });

--- a/redisson-spring/redisson-spring-data/redisson-spring-data-41/src/test/java/org/redisson/spring/data/connection/RedissonReactiveHashCommandsTest.java
+++ b/redisson-spring/redisson-spring-data/redisson-spring-data-41/src/test/java/org/redisson/spring/data/connection/RedissonReactiveHashCommandsTest.java
@@ -1,0 +1,186 @@
+package org.redisson.spring.data.connection;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.ExpirationOptions;
+import org.springframework.data.redis.connection.ReactiveHashCommands;
+import org.springframework.data.redis.core.types.Expiration;
+import reactor.core.publisher.Mono;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RedissonReactiveHashCommandsTest extends BaseConnectionTest {
+
+    private final byte[] key = "hash".getBytes(StandardCharsets.UTF_8);
+    private final byte[] field = "field".getBytes(StandardCharsets.UTF_8);
+    private final byte[] value = "value".getBytes(StandardCharsets.UTF_8);
+
+    private List<Long> applyExpiration(Expiration expiration, ExpirationOptions options) {
+        ReactiveHashCommands.HashExpireCommand command = ReactiveHashCommands.HashExpireCommand
+                .expire(List.of(ByteBuffer.wrap(field)), expiration)
+                .from(ByteBuffer.wrap(key)).withOptions(options);
+        return new RedissonConnectionFactory(redisson).getReactiveConnection().hashCommands()
+                .applyHashFieldExpiration(Mono.just(command))
+                .map(response -> response.getOutput()).collectList().block();
+    }
+
+    private Long ttl(TimeUnit unit) {
+        if (unit == TimeUnit.MILLISECONDS) {
+            return connection.hpTtl(key, field).get(0);
+        }
+        return connection.hTtl(key, unit, field).get(0);
+    }
+
+    @Test
+    public void subSecondMillisDoesNotDeleteField() {
+        connection.hSet(key, field, value);
+
+        assertThat(applyExpiration(Expiration.milliseconds(500), ExpirationOptions.none())).containsExactly(1L);
+
+        assertThat(connection.hGet(key, field)).isEqualTo(value);
+        assertThat(ttl(TimeUnit.MILLISECONDS)).isBetween(1L, 500L);
+    }
+
+    @Test
+    public void persistentRemovesFieldTtl() {
+        connection.hSet(key, field, value);
+        connection.hExpire(key, 100, field);
+
+        assertThat(applyExpiration(Expiration.persistent(), ExpirationOptions.none())).containsExactly(1L);
+
+        assertThat(ttl(TimeUnit.MILLISECONDS)).isEqualTo(-1L);
+        assertThat(connection.hGet(key, field)).isEqualTo(value);
+    }
+
+    @Test
+    public void absoluteSecondsUsesHexpireat() {
+        connection.hSet(key, field, value);
+        Expiration expiration = Expiration.unixTimestamp(Instant.now().plusSeconds(120).getEpochSecond(), TimeUnit.SECONDS);
+
+        assertThat(applyExpiration(expiration, ExpirationOptions.none())).containsExactly(1L);
+
+        assertThat(ttl(TimeUnit.SECONDS)).isBetween(110L, 120L);
+    }
+
+    @Test
+    public void relativeSecondsUsesHexpire() {
+        connection.hSet(key, field, value);
+
+        assertThat(applyExpiration(Expiration.seconds(100), ExpirationOptions.none())).containsExactly(1L);
+
+        assertThat(ttl(TimeUnit.SECONDS)).isBetween(95L, 100L);
+        assertThat(connection.hGet(key, field)).isEqualTo(value);
+    }
+
+    @Test
+    public void millisPrecisionPreservedForNonRoundValue() {
+        connection.hSet(key, field, value);
+
+        assertThat(applyExpiration(Expiration.milliseconds(1500), ExpirationOptions.none())).containsExactly(1L);
+
+        assertThat(ttl(TimeUnit.MILLISECONDS)).isBetween(1001L, 1500L);
+    }
+
+    @Test
+    public void absoluteMillisUsesHpexpireat() {
+        connection.hSet(key, field, value);
+        Expiration expiration = Expiration.unixTimestamp(Instant.now().plusSeconds(120).toEpochMilli(), TimeUnit.MILLISECONDS);
+
+        assertThat(applyExpiration(expiration, ExpirationOptions.none())).containsExactly(1L);
+
+        assertThat(ttl(TimeUnit.MILLISECONDS)).isBetween(110_000L, 120_000L);
+    }
+
+    @Test
+    public void conditionForwardedToExpireCommand() {
+        connection.hSet(key, field, value);
+        connection.hExpire(key, 200, field);
+
+        assertThat(applyExpiration(Expiration.seconds(50), ExpirationOptions.builder().gt().build())).containsExactly(0L);
+        assertThat(ttl(TimeUnit.SECONDS)).isBetween(195L, 200L);
+
+        assertThat(applyExpiration(Expiration.seconds(300), ExpirationOptions.builder().gt().build())).containsExactly(1L);
+        assertThat(ttl(TimeUnit.SECONDS)).isBetween(295L, 300L);
+
+        assertThat(applyExpiration(Expiration.seconds(50), ExpirationOptions.builder().lt().build())).containsExactly(1L);
+        assertThat(ttl(TimeUnit.SECONDS)).isBetween(45L, 50L);
+    }
+
+    @Test
+    public void conditionMatrixDoesNotThrow() {
+        List<String> failures = new ArrayList<>();
+        String[] names = {"HEXPIRE", "HPEXPIRE", "HEXPIREAT", "HPEXPIREAT", "HPERSIST"};
+        ExpirationOptions[] options = {
+                ExpirationOptions.builder().nx().build(),
+                ExpirationOptions.builder().xx().build(),
+                ExpirationOptions.builder().gt().build(),
+                ExpirationOptions.builder().lt().build()
+        };
+
+        for (int i = 0; i < names.length; i++) {
+            for (ExpirationOptions option : options) {
+                connection.hSet(key, field, value);
+                connection.hExpire(key, 200, field);
+                Expiration[] expirations = {
+                        Expiration.seconds(100),
+                        Expiration.milliseconds(100_000),
+                        Expiration.unixTimestamp(Instant.now().plusSeconds(100).getEpochSecond(), TimeUnit.SECONDS),
+                        Expiration.unixTimestamp(Instant.now().plusSeconds(100).toEpochMilli(), TimeUnit.MILLISECONDS),
+                        Expiration.persistent()
+                };
+
+                try {
+                    List<Long> result = applyExpiration(expirations[i], option);
+                    if (expirations[i].isPersistent()) {
+                        assertThat(result).containsExactly(1L);
+                        assertThat(ttl(TimeUnit.MILLISECONDS)).isEqualTo(-1L);
+                    } else if (option.getCondition() == ExpirationOptions.Condition.NX
+                            || option.getCondition() == ExpirationOptions.Condition.GT) {
+                        assertThat(result).containsExactly(0L);
+                        assertThat(ttl(TimeUnit.SECONDS)).isBetween(195L, 200L);
+                    } else {
+                        assertThat(result).containsExactly(1L);
+                        assertThat(ttl(TimeUnit.SECONDS)).isBetween(95L, 100L);
+                    }
+                    assertThat(connection.hGet(key, field)).isEqualTo(value);
+                } catch (Exception | AssertionError e) {
+                    failures.add(names[i] + " / " + option.getCondition() + ": " + e);
+                }
+            }
+        }
+        assertThat(failures).isEmpty();
+    }
+
+    @Test
+    public void persistIgnoresCondition() {
+        connection.hSet(key, field, value);
+        connection.hExpire(key, 100, field);
+
+        assertThat(applyExpiration(Expiration.persistent(), ExpirationOptions.builder().xx().build())).containsExactly(1L);
+
+        assertThat(ttl(TimeUnit.MILLISECONDS)).isEqualTo(-1L);
+        assertThat(connection.hGet(key, field)).isEqualTo(value);
+    }
+
+    @Test
+    public void responsesFollowFieldOrder() {
+        connection.hSet(key, field, value);
+        ReactiveHashCommands.HashExpireCommand command = ReactiveHashCommands.HashExpireCommand
+                .expire(List.of(ByteBuffer.wrap("missing".getBytes(StandardCharsets.UTF_8)), ByteBuffer.wrap(field)),
+                        Expiration.milliseconds(100_000))
+                .from(ByteBuffer.wrap(key));
+
+        List<Long> result = new RedissonConnectionFactory(redisson).getReactiveConnection().hashCommands()
+                .applyHashFieldExpiration(Mono.just(command))
+                .map(response -> response.getOutput()).collectList().block();
+
+        assertThat(result).containsExactly(-2L, 1L);
+        assertThat(ttl(TimeUnit.MILLISECONDS)).isBetween(95_000L, 100_000L);
+    }
+}


### PR DESCRIPTION
Fixes #7352

`RedissonReactiveHashCommands.applyHashFieldExpiration()` always sends `HEXPIRE` with a
seconds-converted value. This deletes fields immediately for positive timeouts below one second,
truncates other millisecond timeouts, rejects persistent-expiration requests, and treats absolute
timestamps as relative timeouts.

## Changes

- Select `HEXPIRE`, `HPEXPIRE`, `HEXPIREAT`, `HPEXPIREAT`, or `HPERSIST` according to the requested
  expiration in `redisson-spring-data-35`, `-40`, and `-41`.
- Preserve `NX`/`XX`/`GT`/`LT` for expiration commands. Omit the timeout and condition arguments
  for `HPERSIST`.
- Determine precision using `getTimeUnit() == TimeUnit.MILLISECONDS`. This matches the synchronous
  override in module 41 and remains compatible with Spring Data Redis 3.5.9, where `isPrecise()`
  is unavailable.
- Add 10 regression tests per module covering relative and absolute expiration, sub-second and
  1500ms timeouts, persistence, conditional options, and per-field response order.

The command selection follows the synchronous implementation and Spring Data Redis's Lettuce
reactive implementation. Direct reactive `hPersist()` calls and the synchronous code are unchanged.

## Testing

Ran `verify` against Redis 8.10.1 using Testcontainers, with tests explicitly enabled and the
following classes selected: `RedissonReactiveHashCommandsTest`, `RedissonConnectionTest`, and
`RedissonReactiveStringCommandsTest`.

| Module | New hash tests | Total tests run | Result |
| --- | ---: | ---: | --- |
| 35 | 10 | 40 | Passed |
| 40 | 10 | 47 | Passed |
| 41 | 10 | 47 | Passed |

All three builds passed: **134 tests, zero failures, errors, or skipped tests**.

Command used for each module (replace `MODULE` with `35`, `40`, or `41`):

```shell
mvn -q -pl :redisson-spring-data-MODULE -am verify \
  -Dmaven.test.skip=false \
  -Dtest=RedissonReactiveHashCommandsTest,RedissonConnectionTest,RedissonReactiveStringCommandsTest \
  -Dsurefire.failIfNoSpecifiedTests=false
```

Millisecond TTL assertions use `hpTtl()` to read `HPTTL` directly. `hTtl(..., MILLISECONDS)`
converts the rounded seconds returned by `HTTL`, so it cannot verify millisecond precision.